### PR TITLE
chore: show the return code when an SPM command fails

### DIFF
--- a/swiftpkg/internal/repository_utils.bzl
+++ b/swiftpkg/internal/repository_utils.bzl
@@ -59,12 +59,17 @@ def _execute_spm_command(
     if exec_result.return_code != 0:
         if err_msg_tpl == None:
             err_msg_tpl = """\
-Failed to execute SPM command. name: {repo_name}, args: {exec_args}\n{stderr}.\
+Failed to execute SPM command. \
+name: {repo_name}, \
+args: {exec_args}, \
+return_code: {return_code}\
+\n{stderr}.\
 """
         fail(err_msg_tpl.format(
             repo_name = repository_ctx.attr.name,
             exec_args = exec_args,
             stderr = exec_result.stderr,
+            return_code = exec_result.return_code,
         ))
     return exec_result.stdout
 


### PR DESCRIPTION
- Add the `return_code` to the error message sent to stderr.

