### PR TITLE
chore: refactor how resources are specified on `apple_resource_bundle`

### DIFF
--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -241,13 +241,37 @@ def _new_target_from_json_maps(
     linker_settings = _new_linker_settings_from_dump_json_list(
         dump_map["settings"],
     )
-    resources_map = dump_map.get("resources", [])
-    if len(resources_map) == 0:
-        resources_map = desc_map.get("resources", [])
+
+    # The description JSON should have a list with all of the resources with
+    # their absolute paths.
     resources = [
-        _new_resource_from_dump_json_map(d, pkg_path)
-        for d in resources_map
+        _new_resource_from_desc_map(r, pkg_path)
+        for r in desc_map.get("resources", [])
     ]
+
+    # desc_resources = desc_map.get("resources", [])
+    # if desc_resources != []:
+    #     resources = [
+    #         _new_resource_from_desc_map(repository_ctx, d, pkg_path)
+    #         for d in desc_resources
+    #     ]
+    # else:
+    #     resources = [
+    #         _new_resource_from_desc_map(repository_ctx, d, pkg_path)
+    #         for d in dump_map.get("resources", [])
+    #     ]
+
+    # resources_map = dump_map.get("resources", [])
+    # if len(resources_map) == 0:
+    #     resources_map = desc_map.get("resources", [])
+    # resources_map = desc_map.get("resources", [])
+    # if len(resources_map) == 0:
+    #     resources_map = dump_map.get("resources", [])
+    # resources = [
+    #     _new_resource_from_json_map(repository_ctx, d, pkg_path)
+    #     for d in resources_map
+    # ]
+
     artifact_download_info = None
     url = dump_map.get("url")
     if url != None:
@@ -783,11 +807,19 @@ def _new_swift_src_info_from_sources(repository_ctx, target_path, sources):
     # Do not include directories in the output.
     tp_prefix = target_path + "/"
     discovered_res_files = [
-        f.removeprefix(tp_prefix)
+        # f.removeprefix(tp_prefix)
+        f
         for f in all_target_files
         if not repository_files.is_directory(repository_ctx, f) and
            resource_files.is_auto_discovered_resource(f)
     ]
+
+    # DEBUG BEGIN
+    print("*** CHUCK discovered_res_files: ")
+    for idx, item in enumerate(discovered_res_files):
+        print("*** CHUCK", idx, ":", item)
+
+    # DEBUG END
 
     return _new_swift_src_info(
         has_objc_directive = has_objc_directive,
@@ -1285,13 +1317,21 @@ def _new_resource_rule_process(localization = None):
         localization = localization,
     )
 
-def _new_resource_from_dump_json_map(dump_map, pkg_path):
-    path = dump_map["path"]
+def _new_resource_from_desc_map(desc_map, pkg_path):
+    path = desc_map["path"]
     if paths.is_absolute(path):
         path = paths.relativize(path, pkg_path)
+
+    # DEBUG BEGIN
+    print("*** CHUCK ---------")
+    print("*** CHUCK desc_map[\"path\"]: ", desc_map["path"])
+    print("*** CHUCK pkg_path: ", pkg_path)
+    print("*** CHUCK path: ", path)
+
+    # DEBUG END
     return _new_resource(
         path = path,
-        rule = _new_resource_rule_from_dump_json_map(dump_map["rule"]),
+        rule = _new_resource_rule_from_dump_json_map(desc_map["rule"]),
     )
 
 def _new_resource_rule_from_dump_json_map(dump_map):

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -780,11 +780,11 @@ def _new_swift_src_info_from_sources(repository_ctx, target_path, sources):
         target_path,
     )
 
+    # TODO(chuck): Remove is_directory check.
+
     # The paths should be relative to the target not the root of the workspace.
     # Do not include directories in the output.
-    tp_prefix = target_path + "/"
     discovered_res_files = [
-        # f.removeprefix(tp_prefix)
         f
         for f in all_target_files
         if not repository_files.is_directory(repository_ctx, f) and

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -249,29 +249,6 @@ def _new_target_from_json_maps(
         for r in desc_map.get("resources", [])
     ]
 
-    # desc_resources = desc_map.get("resources", [])
-    # if desc_resources != []:
-    #     resources = [
-    #         _new_resource_from_desc_map(repository_ctx, d, pkg_path)
-    #         for d in desc_resources
-    #     ]
-    # else:
-    #     resources = [
-    #         _new_resource_from_desc_map(repository_ctx, d, pkg_path)
-    #         for d in dump_map.get("resources", [])
-    #     ]
-
-    # resources_map = dump_map.get("resources", [])
-    # if len(resources_map) == 0:
-    #     resources_map = desc_map.get("resources", [])
-    # resources_map = desc_map.get("resources", [])
-    # if len(resources_map) == 0:
-    #     resources_map = dump_map.get("resources", [])
-    # resources = [
-    #     _new_resource_from_json_map(repository_ctx, d, pkg_path)
-    #     for d in resources_map
-    # ]
-
     artifact_download_info = None
     url = dump_map.get("url")
     if url != None:
@@ -814,13 +791,6 @@ def _new_swift_src_info_from_sources(repository_ctx, target_path, sources):
            resource_files.is_auto_discovered_resource(f)
     ]
 
-    # DEBUG BEGIN
-    print("*** CHUCK discovered_res_files: ")
-    for idx, item in enumerate(discovered_res_files):
-        print("*** CHUCK", idx, ":", item)
-
-    # DEBUG END
-
     return _new_swift_src_info(
         has_objc_directive = has_objc_directive,
         imports_xctest = imports_xctest,
@@ -1321,14 +1291,6 @@ def _new_resource_from_desc_map(desc_map, pkg_path):
     path = desc_map["path"]
     if paths.is_absolute(path):
         path = paths.relativize(path, pkg_path)
-
-    # DEBUG BEGIN
-    print("*** CHUCK ---------")
-    print("*** CHUCK desc_map[\"path\"]: ", desc_map["path"])
-    print("*** CHUCK pkg_path: ", pkg_path)
-    print("*** CHUCK path: ", path)
-
-    # DEBUG END
     return _new_resource(
         path = path,
         rule = _new_resource_rule_from_dump_json_map(desc_map["rule"]),

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -780,8 +780,6 @@ def _new_swift_src_info_from_sources(repository_ctx, target_path, sources):
         target_path,
     )
 
-    # TODO(chuck): Remove is_directory check.
-
     # The paths should be relative to the target not the root of the workspace.
     # Do not include directories in the output.
     discovered_res_files = [

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -401,7 +401,26 @@ def _apple_resource_bundle(repository_ctx, target, default_localization):
             glob_paths.append("{}/**".format(path))
         else:
             file_paths.append(path)
-    resources = scg.new_fn_call("glob", glob_paths + file_paths)
+
+    resource_parts = []
+    if len(glob_paths) > 0:
+        resource_parts.append(scg.new_fn_call("glob", glob_paths))
+    if len(file_paths) > 0:
+        resource_parts.append(file_paths)
+
+    rp_len = len(resource_parts)
+    if rp_len == 0:
+        fail("""\
+We were asked to create an apple_resource_bundle, but no resources were specified.\
+""")
+    elif rp_len == 1:
+        resources = resource_parts[0]
+    else:
+        resources = scg.new_expr(
+            resource_parts[0],
+            scg.new_op("+"),
+            resource_parts[1],
+        )
 
     load_stmts = [
         apple_resource_bundle_load_stmt,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -394,13 +394,14 @@ def _apple_resource_bundle(repository_ctx, target, default_localization):
     # file paths using a list.
 
     glob_paths = []
+    file_paths = []
     for r in target.resources:
         path = pkginfo_targets.join_path(target, r.path)
         if repository_files.is_directory(repository_ctx, path):
             glob_paths.append("{}/**".format(path))
         else:
-            glob_paths.append(path)
-    resources = scg.new_fn_call("glob", glob_paths)
+            file_paths.append(path)
+    resources = scg.new_fn_call("glob", glob_paths + file_paths)
 
     load_stmts = [
         apple_resource_bundle_load_stmt,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -10,7 +10,6 @@ load(":load_statements.bzl", "load_statements")
 load(":pkginfo_target_deps.bzl", "pkginfo_target_deps")
 load(":pkginfo_targets.bzl", "pkginfo_targets")
 load(":pkginfos.bzl", "build_setting_kinds", "module_types", "pkginfos", "target_types")
-load(":repository_files.bzl", "repository_files")
 load(":starlark_codegen.bzl", scg = "starlark_codegen")
 
 # MARK: - Target Entry Point
@@ -390,42 +389,39 @@ def _apple_resource_bundle(repository_ctx, target, default_localization):
         bzl_target_name,
     )
 
-    glob_paths = []
-    file_paths = []
-    for r in target.resources:
-        # path = pkginfo_targets.join_path(target, r.path)
-        path = r.path
+    resources = [
+        r.path
+        for r in target.resources
+    ]
 
-        # DEBUG BEGIN
-        print("*** CHUCK --------")
-        print("*** CHUCK target.path: ", target.path)
-        print("*** CHUCK r.path: ", r.path)
+    # glob_paths = []
+    # file_paths = []
+    # for r in target.resources:
+    #     path = r.path
+    #     if repository_files.is_directory(repository_ctx, path):
+    #         glob_paths.append("{}/**".format(path))
+    #     else:
+    #         file_paths.append(path)
 
-        # DEBUG END
-        if repository_files.is_directory(repository_ctx, path):
-            glob_paths.append("{}/**".format(path))
-        else:
-            file_paths.append(path)
+    # resource_parts = []
+    # if len(glob_paths) > 0:
+    #     resource_parts.append(scg.new_fn_call("glob", glob_paths))
+    # if len(file_paths) > 0:
+    #     resource_parts.append(file_paths)
 
-    resource_parts = []
-    if len(glob_paths) > 0:
-        resource_parts.append(scg.new_fn_call("glob", glob_paths))
-    if len(file_paths) > 0:
-        resource_parts.append(file_paths)
-
-    rp_len = len(resource_parts)
-    if rp_len == 0:
-        fail("""\
-We were asked to create an apple_resource_bundle, but no resources were specified.\
-""")
-    elif rp_len == 1:
-        resources = resource_parts[0]
-    else:
-        resources = scg.new_expr(
-            resource_parts[0],
-            scg.new_op("+"),
-            resource_parts[1],
-        )
+    # rp_len = len(resource_parts)
+    # if rp_len == 0:
+    #     fail("""\
+    # We were asked to create an apple_resource_bundle, but no resources were specified.\
+    # """)
+    # elif rp_len == 1:
+    #     resources = resource_parts[0]
+    # else:
+    #     resources = scg.new_expr(
+    #         resource_parts[0],
+    #         scg.new_op("+"),
+    #         resource_parts[1],
+    #     )
 
     load_stmts = [
         apple_resource_bundle_load_stmt,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -390,13 +390,18 @@ def _apple_resource_bundle(repository_ctx, target, default_localization):
         bzl_target_name,
     )
 
-    # GH575: Refactor the resources into glob patterns and file paths. Add
-    # file paths using a list.
-
     glob_paths = []
     file_paths = []
     for r in target.resources:
-        path = pkginfo_targets.join_path(target, r.path)
+        # path = pkginfo_targets.join_path(target, r.path)
+        path = r.path
+
+        # DEBUG BEGIN
+        print("*** CHUCK --------")
+        print("*** CHUCK target.path: ", target.path)
+        print("*** CHUCK r.path: ", r.path)
+
+        # DEBUG END
         if repository_files.is_directory(repository_ctx, path):
             glob_paths.append("{}/**".format(path))
         else:

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -18,7 +18,7 @@ def _new_for_target(repository_ctx, pkg_ctx, target):
     if target.module_type == module_types.clang:
         return _clang_target_build_file(repository_ctx, pkg_ctx, target)
     elif target.module_type == module_types.swift:
-        return _swift_target_build_file(repository_ctx, pkg_ctx, target)
+        return _swift_target_build_file(pkg_ctx, target)
     elif target.module_type == module_types.system_library:
         return _system_library_build_file(target)
     elif target.module_type == module_types.binary:
@@ -30,7 +30,7 @@ def _new_for_target(repository_ctx, pkg_ctx, target):
 
 # MARK: - Swift Target
 
-def _swift_target_build_file(repository_ctx, pkg_ctx, target):
+def _swift_target_build_file(pkg_ctx, target):
     if target.swift_src_info == None:
         fail("Expected a `swift_src_info`. name: ", target.name)
 
@@ -86,7 +86,6 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
         # Apparently, SPM provides a `Bundle.module` accessor. So, we do too.
         # https://stackoverflow.com/questions/63237395/generating-resource-bundle-accessor-type-bundle-has-no-member-module
         all_build_files.append(_apple_resource_bundle(
-            repository_ctx,
             target,
             pkg_ctx.pkg_info.default_localization,
         ))
@@ -382,7 +381,7 @@ def _apple_static_xcframework_import_build_file(target):
 
 # MARK: - Apple Resource Group
 
-def _apple_resource_bundle(repository_ctx, target, default_localization):
+def _apple_resource_bundle(target, default_localization):
     bzl_target_name = pkginfo_targets.bazel_label_name(target)
     bundle_name = pkginfo_targets.resource_bundle_label_name(bzl_target_name)
     infoplist_name = pkginfo_targets.resource_bundle_infoplist_label_name(
@@ -393,35 +392,6 @@ def _apple_resource_bundle(repository_ctx, target, default_localization):
         r.path
         for r in target.resources
     ]
-
-    # glob_paths = []
-    # file_paths = []
-    # for r in target.resources:
-    #     path = r.path
-    #     if repository_files.is_directory(repository_ctx, path):
-    #         glob_paths.append("{}/**".format(path))
-    #     else:
-    #         file_paths.append(path)
-
-    # resource_parts = []
-    # if len(glob_paths) > 0:
-    #     resource_parts.append(scg.new_fn_call("glob", glob_paths))
-    # if len(file_paths) > 0:
-    #     resource_parts.append(file_paths)
-
-    # rp_len = len(resource_parts)
-    # if rp_len == 0:
-    #     fail("""\
-    # We were asked to create an apple_resource_bundle, but no resources were specified.\
-    # """)
-    # elif rp_len == 1:
-    #     resources = resource_parts[0]
-    # else:
-    #     resources = scg.new_expr(
-    #         resource_parts[0],
-    #         scg.new_op("+"),
-    #         resource_parts[1],
-    #     )
 
     load_stmts = [
         apple_resource_bundle_load_stmt,

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -96,7 +96,7 @@ def _new_from_parsed_json_for_swift_targets_test(ctx):
                 product_memberships = ["printstuff"],
                 resources = [
                     pkginfos.new_resource(
-                        path = "Resources/chicken.json",
+                        path = "Sources/MySwiftPackage/Resources/chicken.json",
                         rule = pkginfos.new_resource_rule(
                             process = pkginfos.new_resource_rule_process(),
                         ),
@@ -538,6 +538,12 @@ _swift_arg_parser_desc_json = """
       ],
       "product_memberships" : [
         "printstuff"
+      ],
+      "resources": [
+        {
+          "path" : "/Users/chuck/code/cgrindel/rules_swift_package_manager/gh009_update_repos_new/examples/pkg_manifest/Sources/MySwiftPackage/Resources/chicken.json",
+          "rule" : { "process" : {} }
+        }
       ],
       "sources" : [
         "MySwiftPackage.swift"

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -401,6 +401,33 @@ _pkg_info = pkginfos.new(
             repo_name = _repo_name,
             swift_src_info = pkginfos.new_swift_src_info(),
         ),
+        pkginfos.new_target(
+            name = "SwiftLibraryWithFileAndDirResources",
+            type = "regular",
+            c99name = "SwiftLibraryWithFileAndDirResources",
+            module_type = "SwiftTarget",
+            path = "Source/SwiftLibraryWithFileAndDirResources",
+            sources = [
+                "SwiftLibraryWithFileAndDirResources.swift",
+            ],
+            resources = [
+                pkginfos.new_resource(
+                    path = "Resources/chicken.json",
+                    rule = pkginfos.new_resource_rule(
+                        process = pkginfos.new_resource_rule_process(),
+                    ),
+                ),
+                pkginfos.new_resource(
+                    path = "Resources/Assets.xcassets",
+                    rule = pkginfos.new_resource_rule(
+                        process = pkginfos.new_resource_rule_process(),
+                    ),
+                ),
+            ],
+            dependencies = [],
+            repo_name = _repo_name,
+            swift_src_info = pkginfos.new_swift_src_info(),
+        ),
     ],
 )
 
@@ -854,6 +881,46 @@ swift_library(
     srcs = [
         "Source/SwiftLibraryWithDirResource/SwiftLibraryWithDirResource.swift",
         ":Source_SwiftLibraryWithDirResource_resource_bundle_accessor",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+        ),
+        struct(
+            msg = "Swift library target with file and directory resources",
+            name = "SwiftLibraryWithFileAndDirResources",
+            is_directory = {"Resources/Assets.xcassets": True},
+            exp = """\
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "resource_bundle_accessor", "resource_bundle_infoplist")
+
+apple_resource_bundle(
+    name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle",
+    bundle_name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle",
+    infoplists = [":Source_SwiftLibraryWithFileAndDirResources_resource_bundle_infoplist"],
+    resources = glob(["Source/SwiftLibraryWithFileAndDirResources/Resources/Assets.xcassets/**"]) + ["Source/SwiftLibraryWithFileAndDirResources/Resources/chicken.json"],
+)
+
+resource_bundle_accessor(
+    name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle_accessor",
+    bundle_name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle",
+)
+
+resource_bundle_infoplist(
+    name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle_infoplist",
+    region = "en",
+)
+
+swift_library(
+    name = "Source_SwiftLibraryWithFileAndDirResources",
+    data = [":Source_SwiftLibraryWithFileAndDirResources_resource_bundle"],
+    defines = ["SWIFT_PACKAGE"],
+    deps = [],
+    module_name = "SwiftLibraryWithFileAndDirResources",
+    srcs = [
+        "Source/SwiftLibraryWithFileAndDirResources/SwiftLibraryWithFileAndDirResources.swift",
+        ":Source_SwiftLibraryWithFileAndDirResources_resource_bundle_accessor",
     ],
     visibility = ["//visibility:public"],
 )

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -370,55 +370,7 @@ _pkg_info = pkginfos.new(
             ],
             resources = [
                 pkginfos.new_resource(
-                    path = "Resources/chicken.json",
-                    rule = pkginfos.new_resource_rule(
-                        process = pkginfos.new_resource_rule_process(),
-                    ),
-                ),
-            ],
-            dependencies = [],
-            repo_name = _repo_name,
-            swift_src_info = pkginfos.new_swift_src_info(),
-        ),
-        pkginfos.new_target(
-            name = "SwiftLibraryWithDirResource",
-            type = "regular",
-            c99name = "SwiftLibraryWithDirResource",
-            module_type = "SwiftTarget",
-            path = "Source/SwiftLibraryWithDirResource",
-            sources = [
-                "SwiftLibraryWithDirResource.swift",
-            ],
-            resources = [
-                pkginfos.new_resource(
-                    path = "Resources/Assets.xcassets",
-                    rule = pkginfos.new_resource_rule(
-                        process = pkginfos.new_resource_rule_process(),
-                    ),
-                ),
-            ],
-            dependencies = [],
-            repo_name = _repo_name,
-            swift_src_info = pkginfos.new_swift_src_info(),
-        ),
-        pkginfos.new_target(
-            name = "SwiftLibraryWithFileAndDirResources",
-            type = "regular",
-            c99name = "SwiftLibraryWithFileAndDirResources",
-            module_type = "SwiftTarget",
-            path = "Source/SwiftLibraryWithFileAndDirResources",
-            sources = [
-                "SwiftLibraryWithFileAndDirResources.swift",
-            ],
-            resources = [
-                pkginfos.new_resource(
-                    path = "Resources/chicken.json",
-                    rule = pkginfos.new_resource_rule(
-                        process = pkginfos.new_resource_rule_process(),
-                    ),
-                ),
-                pkginfos.new_resource(
-                    path = "Resources/Assets.xcassets",
+                    path = "Source/SwiftLibraryWithFilePathResource/Resources/chicken.json",
                     rule = pkginfos.new_resource_rule(
                         process = pkginfos.new_resource_rule_process(),
                     ),
@@ -840,88 +792,6 @@ swift_library(
     srcs = [
         "Source/SwiftLibraryWithFilePathResource/SwiftLibraryWithFilePathResource.swift",
         ":Source_SwiftLibraryWithFilePathResource_resource_bundle_accessor",
-    ],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-""",
-        ),
-        struct(
-            msg = "Swift library target with directory resource",
-            name = "SwiftLibraryWithDirResource",
-            is_directory = {"Resources/Assets.xcassets": True},
-            exp = """\
-load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "resource_bundle_accessor", "resource_bundle_infoplist")
-
-apple_resource_bundle(
-    name = "Source_SwiftLibraryWithDirResource_resource_bundle",
-    bundle_name = "Source_SwiftLibraryWithDirResource_resource_bundle",
-    infoplists = [":Source_SwiftLibraryWithDirResource_resource_bundle_infoplist"],
-    resources = glob(["Source/SwiftLibraryWithDirResource/Resources/Assets.xcassets/**"]),
-)
-
-resource_bundle_accessor(
-    name = "Source_SwiftLibraryWithDirResource_resource_bundle_accessor",
-    bundle_name = "Source_SwiftLibraryWithDirResource_resource_bundle",
-)
-
-resource_bundle_infoplist(
-    name = "Source_SwiftLibraryWithDirResource_resource_bundle_infoplist",
-    region = "en",
-)
-
-swift_library(
-    name = "Source_SwiftLibraryWithDirResource",
-    data = [":Source_SwiftLibraryWithDirResource_resource_bundle"],
-    defines = ["SWIFT_PACKAGE"],
-    deps = [],
-    module_name = "SwiftLibraryWithDirResource",
-    srcs = [
-        "Source/SwiftLibraryWithDirResource/SwiftLibraryWithDirResource.swift",
-        ":Source_SwiftLibraryWithDirResource_resource_bundle_accessor",
-    ],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-""",
-        ),
-        struct(
-            msg = "Swift library target with file and directory resources",
-            name = "SwiftLibraryWithFileAndDirResources",
-            is_directory = {"Resources/Assets.xcassets": True},
-            exp = """\
-load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "resource_bundle_accessor", "resource_bundle_infoplist")
-
-apple_resource_bundle(
-    name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle",
-    bundle_name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle",
-    infoplists = [":Source_SwiftLibraryWithFileAndDirResources_resource_bundle_infoplist"],
-    resources = glob(["Source/SwiftLibraryWithFileAndDirResources/Resources/Assets.xcassets/**"]) + ["Source/SwiftLibraryWithFileAndDirResources/Resources/chicken.json"],
-)
-
-resource_bundle_accessor(
-    name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle_accessor",
-    bundle_name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle",
-)
-
-resource_bundle_infoplist(
-    name = "Source_SwiftLibraryWithFileAndDirResources_resource_bundle_infoplist",
-    region = "en",
-)
-
-swift_library(
-    name = "Source_SwiftLibraryWithFileAndDirResources",
-    data = [":Source_SwiftLibraryWithFileAndDirResources_resource_bundle"],
-    defines = ["SWIFT_PACKAGE"],
-    deps = [],
-    module_name = "SwiftLibraryWithFileAndDirResources",
-    srcs = [
-        "Source/SwiftLibraryWithFileAndDirResources/SwiftLibraryWithFileAndDirResources.swift",
-        ":Source_SwiftLibraryWithFileAndDirResources_resource_bundle_accessor",
     ],
     tags = ["manual"],
     visibility = ["//visibility:public"],

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -824,6 +824,39 @@ swift_library(
             name = "SwiftLibraryWithDirResource",
             is_directory = {"Resources/Assets.xcassets": True},
             exp = """\
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "resource_bundle_accessor", "resource_bundle_infoplist")
+
+apple_resource_bundle(
+    name = "Source_SwiftLibraryWithDirResource_resource_bundle",
+    bundle_name = "Source_SwiftLibraryWithDirResource_resource_bundle",
+    infoplists = [":Source_SwiftLibraryWithDirResource_resource_bundle_infoplist"],
+    resources = glob(["Source/SwiftLibraryWithDirResource/Resources/Assets.xcassets/**"]),
+)
+
+resource_bundle_accessor(
+    name = "Source_SwiftLibraryWithDirResource_resource_bundle_accessor",
+    bundle_name = "Source_SwiftLibraryWithDirResource_resource_bundle",
+)
+
+resource_bundle_infoplist(
+    name = "Source_SwiftLibraryWithDirResource_resource_bundle_infoplist",
+    region = "en",
+)
+
+swift_library(
+    name = "Source_SwiftLibraryWithDirResource",
+    data = [":Source_SwiftLibraryWithDirResource_resource_bundle"],
+    defines = ["SWIFT_PACKAGE"],
+    deps = [],
+    module_name = "SwiftLibraryWithDirResource",
+    srcs = [
+        "Source/SwiftLibraryWithDirResource/SwiftLibraryWithDirResource.swift",
+        ":Source_SwiftLibraryWithDirResource_resource_bundle_accessor",
+    ],
+    visibility = ["//visibility:public"],
+)
 """,
         ),
     ]

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -380,6 +380,27 @@ _pkg_info = pkginfos.new(
             repo_name = _repo_name,
             swift_src_info = pkginfos.new_swift_src_info(),
         ),
+        pkginfos.new_target(
+            name = "SwiftLibraryWithDirResource",
+            type = "regular",
+            c99name = "SwiftLibraryWithDirResource",
+            module_type = "SwiftTarget",
+            path = "Source/SwiftLibraryWithDirResource",
+            sources = [
+                "SwiftLibraryWithDirResource.swift",
+            ],
+            resources = [
+                pkginfos.new_resource(
+                    path = "Resources/Assets.xcassets",
+                    rule = pkginfos.new_resource_rule(
+                        process = pkginfos.new_resource_rule_process(),
+                    ),
+                ),
+            ],
+            dependencies = [],
+            repo_name = _repo_name,
+            swift_src_info = pkginfos.new_swift_src_info(),
+        ),
     ],
 )
 
@@ -759,7 +780,7 @@ swift_library(
 """,
         ),
         struct(
-            msg = "Swift library target with resources",
+            msg = "Swift library target with file path resource",
             name = "SwiftLibraryWithFilePathResource",
             exp = """\
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
@@ -798,6 +819,13 @@ swift_library(
 )
 """,
         ),
+        struct(
+            msg = "Swift library target with directory resource",
+            name = "SwiftLibraryWithDirResource",
+            is_directory = {"Resources/Assets.xcassets": True},
+            exp = """\
+""",
+        ),
     ]
     for t in tests:
         target = pkginfo_targets.get(_pkg_info.targets, t.name)
@@ -813,6 +841,10 @@ swift_library(
                     for fp in file_paths
                 ]
                 for dirname, file_paths in getattr(t, "find_results", {}).items()
+            },
+            is_directory_results = {
+                paths.normalize(paths.join(target.path, path)): result
+                for path, result in getattr(t, "is_directory", {}).items()
             },
         )
         actual = scg.to_starlark(

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -922,6 +922,7 @@ swift_library(
         "Source/SwiftLibraryWithFileAndDirResources/SwiftLibraryWithFileAndDirResources.swift",
         ":Source_SwiftLibraryWithFileAndDirResources_resource_bundle_accessor",
     ],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -360,13 +360,13 @@ _pkg_info = pkginfos.new(
             swift_src_info = pkginfos.new_swift_src_info(has_objc_directive = True),
         ),
         pkginfos.new_target(
-            name = "SwiftLibraryWithResources",
+            name = "SwiftLibraryWithFilePathResource",
             type = "regular",
-            c99name = "SwiftLibraryWithResources",
+            c99name = "SwiftLibraryWithFilePathResource",
             module_type = "SwiftTarget",
-            path = "Source/SwiftLibraryWithResources",
+            path = "Source/SwiftLibraryWithFilePathResource",
             sources = [
-                "SwiftLibraryWithResources.swift",
+                "SwiftLibraryWithFilePathResource.swift",
             ],
             resources = [
                 pkginfos.new_resource(
@@ -760,38 +760,38 @@ swift_library(
         ),
         struct(
             msg = "Swift library target with resources",
-            name = "SwiftLibraryWithResources",
+            name = "SwiftLibraryWithFilePathResource",
             exp = """\
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "resource_bundle_accessor", "resource_bundle_infoplist")
 
 apple_resource_bundle(
-    name = "Source_SwiftLibraryWithResources_resource_bundle",
-    bundle_name = "Source_SwiftLibraryWithResources_resource_bundle",
-    infoplists = [":Source_SwiftLibraryWithResources_resource_bundle_infoplist"],
-    resources = glob(["Source/SwiftLibraryWithResources/Resources/chicken.json"]),
+    name = "Source_SwiftLibraryWithFilePathResource_resource_bundle",
+    bundle_name = "Source_SwiftLibraryWithFilePathResource_resource_bundle",
+    infoplists = [":Source_SwiftLibraryWithFilePathResource_resource_bundle_infoplist"],
+    resources = glob(["Source/SwiftLibraryWithFilePathResource/Resources/chicken.json"]),
 )
 
 resource_bundle_accessor(
-    name = "Source_SwiftLibraryWithResources_resource_bundle_accessor",
-    bundle_name = "Source_SwiftLibraryWithResources_resource_bundle",
+    name = "Source_SwiftLibraryWithFilePathResource_resource_bundle_accessor",
+    bundle_name = "Source_SwiftLibraryWithFilePathResource_resource_bundle",
 )
 
 resource_bundle_infoplist(
-    name = "Source_SwiftLibraryWithResources_resource_bundle_infoplist",
+    name = "Source_SwiftLibraryWithFilePathResource_resource_bundle_infoplist",
     region = "en",
 )
 
 swift_library(
-    name = "Source_SwiftLibraryWithResources",
-    data = [":Source_SwiftLibraryWithResources_resource_bundle"],
+    name = "Source_SwiftLibraryWithFilePathResource",
+    data = [":Source_SwiftLibraryWithFilePathResource_resource_bundle"],
     defines = ["SWIFT_PACKAGE"],
     deps = [],
-    module_name = "SwiftLibraryWithResources",
+    module_name = "SwiftLibraryWithFilePathResource",
     srcs = [
-        "Source/SwiftLibraryWithResources/SwiftLibraryWithResources.swift",
-        ":Source_SwiftLibraryWithResources_resource_bundle_accessor",
+        "Source/SwiftLibraryWithFilePathResource/SwiftLibraryWithFilePathResource.swift",
+        ":Source_SwiftLibraryWithFilePathResource_resource_bundle_accessor",
     ],
     tags = ["manual"],
     visibility = ["//visibility:public"],

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -791,7 +791,7 @@ apple_resource_bundle(
     name = "Source_SwiftLibraryWithFilePathResource_resource_bundle",
     bundle_name = "Source_SwiftLibraryWithFilePathResource_resource_bundle",
     infoplists = [":Source_SwiftLibraryWithFilePathResource_resource_bundle_infoplist"],
-    resources = glob(["Source/SwiftLibraryWithFilePathResource/Resources/chicken.json"]),
+    resources = ["Source/SwiftLibraryWithFilePathResource/Resources/chicken.json"],
 )
 
 resource_bundle_accessor(

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -882,6 +882,7 @@ swift_library(
         "Source/SwiftLibraryWithDirResource/SwiftLibraryWithDirResource.swift",
         ":Source_SwiftLibraryWithDirResource_resource_bundle_accessor",
     ],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,

--- a/swiftpkg/tests/testutils.bzl
+++ b/swiftpkg/tests/testutils.bzl
@@ -17,8 +17,8 @@ def _new_stub_repository_ctx(
 
     # buildifier: disable=unused-variable
     def execute(args, environment = {}, quiet = True):
-        argsLen = len(args)
-        if argsLen == 3 and args[2].startswith("if [[ -d ") and environment["TARGET_PATH"]:
+        args_len = len(args)
+        if args_len == 3 and args[2].startswith("if [[ -d ") and environment["TARGET_PATH"]:
             # Look for the is_directory check.
             path = environment["TARGET_PATH"]
             result = is_directory_results.get(path, False)
@@ -26,7 +26,7 @@ def _new_stub_repository_ctx(
             stdout += "\n"
             exec_result = _new_exec_result(stdout = stdout)
 
-        elif argsLen >= 4 and args[0] == "find":
+        elif args_len >= 4 and args[0] == "find":
             # The find command that we expect is `find -H -L path`.
             # See repository_files.list_files_under for details.
             path = args[3]

--- a/swiftpkg/tests/testutils.bzl
+++ b/swiftpkg/tests/testutils.bzl
@@ -7,15 +7,28 @@ def _new_exec_result(return_code = 0, stdout = "", stderr = ""):
         stderr = stderr,
     )
 
-def _new_stub_repository_ctx(repo_name, file_contents = {}, find_results = {}):
+def _new_stub_repository_ctx(
+        repo_name,
+        file_contents = {},
+        find_results = {},
+        is_directory_results = {}):
     def read(path):
         return file_contents.get(path, "")
 
     # buildifier: disable=unused-variable
     def execute(args, environment = {}, quiet = True):
-        # The find command that we expect is `find -H -L path`.
-        # See repository_files.list_files_under for details.
-        if len(args) >= 4 and args[0] == "find":
+        argsLen = len(args)
+        if argsLen == 3 and args[2].startswith("if [[ -d ") and environment["TARGET_PATH"]:
+            # Look for the is_directory check.
+            path = environment["TARGET_PATH"]
+            result = is_directory_results.get(path, False)
+            stdout = "TRUE" if result else "FALSE"
+            stdout += "\n"
+            exec_result = _new_exec_result(stdout = stdout)
+
+        elif argsLen >= 4 and args[0] == "find":
+            # The find command that we expect is `find -H -L path`.
+            # See repository_files.list_files_under for details.
             path = args[3]
             results = find_results.get(path, [])
             exec_result = _new_exec_result(


### PR DESCRIPTION
It turns out that the auto-discovered Swift package resources (#576) are listed in the description JSON. This PR ended up removing the auto-discovery code and having each resource listed as a file path.

Updated the `testutils` to support stub calls to `repository_files.is_directory()`.

Closes #575.