### PR TITLE
chore: add conventional commit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,20 @@ name: Continuous Integration
     - cron: 14 11 * * *
 jobs:
   all_ci_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - tidy_and_test_matrix
       - integration_test_matrix
+      - conventional_commit_check
     if: ${{ always() }}
     steps:
       - uses: cgrindel/gha_join_jobs@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+  conventional_commit_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: agenthunt/conventional-commit-checker-action@v1.0.0
   integration_test_matrix:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,11 @@ jobs:
     needs:
       - tidy_and_test_matrix
       - integration_test_matrix
-      - conventional_commit_check
     if: ${{ always() }}
     steps:
       - uses: cgrindel/gha_join_jobs@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-  conventional_commit_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: agenthunt/conventional-commit-checker-action@v1.0.0
   integration_test_matrix:
     strategy:
       fail-fast: false

--- a/.github/workflows/commit_msg_check.yml
+++ b/.github/workflows/commit_msg_check.yml
@@ -9,4 +9,4 @@ jobs:
   conventional_commit_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: agenthunt/conventional-commit-checker-action@v1
+      - uses: agenthunt/conventional-commit-checker-action@v1.0.0

--- a/.github/workflows/commit_msg_check.yml
+++ b/.github/workflows/commit_msg_check.yml
@@ -10,3 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: agenthunt/conventional-commit-checker-action@v1.0.0
+        with:
+          pr-title-regex: "^(fix|feat|chore|docs)(?:(([^)s]+)))?: (.+)"

--- a/.github/workflows/commit_msg_check.yml
+++ b/.github/workflows/commit_msg_check.yml
@@ -1,0 +1,12 @@
+name: Commit Message Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize]
+
+jobs:
+  conventional_commit_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: agenthunt/conventional-commit-checker-action@v1


### PR DESCRIPTION
- Use `agenthunt/conventional-commit-checker-action@v1.0.0` to check commit message.

Closes #340.