### PR TITLE
fix: support `#import` with whitespace between `#` and `import`

### DIFF
--- a/swiftpkg/internal/objc_files.bzl
+++ b/swiftpkg/internal/objc_files.bzl
@@ -5,17 +5,32 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "lists")
 load(":apple_builtin_frameworks.bzl", "apple_builtin_frameworks")
 
-_pound_import = "#import "
-_pound_import_len = len(_pound_import)
 _at_import = "@import "
 _at_import_len = len(_at_import)
 
 def _parse_pound_import(line):
-    import_idx = line.find(_pound_import)
-    if import_idx < 0:
-        return None
-    start_idx = import_idx + _pound_import_len
     line_len = len(line)
+
+    # Find the pound sign
+    pound_idx = line.find("#")
+    if pound_idx < 0:
+        return None
+    start_idx = pound_idx + 1
+
+    # Find import
+    begin_of_import_idx = -1
+    for idx in range(start_idx, line_len):
+        char = line[idx]
+        if char == " " or char == "\t":
+            continue
+        elif char == "i":
+            begin_of_import_idx = idx
+            break
+        else:
+            return None
+    if not line[begin_of_import_idx:].startswith("import"):
+        return None
+    start_idx = begin_of_import_idx + len("import")
 
     # Find the opening bracket
     open_bracket_idx = -1

--- a/swiftpkg/tests/objc_files_tests.bzl
+++ b/swiftpkg/tests/objc_files_tests.bzl
@@ -33,6 +33,13 @@ def _parse_for_imported_framework_test(ctx):
             exp = "CoreTelephony",
         ),
         struct(
+            msg = "#    import, the pound is not adjacent to import ",
+            line = """\
+#    import <SystemConfiguration/SystemConfiguration.h>
+""",
+            exp = "SystemConfiguration",
+        ),
+        struct(
             msg = "#import dir/header with brackets, is not framework",
             line = """\
 #import <Foo/Foo.h>


### PR DESCRIPTION
The [Sentry package](https://github.com/getsentry/sentry-cocoa) uses [an unusual import syntax for the SystemConfiguration framework](https://github.com/getsentry/sentry-cocoa/blob/e32423038e99f0c5d868744421d664cdd55c7383/Sources/Sentry/include/SentryReachability.h#L31):

```objc
#    import <SystemConfiguration/SystemConfiguration.h>
```

This PR updates the parsing logic for `#import` lines to support whitespace between the `#` and the `import`.

Related to #510.