### PR TITLE
chore: use shell script to execute tidy_modified

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+export CC=clang
+bazelisk run --action_env=PATH //:tidy_modified


### PR DESCRIPTION
The shell script sets the appropriate environment variables and passes the correct flags.