### PR TITLE
chore(deps): upgrade rules_go and gazelle

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "cgrindel_bazel_starlib", version = "0.16.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(
     name = "rules_go",
-    version = "0.40.1",
+    version = "0.41.0",
     repo_name = "io_bazel_rules_go",
 )
 bazel_dep(name = "rules_cc", version = "0.0.6")
@@ -29,7 +29,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "gazelle",
-    version = "0.31.1",
+    version = "0.32.0",
     repo_name = "bazel_gazelle",
 )
 


### PR DESCRIPTION
- Upgrade `rules_go` to 0.41.0.
- Upgrade `gazelle` to 0.32.0.

Take 2 after #529.