### PR TITLE
chore: remove legacy WORKSPACE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,79 +32,54 @@ jobs:
         include:
           - test: '@@//bzlmod:e2e_test'
             runner: ubuntu-22.04
-            enable_bzlmod: true
           - test: '@@//bzlmod:e2e_test'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:firebase_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
-            enable_bzlmod: true
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
-          - test: '@@//examples:http_archive_ext_deps_test_bazel_.bazelversion'
+          - test: '@@//examples:http_archive_ext_deps_legacy_test_bazel_.bazelversion'
             runner: ubuntu-22.04
-            enable_bzlmod: false
-          - test: '@@//examples:http_archive_ext_deps_test_bazel_.bazelversion'
+          - test: '@@//examples:http_archive_ext_deps_legacy_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: false
           - test: '@@//examples:interesting_deps_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:ios_sim_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:objc_code_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:phone_number_kit_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:pkg_manifest_minimal_test_bazel_.bazelversion'
             runner: ubuntu-22.04
-            enable_bzlmod: true
           - test: '@@//examples:pkg_manifest_minimal_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:resources_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:snapkit_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:soto_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
-            enable_bzlmod: true
           - test: '@@//examples:soto_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:stripe_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
+          - test: '@@//examples:vapor_example_legacy_test_bazel_.bazelversion'
+            runner: ubuntu-22.04
+          - test: '@@//examples:vapor_example_legacy_test_bazel_.bazelversion'
+            runner: macos-13
           - test: '@@//examples:vapor_example_test_bazel_.bazelversion'
             runner: ubuntu-22.04
-            enable_bzlmod: false
-          - test: '@@//examples:vapor_example_test_bazel_.bazelversion'
-            runner: ubuntu-22.04
-            enable_bzlmod: true
           - test: '@@//examples:vapor_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: false
-          - test: '@@//examples:vapor_example_test_bazel_.bazelversion'
-            runner: macos-13
-            enable_bzlmod: true
           - test: '@@//examples:xcmetrics_example_test_bazel_.bazelversion'
             runner: macos-13
-            enable_bzlmod: true
           - test: '@@//release:archive_test'
             runner: ubuntu-22.04
-            enable_bzlmod: true
           - test: '@@//release:archive_test'
             runner: macos-13
-            enable_bzlmod: true
     runs-on: ${{ matrix.runner }}
     env:
       CC: clang
@@ -120,9 +95,6 @@ jobs:
         with:
           repo_name: rules_swift_package_manager
           xcode_version: "14.2"
-      - uses: ./.github/actions/configure_bzlmod
-        with:
-          enabled: ${{ matrix.enable_bzlmod }}
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
           buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
@@ -137,9 +109,6 @@ jobs:
         runner:
           - macos-13
           - ubuntu-22.04
-        enable_bzlmod:
-          - true
-          - false
     runs-on: ${{ matrix.runner }}
     env:
       CC: clang
@@ -155,9 +124,6 @@ jobs:
         with:
           repo_name: rules_swift_package_manager
           xcode_version: "14.2"
-      - uses: ./.github/actions/configure_bzlmod
-        with:
-          enabled: ${{ matrix.enable_bzlmod }}
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
           buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
+load("@cgrindel_bazel_starlib//shlib/rules:execute_binary.bzl", "execute_binary")
 load(
     "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
@@ -25,6 +26,13 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
         "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
+)
+
+execute_binary(
+    name = "legacy_test_runner",
+    testonly = True,
+    arguments = ["--legacy"],
+    binary = ":test_runner",
 )
 
 # MARK: - Integration Tests

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -39,20 +39,28 @@ example_infos.ci_test_params_suite(
     example_infos = example_infos.all,
 )
 
-_smoke_test_names = sorted([
-    example_infos.test_name(
-        ei.name,
-        bazel_binaries.versions.current,
-    )
-    for ei in example_infos.all
-])
-
-_all_test_names = sorted(lists.flatten([
+_smoke_test_names = sorted(lists.flatten([
     [
         example_infos.test_name(
             ei.name,
-            version,
+            enable_bzlmod,
+            bazel_binaries.versions.current,
         )
+        for enable_bzlmod in ei.enable_bzlmods
+    ]
+    for ei in example_infos.all
+]))
+
+_all_test_names = sorted(lists.flatten([
+    [
+        [
+            example_infos.test_name(
+                ei.name,
+                enable_bzlmod,
+                version,
+            )
+            for enable_bzlmod in ei.enable_bzlmods
+        ]
         for version in ei.versions
     ]
     for ei in example_infos.all

--- a/examples/example_infos.bzl
+++ b/examples/example_infos.bzl
@@ -34,21 +34,9 @@ def _new(name, oss, versions, enable_bzlmods):
         enable_bzlmods = enable_bzlmods,
     )
 
-# def _test_name(example_name, version, enable_bzlmod = True):
-#     tmpl = "{name}_{version}_test"
-#     if not enable_bzlmod:
-#         tmpl = "{name}_{version}_legacy_test"
-#     return tmpl.format(name = example_name, version = version)
-
 def _test_name_prefix(name, enable_bzlmod = True):
     suffix = "_test" if enable_bzlmod else "_legacy_test"
     return name + suffix
-
-# def _test_name(example_name, version):
-#     return integration_test_utils.bazel_integration_test_name(
-#         example_name + "_test",
-#         version,
-#     )
 
 def _test_name(example_name, enable_bzlmod, version):
     return integration_test_utils.bazel_integration_test_name(
@@ -65,12 +53,12 @@ def _bazel_integration_test(ei):
         {"//conditions:default": ["@platforms//:incompatible"]},
     ))
     timeout = _timeouts.get(ei.name, _default_timeout)
-    test_runner = ":test_runner"
     workspace_files = integration_test_utils.glob_workspace_files(ei.name) + [
         "//:runtime_files",
     ]
     workspace_path = ei.name
     for enable_bzlmod in ei.enable_bzlmods:
+        test_runner = ":test_runner" if enable_bzlmod else ":legacy_test_runner"
         bazel_integration_tests(
             name = _test_name_prefix(ei.name, enable_bzlmod = enable_bzlmod),
             bazel_binaries = bazel_binaries,
@@ -99,19 +87,6 @@ def _ci_integration_test_params(ei, enable_bzlmod, version):
         test_names = [test_name],
         visibility = ["//:__subpackages__"],
     )
-
-# def _ci_integration_test_params(ei, version):
-#     test_name = _test_name(ei.name, version)
-#     ci_integration_test_params(
-#         name = _test_params_name_from_test_name(test_name),
-#         bzlmod_modes = [
-#             bzlmod_modes.from_bool(enable_bzlmod)
-#             for enable_bzlmod in ei.enable_bzlmods
-#         ],
-#         oss = ei.oss,
-#         test_names = [test_name],
-#         visibility = ["//:__subpackages__"],
-#     )
 
 def _ci_test_params_suite(name, example_infos):
     ci_test_params_suite(

--- a/examples/example_infos.bzl
+++ b/examples/example_infos.bzl
@@ -5,13 +5,11 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load(
     "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
-    "bazel_integration_test",
     "bazel_integration_tests",
     "integration_test_utils",
 )
 load(
     "//ci:defs.bzl",
-    "bzlmod_modes",
     "ci_integration_test_params",
     "ci_test_params_suite",
 )
@@ -36,14 +34,29 @@ def _new(name, oss, versions, enable_bzlmods):
         enable_bzlmods = enable_bzlmods,
     )
 
-def _test_name(example_name, version):
+# def _test_name(example_name, version, enable_bzlmod = True):
+#     tmpl = "{name}_{version}_test"
+#     if not enable_bzlmod:
+#         tmpl = "{name}_{version}_legacy_test"
+#     return tmpl.format(name = example_name, version = version)
+
+def _test_name_prefix(name, enable_bzlmod = True):
+    suffix = "_test" if enable_bzlmod else "_legacy_test"
+    return name + suffix
+
+# def _test_name(example_name, version):
+#     return integration_test_utils.bazel_integration_test_name(
+#         example_name + "_test",
+#         version,
+#     )
+
+def _test_name(example_name, enable_bzlmod, version):
     return integration_test_utils.bazel_integration_test_name(
-        example_name + "_test",
+        _test_name_prefix(example_name, enable_bzlmod = enable_bzlmod),
         version,
     )
 
 def _bazel_integration_test(ei):
-    versions_len = len(ei.versions)
     target_compatible_with = select(dicts.add(
         {
             "@platforms//os:{}".format(os): []
@@ -57,23 +70,9 @@ def _bazel_integration_test(ei):
         "//:runtime_files",
     ]
     workspace_path = ei.name
-    if versions_len == 1:
-        version = ei.versions[0]
-        test_name = _test_name(ei.name, version)
-        bazel_integration_test(
-            name = test_name,
-            bazel_binaries = bazel_binaries,
-            bazel_version = version,
-            timeout = timeout,
-            target_compatible_with = target_compatible_with,
-            test_runner = test_runner,
-            workspace_files = workspace_files,
-            workspace_path = workspace_path,
-        )
-        _ci_integration_test_params(ei, version)
-    elif versions_len > 1:
+    for enable_bzlmod in ei.enable_bzlmods:
         bazel_integration_tests(
-            name = ei.name + "_test",
+            name = _test_name_prefix(ei.name, enable_bzlmod = enable_bzlmod),
             bazel_binaries = bazel_binaries,
             bazel_versions = ei.versions,
             timeout = timeout,
@@ -83,34 +82,46 @@ def _bazel_integration_test(ei):
             workspace_path = workspace_path,
         )
         for version in ei.versions:
-            _ci_integration_test_params(ei, version)
+            _ci_integration_test_params(ei, enable_bzlmod, version)
 
-def _test_params_name(ei, version):
-    test_name = _test_name(ei.name, version)
+def _test_params_name(name, enable_bzlmod, version):
+    test_name = _test_name(name, enable_bzlmod, version)
     return _test_params_name_from_test_name(test_name)
 
 def _test_params_name_from_test_name(test_name):
     return "{}_params".format(test_name)
 
-def _ci_integration_test_params(ei, version):
-    test_name = _test_name(ei.name, version)
+def _ci_integration_test_params(ei, enable_bzlmod, version):
+    test_name = _test_name(ei.name, enable_bzlmod, version)
     ci_integration_test_params(
         name = _test_params_name_from_test_name(test_name),
-        bzlmod_modes = [
-            bzlmod_modes.from_bool(enable_bzlmod)
-            for enable_bzlmod in ei.enable_bzlmods
-        ],
         oss = ei.oss,
         test_names = [test_name],
         visibility = ["//:__subpackages__"],
     )
+
+# def _ci_integration_test_params(ei, version):
+#     test_name = _test_name(ei.name, version)
+#     ci_integration_test_params(
+#         name = _test_params_name_from_test_name(test_name),
+#         bzlmod_modes = [
+#             bzlmod_modes.from_bool(enable_bzlmod)
+#             for enable_bzlmod in ei.enable_bzlmods
+#         ],
+#         oss = ei.oss,
+#         test_names = [test_name],
+#         visibility = ["//:__subpackages__"],
+#     )
 
 def _ci_test_params_suite(name, example_infos):
     ci_test_params_suite(
         name = name,
         test_params = lists.flatten([
             [
-                _test_params_name(ei, v)
+                [
+                    _test_params_name(ei.name, eb, v)
+                    for eb in ei.enable_bzlmods
+                ]
                 for v in ei.versions
             ]
             for ei in example_infos
@@ -200,5 +211,6 @@ example_infos = struct(
     bazel_integration_test = _bazel_integration_test,
     ci_test_params_suite = _ci_test_params_suite,
     new = _new,
+    test_name_prefix = _test_name_prefix,
     test_name = _test_name,
 )

--- a/examples/example_infos.bzl
+++ b/examples/example_infos.bzl
@@ -59,7 +59,7 @@ def _bazel_integration_test(ei):
     workspace_path = ei.name
     if versions_len == 1:
         version = ei.versions[0]
-        test_name = example_infos.test_name(ei.name, version)
+        test_name = _test_name(ei.name, version)
         bazel_integration_test(
             name = test_name,
             bazel_binaries = bazel_binaries,
@@ -86,14 +86,14 @@ def _bazel_integration_test(ei):
             _ci_integration_test_params(ei, version)
 
 def _test_params_name(ei, version):
-    test_name = example_infos.test_name(ei.name, version)
+    test_name = _test_name(ei.name, version)
     return _test_params_name_from_test_name(test_name)
 
 def _test_params_name_from_test_name(test_name):
     return "{}_params".format(test_name)
 
 def _ci_integration_test_params(ei, version):
-    test_name = example_infos.test_name(ei.name, version)
+    test_name = _test_name(ei.name, version)
     ci_integration_test_params(
         name = _test_params_name_from_test_name(test_name),
         bzlmod_modes = [

--- a/examples/test_runner.sh
+++ b/examples/test_runner.sh
@@ -25,6 +25,24 @@ create_scratch_dir_sh="$(rlocation "${create_scratch_dir_sh_location}")" || \
 
 # MARK - Process Arguments
 
+legacy_mode=false
+while (("$#")); do
+  case "${1}" in
+    "--legacy")
+      legacy_mode=true
+      shift 1
+      ;;
+    "--nolegacy")
+      legacy_mode=false
+      shift 1
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done
+
 bazel="${BIT_BAZEL_BINARY:-}"
 workspace_dir="${BIT_WORKSPACE_DIR:-}"
 
@@ -36,6 +54,10 @@ workspace_dir="${BIT_WORKSPACE_DIR:-}"
 scratch_dir="$("${create_scratch_dir_sh}" --workspace "${workspace_dir}")"
 cd "${scratch_dir}"
 
+if [[ "${legacy_mode}" == "true" ]]; then
+  echo "build --config=legacy" >> .bazelrc
+fi
+
 # Dump Bazel info
 bazel info
 
@@ -45,5 +67,8 @@ do_test
 
 # MARK - Clean Test
 
-set_up_clean_test
-do_test
+if [[ -f set_up_clean_test ]]; then
+  set_up_clean_test
+  do_test
+fi
+

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -43,4 +43,4 @@ run --bes_results_url=
 
 # Configuration group to run using legacy WORKSPACE
 common:legacy --noenable_bzlmod
-build:legacy --@nocgrindel_bazel_starlib//bzlmod:enabled
+build:legacy --no@cgrindel_bazel_starlib//bzlmod:enabled

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -41,3 +41,6 @@ build --bes_upload_mode=fully_async
 run --bes_backend=
 run --bes_results_url=
 
+# Configuration group to run using legacy WORKSPACE
+common:legacy --noenable_bzlmod
+build:legacy --@nocgrindel_bazel_starlib//bzlmod:enabled

--- a/tools/generate_ci_workflow/internal/github/workflow.go
+++ b/tools/generate_ci_workflow/internal/github/workflow.go
@@ -113,18 +113,14 @@ func (ff FailFast) IsZero() bool {
 
 // SBMatrixStrategy is the job execution matrix.
 type SBMatrixStrategy struct {
-	Example      []string          `yaml:"example,omitempty"`
-	BazelVersion []string          `yaml:"bazel_version,omitempty"`
-	Runner       []string          `yaml:"runner,omitempty"`
-	EnableBzlmod []bool            `yaml:"enable_bzlmod,omitempty"`
-	Include      []SBMatrixInclude `yaml:"include,omitempty"`
+	Example []string          `yaml:"example,omitempty"`
+	Runner  []string          `yaml:"runner,omitempty"`
+	Include []SBMatrixInclude `yaml:"include,omitempty"`
 }
 
 // SBMatrixInclude is the include for the job execution matrix.
 type SBMatrixInclude struct {
-	Example      string `yaml:"example,omitempty"`
-	BazelVersion string `yaml:"bazel_version,omitempty"`
-	Test         string `yaml:"test"`
-	Runner       string `yaml:"runner"`
-	EnableBzlmod bool   `yaml:"enable_bzlmod"`
+	Example string `yaml:"example,omitempty"`
+	Test    string `yaml:"test"`
+	Runner  string `yaml:"runner"`
 }

--- a/tools/generate_ci_workflow/internal/testparams/int_test_params.go
+++ b/tools/generate_ci_workflow/internal/testparams/int_test_params.go
@@ -6,20 +6,8 @@ const MacOS = "macos"
 const LinuxOS = "linux"
 
 type IntTestParams struct {
-	Test       string `json:"test"`
-	OS         string `json:"os"`
-	BzlmodMode string `json:"bzlmod_mode"`
-}
-
-func (itp *IntTestParams) EnableBzlmod() bool {
-	switch itp.BzlmodMode {
-	case "enabled":
-		return true
-	case "disabled":
-		return false
-	default:
-		return false
-	}
+	Test string `json:"test"`
+	OS   string `json:"os"`
 }
 
 func (itp *IntTestParams) Runner() string {

--- a/tools/generate_ci_workflow/internal/testparams/int_test_params_test.go
+++ b/tools/generate_ci_workflow/internal/testparams/int_test_params_test.go
@@ -12,8 +12,8 @@ func TestNewIntTestParamsFromJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, actual, 2)
 	expected := []testparams.IntTestParams{
-		{Test: "@@//path:int_test", OS: "macos", BzlmodMode: "enabled"},
-		{Test: "@@//path:int_test", OS: "linux", BzlmodMode: "disabled"},
+		{Test: "@@//path:int_test", OS: "macos"},
+		{Test: "@@//path:int_test", OS: "linux"},
 	}
 	assert.Equal(t, expected, actual)
 }

--- a/tools/generate_ci_workflow/main.go
+++ b/tools/generate_ci_workflow/main.go
@@ -107,9 +107,8 @@ func updateMatrix(m *github.SBMatrixStrategy, intTestParams []testparams.IntTest
 	newM := github.SBMatrixStrategy{}
 	for _, itp := range intTestParams {
 		inc := github.SBMatrixInclude{
-			Test:         itp.Test,
-			Runner:       itp.Runner(),
-			EnableBzlmod: itp.EnableBzlmod(),
+			Test:   itp.Test,
+			Runner: itp.Runner(),
 		}
 		newM.Include = append(newM.Include, inc)
 	}


### PR DESCRIPTION
- Remove the content of `WORKSPACE`.
- Rework Bazel integration tests so that legacy (non-bzlmod) tests are listed as targets.
- Update the CI workflow to not include `enable_bzlmod`.