### PR TITLE
chore: add `label` to target

### DIFF
--- a/swiftpkg/internal/pkginfo_targets.bzl
+++ b/swiftpkg/internal/pkginfo_targets.bzl
@@ -29,6 +29,27 @@ def _get(targets, name, fail_if_not_found = True):
         fail("Failed to find target. name:", name)
     return None
 
+def _get_by_label(targets, label, fail_if_not_found = True):
+    """Retrieves the target with the given name from a list of targets.
+
+    Args:
+        targets: A `list` of target `struct` values as returned by
+            `pkginfos.new_target`.
+        label: The Bazel label of a target as a `string`.
+        fail_if_not_found: Optional. A `bool` that determines whether to fail
+            (True) or return `None` (False) if a target is not found.
+
+    Returns:
+        A target `struct` if a match is found. Otherwise, it fails or returns
+        `None` depending upon the value of `fail_if_not_found`.
+    """
+    for target in targets:
+        if target.label == label:
+            return target
+    if fail_if_not_found:
+        fail("Failed to find target. label:", label)
+    return None
+
 def _srcs(target):
     """Returns the sources formatted for inclusion in a Bazel target's `srcs` attribute.
 
@@ -210,6 +231,7 @@ def make_pkginfo_targets(bazel_labels):
         bazel_label_from_parts = _bazel_label_from_parts,
         bazel_label_name = _bazel_label_name,
         get = _get,
+        get_by_label = _get_by_label,
         is_modulemap_label = _is_modulemap_label,
         join_path = _join_path,
         modulemap_label_name = _modulemap_label_name,

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -202,6 +202,8 @@ def _new_target_dependency_from_dump_json_map(dump_map):
 
 def _new_target_from_json_maps(repository_ctx, dump_map, desc_map, deps_index):
     repo_name = repository_ctx.attr.bazel_package_name
+    if repo_name == "":
+        repo_name = repository_ctx.name
     target_name = dump_map["name"]
     target_path = desc_map["path"]
     target_label = pkginfo_targets.bazel_label_from_parts(

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -253,7 +253,9 @@ def _new_target_from_json_maps(repository_ctx, dump_map, desc_map, deps_index):
             sources,
         )
 
-    # TODO(chuck): FINISH ME
+    # GH425: Implement clang_src_info.
+
+    # GH425: Implement objc_src_info
     # elif module_type == module_types.clang and objc_files.has_objc_srcs(sources):
     #     objc_src_info = _new_objc_src_info_from_sources(gT)
 

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -88,7 +88,6 @@ def _get(repository_ctx, directory, deps_index, env = {}):
         repository_ctx = repository_ctx,
         dump_manifest = dump_manifest,
         desc_manifest = desc_manifest,
-        repo_name = repository_utils.package_name(repository_ctx),
         deps_index = deps_index,
     )
 

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -1,5 +1,6 @@
 """API for creating and loading Swift package information."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load(
     "//config_settings/spm/configuration:configurations.bzl",
@@ -13,6 +14,7 @@ load(":deps_indexes.bzl", "deps_indexes")
 load(":pkginfo_dependencies.bzl", "pkginfo_dependencies")
 load(":pkginfo_targets.bzl", "pkginfo_targets")
 load(":repository_utils.bzl", "repository_utils")
+load(":swift_files.bzl", "swift_files")
 load(":validations.bzl", "validations")
 
 _DEFAULT_LOCALIZATION = "en"
@@ -83,6 +85,7 @@ def _get(repository_ctx, directory, deps_index, env = {}):
         working_directory = directory,
     )
     pkg_info = _new_from_parsed_json(
+        repository_ctx = repository_ctx,
         dump_manifest = dump_manifest,
         desc_manifest = desc_manifest,
         repo_name = repository_utils.package_name(repository_ctx),
@@ -198,7 +201,8 @@ def _new_target_dependency_from_dump_json_map(dump_map):
         target = target,
     )
 
-def _new_target_from_json_maps(dump_map, desc_map, repo_name, deps_index):
+def _new_target_from_json_maps(repository_ctx, dump_map, desc_map, deps_index):
+    repo_name = repository_ctx.attr.bazel_package_name
     target_name = dump_map["name"]
     target_path = desc_map["path"]
     target_label = pkginfo_targets.bazel_label_from_parts(
@@ -237,14 +241,31 @@ def _new_target_from_json_maps(dump_map, desc_map, repo_name, deps_index):
             url = url,
             checksum = dump_map.get("checksum"),
         )
+    module_type = desc_map["module_type"]
+    sources = desc_map["sources"]
+
+    swift_src_info = None
+    objc_src_info = None
+    if module_type == module_types.swift:
+        swift_src_info = _new_swift_src_info_from_sources(
+            repository_ctx,
+            target_path,
+            sources,
+        )
+
+    # TODO(chuck): FINISH ME
+    # elif module_type == module_types.clang and objc_files.has_objc_srcs(sources):
+    #     objc_src_info = _new_objc_src_info_from_sources(gT)
+
     return _new_target(
         name = target_name,
         type = dump_map["type"],
         c99name = desc_map["c99name"],
-        module_type = desc_map["module_type"],
+        module_type = module_type,
         path = target_path,
+        label = target_label,
         # List of sources provided by SPM
-        sources = desc_map["sources"],
+        sources = sources,
         # Exclude paths specified by the Swift package manifest author.
         exclude_paths = dump_map.get("exclude", default = []),
         # Source paths specified by the Swift package manifest author.
@@ -257,6 +278,8 @@ def _new_target_from_json_maps(dump_map, desc_map, repo_name, deps_index):
         artifact_download_info = artifact_download_info,
         product_memberships = product_memberships,
         resources = resources,
+        swift_src_info = swift_src_info,
+        objc_src_info = objc_src_info,
     )
 
 def _new_build_setting_condition_from_json(dump_map):
@@ -349,17 +372,16 @@ def _new_dependency_identity_to_name_map(dump_deps):
         result[identity] = name
     return result
 
-def _new_from_parsed_json(dump_manifest, desc_manifest, repo_name, deps_index):
+def _new_from_parsed_json(repository_ctx, dump_manifest, desc_manifest, deps_index):
     """Returns the package information from the provided Swift package JSON \
     structures.
 
     Args:
+        repository_ctx: A `repository_ctx`.
         dump_manifest: A `dict` representing the parsed JSON from `swift
             package dump-package`.
         desc_manifest: A `dict` representing the parsed JSON from `swift
             package describe`.
-        repo_name: The name of the current repository as returned by
-            `ctx_repository.name`.
         deps_index: A `struct` as returned by `deps_indexes.new`.
 
     Returns:
@@ -393,9 +415,9 @@ def _new_from_parsed_json(dump_manifest, desc_manifest, repo_name, deps_index):
 
     targets = lists.compact([
         _new_target_from_json_maps(
+            repository_ctx = repository_ctx,
             dump_map = target_map,
             desc_map = desc_targets_by_name[target_map["name"]],
-            repo_name = repo_name,
             deps_index = deps_index,
         )
         for target_map in dump_manifest["targets"]
@@ -694,6 +716,25 @@ A target dependency must have one of the following: `by_name`, `product`, `targe
         target = target,
     )
 
+# MARK: - Swift Source Info
+
+def _new_swift_src_info_from_sources(repository_ctx, target_path, sources):
+    # Check for any @objc directives in the source files
+    has_objc_directive = False
+    for src in sources:
+        path = paths.join(target_path, src)
+        if swift_files.has_objc_directive(repository_ctx, path):
+            has_objc_directive = True
+            break
+    return _new_swift_src_info(
+        has_objc_directive = has_objc_directive,
+    )
+
+def _new_swift_src_info(has_objc_directive = False):
+    return struct(
+        has_objc_directive = has_objc_directive,
+    )
+
 # MARK: - Target
 
 def _new_target(
@@ -704,6 +745,8 @@ def _new_target(
         path,
         sources,
         dependencies,
+        label = None,
+        repo_name = None,
         exclude_paths = [],
         source_paths = None,
         clang_settings = None,
@@ -712,7 +755,9 @@ def _new_target(
         public_hdrs_path = None,
         artifact_download_info = None,
         product_memberships = [],
-        resources = []):
+        resources = [],
+        swift_src_info = None,
+        objc_src_info = None):
     """Creates a target.
 
     Args:
@@ -725,6 +770,11 @@ def _new_target(
             to the `path`.
         dependencies: A `list` of target dependency values as returned by
             `pkginfos.new_target_dependency()`.
+        label: Optional. The Bazel label `struct` for the target as returned by
+            `bazel_labels.new`. Either this or `repo_name` needs to be
+            specified.
+        repo_name: Optional. The repository name as a `string`. Either this or
+            `label` need to be speicified.
         exclude_paths: Optional. A `list` of paths that should be excluded as
             specified by the Swift package manifest author.
         source_paths: Optional. A `list` of paths (`string` values) specified by
@@ -739,6 +789,12 @@ def _new_target(
             target is referenced by.
         resources: Optional. A `list` of resource `struct` values as returned
             by `pkginfos.new_resource`.
+        swift_src_info: Optional. A `struct` as returned by
+            `pkginfos.new_swift_src_info`. If the target is a Swift target, this
+            will not be `None`.
+        objc_src_info: Optional. A `struct` as returned by
+            `pkginfos.new_objc_src_info`. If the target is an Objc target, this
+            will not be `None`.
 
     Returns:
         A `struct` representing a target in a Swift package.
@@ -762,6 +818,14 @@ def _new_target(
             sp[:-1] if sp.endswith("/") else sp
             for sp in source_paths
         ]
+    if label == None and repo_name == None:
+        fail("Need to specify `label` or `repo_name`.")
+    if label == None:
+        label = pkginfo_targets.bazel_label_from_parts(
+            target_path = path,
+            target_name = name,
+            repo_name = repo_name,
+        )
     return struct(
         name = name,
         type = type,
@@ -770,6 +834,7 @@ def _new_target(
         path = path,
         sources = sources,
         dependencies = dependencies,
+        label = label,
         exclude_paths = exclude_paths,
         source_paths = normalized_src_paths,
         clang_settings = clang_settings,
@@ -779,6 +844,8 @@ def _new_target(
         artifact_download_info = artifact_download_info,
         product_memberships = product_memberships,
         resources = resources,
+        swift_src_info = swift_src_info,
+        objc_src_info = objc_src_info,
     )
 
 # MARK: - Build Settings
@@ -1092,4 +1159,5 @@ pkginfos = struct(
     new_target_dependency_from_dump_json_map = _new_target_dependency_from_dump_json_map,
     new_target_reference = _new_target_reference,
     new_version_range = _new_version_range,
+    new_swift_src_info = _new_swift_src_info,
 )

--- a/swiftpkg/tests/BUILD.bazel
+++ b/swiftpkg/tests/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":bazel_apple_platforms_tests.bzl", "bazel_apple_platforms_test_suite")
 load(":bazel_repo_names_tests.bzl", "bazel_repo_names_test_suite")
@@ -55,3 +56,9 @@ swift_files_test_suite()
 swiftpkg_build_files_test_suite()
 
 validations_test_suite()
+
+bzl_library(
+    name = "testutils",
+    srcs = ["testutils.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -77,6 +77,7 @@ _pkg_info = pkginfos.new(
                 "Bar.swift",
             ],
             dependencies = [],
+            repo_name = _repo_name,
         ),
     ],
 )

--- a/swiftpkg/tests/pkginfo_targets_tests.bzl
+++ b/swiftpkg/tests/pkginfo_targets_tests.bzl
@@ -22,6 +22,7 @@ _bar_target = pkginfos.new_target(
     path = "Sources/Bar",
     sources = ["Chicken.swift", "Smidgen/Hello.swift"],
     dependencies = [],
+    repo_name = _repo_name,
 )
 _foo_target = pkginfos.new_target(
     name = "Foo",
@@ -31,6 +32,7 @@ _foo_target = pkginfos.new_target(
     path = "Sources/Foo",
     sources = [],
     dependencies = [],
+    repo_name = _repo_name,
 )
 _chocolate_target = pkginfos.new_target(
     name = "Chocolate",
@@ -40,6 +42,7 @@ _chocolate_target = pkginfos.new_target(
     path = "Sources/Bar",
     sources = [],
     dependencies = [],
+    repo_name = _repo_name,
 )
 _dot_path_target = pkginfos.new_target(
     name = "DotPath",
@@ -49,6 +52,7 @@ _dot_path_target = pkginfos.new_target(
     path = ".",
     sources = ["Chicken.swift", "Smidgen/Hello.swift"],
     dependencies = [],
+    repo_name = _repo_name,
 )
 _simple_path_target = pkginfos.new_target(
     name = "simple_path",
@@ -58,6 +62,7 @@ _simple_path_target = pkginfos.new_target(
     path = "simple_path",
     sources = ["Simple.swift"],
     dependencies = [],
+    repo_name = _repo_name,
 )
 
 def _get_test(ctx):

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -3,16 +3,20 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//swiftpkg/internal:deps_indexes.bzl", "deps_indexes")
 load("//swiftpkg/internal:pkginfos.bzl", "pkginfos")
+load(":testutils.bzl", "testutils")
+
+# MARK: - Tests
 
 def _new_from_parsed_json_for_swift_targets_test(ctx):
     env = unittest.begin(ctx)
 
+    repo_name = "swiftpkg_mypackage"
     dump_manifest = json.decode(_swift_arg_parser_dump_json)
     desc_manifest = json.decode(_swift_arg_parser_desc_json)
     actual = pkginfos.new_from_parsed_json(
+        repository_ctx = testutils.new_stub_repository_ctx(repo_name),
         dump_manifest = dump_manifest,
         desc_manifest = desc_manifest,
-        repo_name = "swiftpkg_mypackage",
         deps_index = deps_indexes.new_from_json(_swift_arg_parser_deps_index_json),
     )
     expected = pkginfos.new(
@@ -60,6 +64,7 @@ def _new_from_parsed_json_for_swift_targets_test(ctx):
                         ),
                     ),
                 ],
+                repo_name = repo_name,
                 clang_settings = pkginfos.new_clang_settings([
                     pkginfos.new_build_setting(
                         kind = "headerSearchPath",
@@ -97,6 +102,7 @@ def _new_from_parsed_json_for_swift_targets_test(ctx):
                         ),
                     ),
                 ],
+                swift_src_info = pkginfos.new_swift_src_info(),
             ),
         ],
     )
@@ -109,12 +115,13 @@ new_from_parsed_json_for_swift_targets_test = unittest.make(_new_from_parsed_jso
 def _new_from_parsed_json_for_clang_targets_test(ctx):
     env = unittest.begin(ctx)
 
+    repo_name = "swiftpkg_libbar"
     dump_manifest = json.decode(_clang_dump_json)
     desc_manifest = json.decode(_clang_desc_json)
     actual = pkginfos.new_from_parsed_json(
+        repository_ctx = testutils.new_stub_repository_ctx(repo_name),
         dump_manifest = dump_manifest,
         desc_manifest = desc_manifest,
-        repo_name = "swiftpkg_libbar",
         deps_index = deps_indexes.new_from_json(_clang_deps_index_json),
     )
 
@@ -135,6 +142,7 @@ def _new_from_parsed_json_for_clang_targets_test(ctx):
             "libbar/sharpyuv/sharpyuv_sse2.c",
         ],
         dependencies = [],
+        repo_name = repo_name,
         source_paths = [
             "libbar/src",
             "libbar/sharpyuv",

--- a/swiftpkg/tests/testutils.bzl
+++ b/swiftpkg/tests/testutils.bzl
@@ -1,0 +1,39 @@
+"""Implementation for `testutils`."""
+
+def _new_exec_result(return_code = 0, stdout = "", stderr = ""):
+    return struct(
+        return_code = return_code,
+        stdout = stdout,
+        stderr = stderr,
+    )
+
+def _new_stub_repository_ctx(repo_name, file_contents = {}, find_results = {}):
+    def read(path):
+        return file_contents.get(path, "")
+
+    # buildifier: disable=unused-variable
+    def execute(args, environment = {}, quiet = True):
+        # The find command that we expect is `find -H -L path`.
+        # See repository_files.list_files_under for details.
+        if len(args) >= 4 and args[0] == "find":
+            path = args[3]
+            results = find_results.get(path, [])
+            exec_result = _new_exec_result(
+                stdout = "\n".join(results),
+            )
+        else:
+            exec_result = _new_exec_result()
+        return exec_result
+
+    return struct(
+        name = "bzlmodmangled~" + repo_name,
+        read = read,
+        execute = execute,
+        attr = struct(
+            bazel_package_name = repo_name,
+        ),
+    )
+
+testutils = struct(
+    new_stub_repository_ctx = _new_stub_repository_ctx,
+)


### PR DESCRIPTION
- Add `label` to target.
- Add `pkginfo_targets.get_by_label()`.
- Pass `repository_ctx` to `pkginfos.new_from_parsed_json()`.
- Add `swift_src_info` with `has_objv_directive`.
- Add `testutils` module.
- Update tests to use mangled repository name when retrieve `repository_ctx.name`.

Related to #425.