### PR TITLE
fix: allow .cpp when listing C++ files

### DIFF
--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -18,7 +18,7 @@ _HEADER_EXTS = [".h", ".hh", ".hpp", ".hxx", ".inl", ".H"]
 # https://bazel.build/reference/be/objective-c#objc_library.srcs
 # NOTE: From examples found so far, .inc files tend to include source, not
 # header declarations.
-_SRC_EXTS = [".c", ".cc", ".S", ".so", ".o", ".m", ".mm", ".inc"]
+_SRC_EXTS = [".c", ".cc", ".cpp", ".S", ".so", ".o", ".m", ".mm", ".inc"]
 
 def _is_hdr(path):
     _root, ext = paths.split_extension(path)


### PR DESCRIPTION
Fixes the issue raised in https://github.com/cgrindel/rules_swift_package_manager/issues/510

In the specific case of Sentry (https://github.com/getsentry/sentry-cocoa), the generated `objc_library` target for the main `Sentry` module included the right headers, allowing it to build, but not the right sources (for instance https://github.com/getsentry/sentry-cocoa/blob/72c8d84c86cebd726dd3b34ab9ff09a3596dd5f2/Sources/Sentry/SentrySamplingProfiler.cpp#L169). This cause the build to work but not the link.