### PR TITLE
chore: upgrade to rules_go 0.39.1 and remove references to go_sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,8 @@ jobs:
             runner: ubuntu-22.04
             enable_bzlmod: false
           - test: '@@//examples:http_archive_ext_deps_test_bazel_.bazelversion'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
-          - test: '@@//examples:http_archive_ext_deps_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: false
-          - test: '@@//examples:http_archive_ext_deps_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:interesting_deps_test_bazel_.bazelversion'
             runner: macos-13
             enable_bzlmod: true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,6 +71,7 @@ gazelle_binary(
 
 # gazelle:prefix github.com/cgrindel/rules_swift_package_manager
 # gazelle:go_naming_convention import
+# gazelle:go_naming_convention_external go_default_library
 gazelle(
     name = "update_build_files",
     command = "fix",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,7 +98,7 @@ execute_binary(
         "mod",
         "tidy",
     ],
-    binary = "@go_sdk//:bin/go",
+    binary = "@io_bazel_rules_go//go",
     execute_in_workspace = True,
 )
 
@@ -110,7 +110,7 @@ execute_binary(
         "-u",
         "./...",
     ],
-    binary = "@go_sdk//:bin/go",
+    binary = "@io_bazel_rules_go//go",
     execute_in_workspace = True,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,8 +5,8 @@ module(
 
 # MARK: - Runtime Dependencies
 
-bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
-bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.16.0")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(
     name = "rules_go",
     version = "0.39.1",
@@ -43,7 +43,6 @@ use_repo(
     "com_github_stretchr_testify",
     "in_gopkg_yaml_v3",
     "org_golang_x_exp",
-    "org_golang_x_tools",
 )
 
 # MARK: - Dev Dependencies

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,12 +27,9 @@ bazel_dep(
     version = "2.1.0",
     repo_name = "build_bazel_rules_apple",
 )
-
-# TODO(chuck): FIX ME! Gazelle needs a new release to get the following fix:
-# https://github.com/bazelbuild/bazel-gazelle/pull/1413
 bazel_dep(
     name = "gazelle",
-    version = "0.29.0",
+    version = "0.31.0",
     repo_name = "bazel_gazelle",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(
     name = "rules_go",
-    version = "0.38.1",
+    version = "0.39.1",
     repo_name = "io_bazel_rules_go",
 )
 bazel_dep(name = "rules_cc", version = "0.0.6")
@@ -34,12 +34,6 @@ bazel_dep(
     name = "gazelle",
     version = "0.29.0",
     repo_name = "bazel_gazelle",
-)
-
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-use_repo(
-    go_sdk,
-    go_sdk = "go_default_sdk",
 )
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")

--- a/deps.bzl
+++ b/deps.bzl
@@ -27,25 +27,12 @@ def swift_bazel_dependencies():
         ],
     )
 
-    # GH143: Waiting for bazel-gazelle release with dep fix:
-    # https://github.com/bazelbuild/bazel-gazelle/pull/1413
-    # maybe(
-    #     http_archive,
-    #     name = "bazel_gazelle",
-    #     sha256 = "ecba0f04f96b4960a5b250c8e8eeec42281035970aa8852dda73098274d14a1d",
-    #     urls = [
-    #         "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
-    #         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
-    #     ],
-    # )
-
     maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "f143a62d6207c783ab2b07904e96d3d51427a2f68d58afa04995420b6adc33dc",
-        strip_prefix = "bazel-gazelle-7feffe17f56e2b76eae8a4f2933215d6c5924176",
+        sha256 = "29d5dafc2a5582995488c6735115d1d366fcd6a0fc2e2a153f02988706349825",
         urls = [
-            "https://github.com/bazelbuild/bazel-gazelle/archive/7feffe17f56e2b76eae8a4f2933215d6c5924176.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.31.0/bazel-gazelle-v0.31.0.tar.gz",
         ],
     )
 

--- a/examples/example_infos.bzl
+++ b/examples/example_infos.bzl
@@ -131,7 +131,8 @@ _timeouts = {
 _default_enable_bzlmods = [True]
 
 _enable_bzlmods = {
-    "http_archive_ext_deps": [True, False],
+    # GH411: Enable bzlmod for http_archive_ext_deps.
+    "http_archive_ext_deps": [False],
     "vapor_example": [True, False],
 }
 

--- a/examples/http_archive_ext_deps/.bazelrc
+++ b/examples/http_archive_ext_deps/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# GH411: Disable bzlmod for http_archive_ext_deps example.
+common --noenable_bzlmod
+build --no@cgrindel_bazel_starlib//bzlmod:enabled

--- a/examples/http_archive_ext_deps/WORKSPACE
+++ b/examples/http_archive_ext_deps/WORKSPACE
@@ -30,8 +30,8 @@ http_archive(
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_skylib_gazelle_plugin//:workspace.bzl", "bazel_skylib_gazelle_plugin_workspace")
-load("@rules_swift_package_manager//:go_deps.bzl", "swift_bazel_go_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_swift_package_manager//:go_deps.bzl", "swift_bazel_go_dependencies")
 
 # Declare Go dependencies before calling go_rules_dependencies.
 swift_bazel_go_dependencies()


### PR DESCRIPTION
- Upgrade `rules_go` to 0.39.1.
- Replace references to `@go_sdk//:bin/go` with `@io_bazel_rules_go//go`.
- Sync'd dependency versions between `WORKSPACE` and `MODULE.bazel`.

Closes #408.

cc: @fmeum