### PR TITLE
chore: mark `swift_library` declarations as manual

### DIFF
--- a/bzlmod/workspace/Sources/MyLibrary/BUILD.bazel
+++ b/bzlmod/workspace/Sources/MyLibrary/BUILD.bazel
@@ -5,6 +5,7 @@ swift_library(
     name = "MyLibrary",
     srcs = ["World.swift"],
     module_name = "MyLibrary",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/examples/http_archive_ext_deps/Sources/MyDequeModule/BUILD.bazel
+++ b/examples/http_archive_ext_deps/Sources/MyDequeModule/BUILD.bazel
@@ -4,6 +4,7 @@ swift_library(
     name = "MyDequeModule",
     srcs = ["Create.swift"],
     module_name = "MyDequeModule",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["@com_github_apple_swift_collections//:DequeModule"],
 )

--- a/examples/ios_sim/Sources/Foo/BUILD.bazel
+++ b/examples/ios_sim/Sources/Foo/BUILD.bazel
@@ -4,6 +4,7 @@ swift_library(
     name = "Foo",
     srcs = ["Bar.swift"],
     module_name = "Foo",
+    tags = ["manual"],
     visibility = ["//:__subpackages__"],
     deps = ["@swiftpkg_swift_nio//:Sources_NIO"],
 )

--- a/examples/nimble_example/Sources/NimbleExample/BUILD.bazel
+++ b/examples/nimble_example/Sources/NimbleExample/BUILD.bazel
@@ -6,6 +6,7 @@ swift_test(
     module_name = "NimbleExample",
     deps = [
         "@swiftpkg_nimble//:Sources_Nimble",
+        "@swiftpkg_nimble//:Sources_NimbleObjectiveC",
         "@swiftpkg_quick//:Sources_Quick",
     ],
 )

--- a/examples/nimble_example/swift_deps_index.json
+++ b/examples/nimble_example/swift_deps_index.json
@@ -67,11 +67,31 @@
       ]
     },
     {
+      "name": "NimbleObjectiveC",
+      "c99name": "NimbleObjectiveC",
+      "src_type": "objc",
+      "label": "@swiftpkg_nimble//:Sources_NimbleObjectiveC",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
       "name": "Quick",
       "c99name": "Quick",
       "src_type": "swift",
       "label": "@swiftpkg_quick//:Sources_Quick",
       "modulemap_label": "@swiftpkg_quick//:Sources_Quick_modulemap",
+      "package_identity": "quick",
+      "product_memberships": [
+        "Quick"
+      ]
+    },
+    {
+      "name": "QuickObjCRuntime",
+      "c99name": "QuickObjCRuntime",
+      "src_type": "objc",
+      "label": "@swiftpkg_quick//:Sources_QuickObjCRuntime",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -109,7 +129,8 @@
       "name": "Nimble",
       "type": "library",
       "target_labels": [
-        "@swiftpkg_nimble//:Sources_Nimble"
+        "@swiftpkg_nimble//:Sources_Nimble",
+        "@swiftpkg_nimble//:Sources_NimbleObjectiveC"
       ]
     },
     {

--- a/examples/pkg_manifest_minimal/Sources/MyLibrary/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyLibrary/BUILD.bazel
@@ -4,6 +4,7 @@ swift_library(
     name = "MyLibrary",
     srcs = ["World.swift"],
     module_name = "MyLibrary",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["@swiftpkg_my_local_package//:Sources_GreetingsFramework"],
 )

--- a/examples/tca_example/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/BUILD.bazel
+++ b/examples/tca_example/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/BUILD.bazel
@@ -8,6 +8,7 @@ swift_library(
         "ReusableComponents-Download.swift",
     ],
     module_name = "04-HigherOrderReducers-ResuableOfflineDownloads",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["@swiftpkg_swift_composable_architecture//:Sources_ComposableArchitecture"],
 )

--- a/examples/tca_example/SwiftUICaseStudies/Internal/BUILD.bazel
+++ b/examples/tca_example/SwiftUICaseStudies/Internal/BUILD.bazel
@@ -10,5 +10,6 @@ swift_library(
         "UIViewRepresented.swift",
     ],
     module_name = "Internal",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )

--- a/examples/vapor_example/Sources/App/BUILD.bazel
+++ b/examples/vapor_example/Sources/App/BUILD.bazel
@@ -9,6 +9,7 @@ swift_library(
         "Models/Foo.swift",
     ],
     module_name = "App",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "@swiftpkg_fluent//:Sources_Fluent",

--- a/examples/xcmetrics_example/Package.resolved
+++ b/examples/xcmetrics_example/Package.resolved
@@ -370,15 +370,6 @@
       }
     },
     {
-      "identity" : "swift-nio-ssl-support",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl-support.git",
-      "state" : {
-        "revision" : "c02eec4e0e6d351cd092938cf44195a8e669f555",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-nio-transport-services",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",

--- a/examples/xcmetrics_example/swift_deps_index.json
+++ b/examples/xcmetrics_example/swift_deps_index.json
@@ -312,6 +312,47 @@
       ]
     },
     {
+      "name": "NimbleCwlCatchExceptionSupport",
+      "c99name": "NimbleCwlCatchExceptionSupport",
+      "src_type": "objc",
+      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Dependencies_CwlCatchException_Sources_CwlCatchExceptionSupport_NimbleCwlCatchExceptionSupport",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
+      "name": "NimbleCwlCatchException",
+      "c99name": "NimbleCwlCatchException",
+      "src_type": "swift",
+      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Dependencies_CwlCatchException_Sources_CwlCatchException_NimbleCwlCatchException",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
+      "name": "NimbleCwlMachBadInstructionHandler",
+      "c99name": "NimbleCwlMachBadInstructionHandler",
+      "src_type": "objc",
+      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Sources_CwlMachBadInstructionHandler_NimbleCwlMachBadInstructionHandler",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
+      "name": "NimbleCwlPreconditionTesting",
+      "c99name": "NimbleCwlPreconditionTesting",
+      "src_type": "swift",
+      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Sources_CwlPreconditionTesting_NimbleCwlPreconditionTesting",
+      "modulemap_label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Sources_CwlPreconditionTesting_NimbleCwlPreconditionTesting_modulemap",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
       "name": "Nimble",
       "c99name": "Nimble",
       "src_type": "swift",
@@ -399,6 +440,16 @@
       "src_type": "swift",
       "label": "@swiftpkg_quick//:Sources_Quick",
       "modulemap_label": "@swiftpkg_quick//:Sources_Quick_modulemap",
+      "package_identity": "quick",
+      "product_memberships": [
+        "Quick"
+      ]
+    },
+    {
+      "name": "QuickObjCRuntime",
+      "c99name": "QuickObjCRuntime",
+      "src_type": "objc",
+      "label": "@swiftpkg_quick//:Sources_QuickObjCRuntime",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -3063,16 +3114,6 @@
       ]
     },
     {
-      "name": "CAWSSDKOpenSSL",
-      "c99name": "CAWSSDKOpenSSL",
-      "src_type": "clang",
-      "label": "@swiftpkg_soto_core//:Sources_CAWSSDKOpenSSL",
-      "package_identity": "soto-core",
-      "product_memberships": [
-        "AWSSDKSwiftCore"
-      ]
-    },
-    {
       "name": "Spectre",
       "c99name": "Spectre",
       "src_type": "swift",
@@ -3704,16 +3745,6 @@
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOTLSServer"
-      ]
-    },
-    {
-      "name": "swift-nio-ssl-support",
-      "c99name": "swift_nio_ssl_support",
-      "src_type": "unknown",
-      "label": "@swiftpkg_swift_nio_ssl_support//:swift-nio-ssl-support",
-      "package_identity": "swift-nio-ssl-support",
-      "product_memberships": [
-        "swift-nio-ssl-support"
       ]
     },
     {
@@ -6622,14 +6653,6 @@
       ]
     },
     {
-      "identity": "swift-nio-ssl-support",
-      "name": "swift-nio-ssl-support",
-      "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl_support//:swift-nio-ssl-support"
-      ]
-    },
-    {
       "identity": "swift-nio-ssl",
       "name": "NIOSSL",
       "type": "library",
@@ -7262,15 +7285,6 @@
         "commit": "4fb7ead803e38949eb1d6fabb849206a72c580f3",
         "remote": "https://github.com/apple/swift-nio-ssl.git",
         "version": "2.23.0"
-      }
-    },
-    {
-      "name": "swiftpkg_swift_nio_ssl_support",
-      "identity": "swift-nio-ssl-support",
-      "remote": {
-        "commit": "c02eec4e0e6d351cd092938cf44195a8e669f555",
-        "remote": "https://github.com/apple/swift-nio-ssl-support.git",
-        "version": "1.0.0"
       }
     },
     {

--- a/gazelle/internal/swift/rules_common.go
+++ b/gazelle/internal/swift/rules_common.go
@@ -20,6 +20,10 @@ func rulesForLibraryModule(
 	r := rule.NewRule(LibraryRuleKind, name)
 	setCommonSwiftAttrs(r, moduleName, srcs, swiftImports)
 	setVisibilityAttr(r, shouldSetVis, []string{"//visibility:public"})
+	// Mark swift_library targets as manual. We do this so that they are always
+	// built from a leaf node which can provide critical configuration
+	// information.
+	r.SetAttr("tags", []string{"manual"})
 	return []*rule.Rule{r}
 }
 

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -121,6 +121,10 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
     return build_files.merge(*all_build_files)
 
 def _swift_library_from_target(target, attrs):
+    # Mark swift_library targets as manual. We do this so that they are always
+    # built from a leaf node which can provide critical configuration
+    # information.
+    attrs["tags"] = ["manual"]
     return build_decls.new(
         kind = swift_kinds.library,
         name = pkginfo_targets.bazel_label_name(target),

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -495,6 +495,7 @@ swift_library(
     deps = [],
     module_name = "RegularSwiftTargetAsLibrary",
     srcs = ["Source/RegularSwiftTargetAsLibrary/RegularSwiftTargetAsLibrary.swift"],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -514,6 +515,7 @@ swift_library(
     deps = ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
     module_name = "RegularTargetForExec",
     srcs = ["Source/RegularTargetForExec/main.swift"],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -575,6 +577,7 @@ swift_library(
     deps = [],
     module_name = "SwiftLibraryUsesXCTest",
     srcs = ["Source/SwiftLibraryUsesXCTest/SwiftLibraryUsesXCTest.swift"],
+    tags = ["manual"],
     testonly = True,
     visibility = ["//visibility:public"],
 )
@@ -688,6 +691,7 @@ swift_library(
     }),
     module_name = "SwiftLibraryWithConditionalDep",
     srcs = ["Source/SwiftLibraryWithConditionalDep/SwiftLibraryWithConditionalDep.swift"],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -749,6 +753,7 @@ swift_library(
     generates_header = True,
     module_name = "SwiftForObjcTarget",
     srcs = ["Source/SwiftForObjcTarget/SwiftForObjcTarget.swift"],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -788,6 +793,7 @@ swift_library(
         "Source/SwiftLibraryWithResources/SwiftLibraryWithResources.swift",
         ":Source_SwiftLibraryWithResources_resource_bundle_accessor",
     ],
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 """,


### PR DESCRIPTION
[Background info](https://github.com/bazelbuild/rules_apple/issues/1939#issuecomment-1495175316)

In short, let the leaf nodes of the build graph pass along the appropriate configuration values when building `swift_library` targets. This PR makes this change for declarations for external Swift packages and for Gazelle generated build files.

Closes #339.