### PR TITLE
fix: Handle Xcode 15 swift package format

### DIFF
--- a/gazelle/internal/spdump/dependency.go
+++ b/gazelle/internal/spdump/dependency.go
@@ -60,11 +60,11 @@ func (sc *SourceControl) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type sourceControlLocationXcode15 struct {
+type sourceControlLocationSwift59 struct {
 	Remote []*RemoteLocation
 }
 
-type sourceControlLocationXcode14 struct {
+type sourceControlLocationSwift58 struct {
 	Remote *RemoteLocation
 }
 
@@ -75,25 +75,25 @@ type SourceControlLocation struct {
 
 func (scl *SourceControlLocation) UnmarshalJSON(b []byte) error {
 
-	// Try the Xcode 15 format first:
-	var sclx15 sourceControlLocationXcode15
-	err := json.Unmarshal(b, &sclx15)
+	// Try the Swift 5.9 format first:
+	var scls59 sourceControlLocationSwift59
+	err := json.Unmarshal(b, &scls59)
 	if err == nil {
-		if len(sclx15.Remote) == 0 {
+		if len(scls59.Remote) == 0 {
 			return errors.New("source control location missing remote")
 		}
-		scl.Remote = sclx15.Remote[0]
+		scl.Remote = scls59.Remote[0]
 		return nil
 	}
 	err = nil
 
-	// Failing that, try the Xcode 14 format:
-	var sclx14 sourceControlLocationXcode14
-	err = json.Unmarshal(b, &sclx14)
+	// Failing that, try the Swift 5.8 format:
+	var scls58 sourceControlLocationSwift58
+	err = json.Unmarshal(b, &scls58)
 	if err != nil {
 		return err
 	}
-	scl.Remote = sclx14.Remote
+	scl.Remote = scls58.Remote
 
 	return nil
 }
@@ -103,14 +103,14 @@ type RemoteLocation struct {
 	URL string
 }
 
-type remoteLocationXcode15 struct {
+type remoteLocationSwift59 struct {
 	URLString string `json:"urlString"`
 }
 
 func (rl *RemoteLocation) UnmarshalJSON(b []byte) error {
 
-	// Try the Xcode 15 format first:
-	var x15 remoteLocationXcode15
+	// Try the Swift 5.9 format first:
+	var x15 remoteLocationSwift59
 	err := json.Unmarshal(b, &x15)
 	if err == nil {
 		rl.URL = x15.URLString
@@ -118,7 +118,7 @@ func (rl *RemoteLocation) UnmarshalJSON(b []byte) error {
 	}
 	err = nil
 
-	// Fall back to the Xcode 14 format if that failed:
+	// Fall back to the Swift 5.8 format if that failed:
 	var raw []any
 	err = json.Unmarshal(b, &raw)
 	if err != nil {


### PR DESCRIPTION
In Xcode 15 / Swift 5.9 Apple changed the output format of `swift package dump-package` which rules_swift_package_manager parsed. This caused the JSON deserialization to fail.

Specifically, the SourceControlLocation type changed from a single RemoteLocation to an array of RemoteLocation(s) and these are now objects with the key "urlString" instead of "url".

I added support for both the Xcode 14 / Swift 5.8 format as well as the new Xcode 15 / Swift 5.9 format.
Whenever we drop support for Xcode 14, the support for the old format can be removed.

I verified the change from my repo by using a local_path_override with this patch and I verified that before swift_update_packages failed with the error:
```
gazelle: index 0 expected to be type 'string', but was type 'map[string]interface {}'
```
While now it succeeds.