### PR TITLE
fix: use `apple_static_xcframework_import` for `binaryTarget` in SPM

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -23,7 +23,8 @@ def _new_for_target(repository_ctx, pkg_ctx, target):
     elif target.module_type == module_types.system_library:
         return _system_library_build_file(target)
     elif target.module_type == module_types.binary:
-        return _apple_dynamic_xcframework_import_build_file(target)
+        # return _apple_dynamic_xcframework_import_build_file(target)
+        return _apple_static_xcframework_import_build_file(target)
 
     # GH046: Support plugins.
     return None
@@ -376,6 +377,27 @@ def _apple_dynamic_xcframework_import_build_file(target):
         decls = decls,
     )
 
+def _apple_static_xcframework_import_build_file(target):
+    load_stmts = [apple_static_xcframework_import_load_stmt]
+    glob = scg.new_fn_call(
+        "glob",
+        ["{tpath}/*.xcframework/**".format(tpath = target.path)],
+    )
+    decls = [
+        build_decls.new(
+            kind = apple_kinds.static_xcframework_import,
+            name = pkginfo_targets.bazel_label_name(target),
+            attrs = {
+                "visibility": ["//visibility:public"],
+                "xcframework_imports": glob,
+            },
+        ),
+    ]
+    return build_files.new(
+        load_stmts = load_stmts,
+        decls = decls,
+    )
+
 # MARK: - Apple Resource Group
 
 def _apple_resource_bundle(repository_ctx, target, default_localization):
@@ -641,6 +663,7 @@ swiftpkg_build_files = struct(
 
 apple_kinds = struct(
     dynamic_xcframework_import = "apple_dynamic_xcframework_import",
+    static_xcframework_import = "apple_static_xcframework_import",
     resource_bundle = "apple_resource_bundle",
 )
 
@@ -651,6 +674,11 @@ apple_resources_location = "@build_bazel_rules_apple//apple:resources.bzl"
 apple_dynamic_xcframework_import_load_stmt = load_statements.new(
     apple_apple_location,
     apple_kinds.dynamic_xcframework_import,
+)
+
+apple_static_xcframework_import_load_stmt = load_statements.new(
+    apple_apple_location,
+    apple_kinds.static_xcframework_import,
 )
 
 apple_resource_bundle_load_stmt = load_statements.new(


### PR DESCRIPTION
Previously, binary targets were exposed using `apple_dynamic_xcframework_import`. Now, they will be exposed as `apple_statix_xcframework_import`. 

If anyone wishes to be able control how these targets are represented in the Bazel build graph, please comment on #559.

Closes #498.