### PR TITLE
chore: reproduce #504, add `Swift-Porter-Stemmer-2` to `interesting_deps` example

### DIFF
--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -43,7 +43,8 @@ swift_binary(
     deps = [
         "@swiftpkg_libwebp_xcode//:libwebp",
         "@swiftpkg_swift_log//:Sources_Logging",
-        "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Swift_PorterStemmer2"
+        "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Stemmer_libstemmer",
+        "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Swift_PorterStemmer2",
     ],
 )
 

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -43,6 +43,7 @@ swift_binary(
     deps = [
         "@swiftpkg_libwebp_xcode//:libwebp",
         "@swiftpkg_swift_log//:Sources_Logging",
+        "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Swift_PorterStemmer2"
     ],
 )
 

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -44,6 +44,7 @@ use_repo(
     swift_deps,
     "swiftpkg_libwebp_xcode",
     "swiftpkg_swift_log",
+    "swiftpkg_swift_porter_stemmer_2",
 )
 # swift_deps END
 swift_deps.configure_package(

--- a/examples/interesting_deps/Package.resolved
+++ b/examples/interesting_deps/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/libwebp-Xcode.git",
       "state" : {
-        "revision" : "4f52fc9b29600a03de6e05af16df0d694cb44301",
-        "version" : "1.2.4"
+        "revision" : "1cdddb80ccef6d30e869c4abe1f9f3d3871a25b5",
+        "version" : "1.3.1"
       }
     },
     {
@@ -16,6 +16,15 @@
       "state" : {
         "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
         "version" : "1.5.2"
+      }
+    },
+    {
+      "identity" : "swift-porter-stemmer-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scaraux/Swift-Porter-Stemmer-2.git",
+      "state" : {
+        "revision" : "9a8055c8dfd8301eaa9104ba0c939f37847dbeb0",
+        "version" : "0.1.1"
       }
     }
   ],

--- a/examples/interesting_deps/Package.resolved
+++ b/examples/interesting_deps/Package.resolved
@@ -23,8 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scaraux/Swift-Porter-Stemmer-2.git",
       "state" : {
-        "revision" : "9a8055c8dfd8301eaa9104ba0c939f37847dbeb0",
-        "version" : "0.1.1"
+        "revision" : "5e90cdbc3700a1bf0b8083ba1117c8c4e48669a6"
       }
     }
   ],

--- a/examples/interesting_deps/Package.swift
+++ b/examples/interesting_deps/Package.swift
@@ -7,5 +7,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log", from: "1.5.2"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.3.1"),
+        .package(url: "https://github.com/scaraux/Swift-Porter-Stemmer-2.git", from: "0.1.1"),
     ]
 )

--- a/examples/interesting_deps/Package.swift
+++ b/examples/interesting_deps/Package.swift
@@ -7,6 +7,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log", from: "1.5.2"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.3.1"),
-        .package(url: "https://github.com/scaraux/Swift-Porter-Stemmer-2.git", from: "0.1.1"),
+        // .package(url: "https://github.com/scaraux/Swift-Porter-Stemmer-2.git", from: "0.1.1"),
+        // This commit fixes the missing dependency in the PortStemmer2 target.
+        .package(url: "https://github.com/scaraux/Swift-Porter-Stemmer-2.git",
+                 revision: "5e90cdbc3700a1bf0b8083ba1117c8c4e48669a6"),
     ]
 )

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -8,5 +8,9 @@ logger.info("Hello World!")
 let webpVersion = WebPGetDecoderVersion()
 logger.info("WebP version: \(webpVersion)")
 
-let stemmer = PorterStemmer(withLanguage: .English)
+guard let stemmer = PorterStemmer(withLanguage: .English) else {
+    logger.error("Failed to create stemmer.")
+    exit(1)
+}
+
 logger.info("Stemmer: \(stemmer.stem("running"))")

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -1,8 +1,12 @@
 import libwebp
 import Logging
+import PorterStemmer2
 
 let logger = Logger(label: "com.example.main")
 logger.info("Hello World!")
 
 let webpVersion = WebPGetDecoderVersion()
 logger.info("WebP version: \(webpVersion)")
+
+let stemmer = PorterStemmer(withLanguage: .English)
+logger.info("Stemmer: \(stemmer.stem("running"))")

--- a/examples/interesting_deps/swift_deps_index.json
+++ b/examples/interesting_deps/swift_deps_index.json
@@ -1,7 +1,8 @@
 {
   "direct_dep_identities": [
     "libwebp-xcode",
-    "swift-log"
+    "swift-log",
+    "swift-porter-stemmer-2"
   ],
   "modules": [
     {
@@ -23,6 +24,26 @@
       "product_memberships": [
         "Logging"
       ]
+    },
+    {
+      "name": "libstemmer",
+      "c99name": "libstemmer",
+      "src_type": "clang",
+      "label": "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Stemmer_libstemmer",
+      "package_identity": "swift-porter-stemmer-2",
+      "product_memberships": [
+        "PorterStemmer2"
+      ]
+    },
+    {
+      "name": "PorterStemmer2",
+      "c99name": "PorterStemmer2",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Swift_PorterStemmer2",
+      "package_identity": "swift-porter-stemmer-2",
+      "product_memberships": [
+        "PorterStemmer2"
+      ]
     }
   ],
   "products": [
@@ -41,6 +62,15 @@
       "target_labels": [
         "@swiftpkg_swift_log//:Sources_Logging"
       ]
+    },
+    {
+      "identity": "swift-porter-stemmer-2",
+      "name": "PorterStemmer2",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Stemmer_libstemmer",
+        "@swiftpkg_swift_porter_stemmer_2//:PorterStemmer2_Classes_Swift_PorterStemmer2"
+      ]
     }
   ],
   "packages": [
@@ -48,9 +78,9 @@
       "name": "swiftpkg_libwebp_xcode",
       "identity": "libwebp-xcode",
       "remote": {
-        "commit": "4f52fc9b29600a03de6e05af16df0d694cb44301",
+        "commit": "1cdddb80ccef6d30e869c4abe1f9f3d3871a25b5",
         "remote": "https://github.com/SDWebImage/libwebp-Xcode.git",
-        "version": "1.2.4"
+        "version": "1.3.1"
       }
     },
     {
@@ -60,6 +90,15 @@
         "commit": "32e8d724467f8fe623624570367e3d50c5638e46",
         "remote": "https://github.com/apple/swift-log",
         "version": "1.5.2"
+      }
+    },
+    {
+      "name": "swiftpkg_swift_porter_stemmer_2",
+      "identity": "swift-porter-stemmer-2",
+      "remote": {
+        "commit": "9a8055c8dfd8301eaa9104ba0c939f37847dbeb0",
+        "remote": "https://github.com/scaraux/Swift-Porter-Stemmer-2.git",
+        "version": "0.1.1"
       }
     }
   ]

--- a/examples/interesting_deps/swift_deps_index.json
+++ b/examples/interesting_deps/swift_deps_index.json
@@ -96,9 +96,8 @@
       "name": "swiftpkg_swift_porter_stemmer_2",
       "identity": "swift-porter-stemmer-2",
       "remote": {
-        "commit": "9a8055c8dfd8301eaa9104ba0c939f37847dbeb0",
-        "remote": "https://github.com/scaraux/Swift-Porter-Stemmer-2.git",
-        "version": "0.1.1"
+        "commit": "5e90cdbc3700a1bf0b8083ba1117c8c4e48669a6",
+        "remote": "https://github.com/scaraux/Swift-Porter-Stemmer-2.git"
       }
     }
   ]


### PR DESCRIPTION
This reproduces the error reported in #504. The index updates are the result of running `bazel :tidy` on the example project.
