### PR TITLE
chore: install clang in `do_renovate_post_upgrade`

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -14,6 +14,14 @@ else
   npm install -g @bazel/bazelisk
 fi
 
+# Install build tools
+if which &>/dev/null clang; then
+  echo "clang was found."
+else
+  echo "clang was not found. Installing build-essential..."
+  install-tool clang
+fi
+
 # Execute tidy for workspaces with modifications The export of CC and the
 # --action_env=PATH are specific to running this repository on Linux.
 export CC=clang


### PR DESCRIPTION
We need clang for Bazel and rules_swift to work properly.
