### PR TITLE
fix: update BCR presubmit to only run on MacOS

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: ""
   matrix:
-    platform: ["macos", "ubuntu2004"]
+    platform: ["macos"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Only test on macos for now as the Ubuntu runner does not have Swift installed.

Related to #322.