### PR TITLE
fix: remove extraneous arg to tidy_and_test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,5 +153,3 @@ jobs:
         with:
           buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/tidy_and_test
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Addresses warning:
```
[tidy_and_test_matrix (macos-12, true)](https://github.com/cgrindel/rules_swift_package_manager/actions/runs/4645768179/jobs/8222718514#step:7:2)
Unexpected input(s) 'github_token', valid inputs are ['']
```