### PR TITLE
Fix local_swift_package relative path resolution

### DIFF
--- a/gazelle/update_repos.go
+++ b/gazelle/update_repos.go
@@ -150,7 +150,7 @@ func importReposFromPackageManifest(args language.ImportReposArgs) language.Impo
 	for _, bzlRepo := range bzlReposByIdentity {
 		repoUsage[bzlRepo.Name] = true
 		var err error
-		result.Gen[idx], err = swift.RepoRuleFromBazelRepo(bzlRepo, sc.DependencyIndexRel, pkgDir)
+		result.Gen[idx], err = swift.RepoRuleFromBazelRepo(bzlRepo, sc.DependencyIndexRel, pkgDir, c.RepoRoot)
 		if err != nil {
 			result.Error = err
 			return result

--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -64,7 +64,7 @@ def _local_swift_package_impl(repository_ctx):
 
 _PATH_ATTRS = {
     "path": attr.string(
-        doc = "The path to the local Swift package directory.",
+        doc = "The path to the local Swift package directory. This can be an absolute path or a relative path to the workspace root.",
         mandatory = True,
     ),
 }


### PR DESCRIPTION
This fixes the relative path resolution for local_swift_package when the Package.swift is not in the root of the repository.

Closes #363