### PR TITLE
fix: correct typo linking to patch doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ The following are a few tips to consider as you work with your repository:
 
 [bzlmod]: https://bazel.build/external/overview#bzlmod
 [legacy `WORKSPACE` dependencies]: https://bazel.build/external/overview#workspace-system
-[our document on patching Swift packages]: docs/patch_swift_package.mddocs/
+[our document on patching Swift packages]: docs/patch_swift_package.md
 [CI GitHub workflow]: .github/workflows/ci.yml
 [Gazelle plugin]: https://github.com/bazelbuild/bazel-gazelle/blob/master/extend.md
 [Gazelle]: https://github.com/bazelbuild/bazel-gazelle

--- a/docs/patch_swift_package.md
+++ b/docs/patch_swift_package.md
@@ -56,8 +56,7 @@ The key (e.g. `swift-cmark`) is the Swift package's identity. The supported fiel
 | `files` | A list of patch files to apply. |
 | `args` | Optional. A list of arguments that should be passed to the patch tool. If you are using a git patch file, be sure to include `-p1`. |
 | `cmds` | Optional. A list of Bash commands (Mac/Linux) to be applied after patches are applied. |
-| `win_cmds` | Optional. A list of Powershell commands (Windows) to applied after patches are
-applied. |
+| `win_cmds` | Optional. A list of Powershell commands (Windows) to applied after patches are applied. |
 | `tool` | Optional. The tool to use to apply the patch. |
 
 


### PR DESCRIPTION
- Remove some garbage text at the end of the URL.
- Fix patch doc table formatting.
