### PR TITLE
feat: Add directive to disable manual tag

### DIFF
--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -14,6 +14,7 @@ tidy(
 
 # Ignore the Swift build folder
 # gazelle:exclude .build
+# gazelle:swift_library_tags -
 
 gazelle_binary(
     name = "gazelle_bin",

--- a/examples/pkg_manifest_minimal/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/BUILD.bazel
@@ -14,6 +14,8 @@ tidy(
 
 # Ignore the Swift build folder
 # gazelle:exclude .build
+
+# Omit tags = ["manual"] from the generated swift library targets
 # gazelle:swift_library_tags -
 
 gazelle_binary(

--- a/examples/pkg_manifest_minimal/Sources/MyLibrary/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyLibrary/BUILD.bazel
@@ -4,7 +4,6 @@ swift_library(
     name = "MyLibrary",
     srcs = ["World.swift"],
     module_name = "MyLibrary",
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = ["@swiftpkg_my_local_package//:Sources_GreetingsFramework"],
 )

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -154,6 +154,9 @@ func (*swiftLang) Configure(c *config.Config, rel string, f *rule.File) {
 		case swiftLibraryTags:
 			var tags []string
 			if d.Value == "" {
+				// Mark swift_library targets as manual.
+				// We do this so that they are always built as a dependency of a target
+				// which can provide critical configuration information.
 				tags = []string{"manual"}
 			} else if d.Value == "-" {
 				tags = nil

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -127,13 +128,13 @@ func (sl *swiftLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 
 const moduleNamingConventionDirective = "swift_module_naming_convention"
 const defaultModuleNameDirective = "swift_default_module_name"
-const swiftLibraryManualTag = "swift_library_manual_tag"
+const swiftLibraryTags = "swift_library_tags"
 
 func (*swiftLang) KnownDirectives() []string {
 	return []string{
 		moduleNamingConventionDirective,
 		defaultModuleNameDirective,
-		swiftLibraryManualTag,
+		swiftLibraryTags,
 	}
 }
 
@@ -150,8 +151,16 @@ func (*swiftLang) Configure(c *config.Config, rel string, f *rule.File) {
 			} else {
 				sc.ModuleNamingConvention = swiftcfg.MatchCaseModuleNamingConvention
 			}
-		case swiftLibraryManualTag:
-			sc.SwiftLibraryManualTagDisabled = d.Value == "disabled"
+		case swiftLibraryTags:
+			var tags []string
+			if d.Value == "" {
+				tags = []string{"manual"}
+			} else if d.Value == "-" {
+				tags = nil
+			} else {
+				tags = strings.Split(d.Value, ",")
+			}
+			sc.SwiftLibraryTags = tags
 		case defaultModuleNameDirective:
 			sc.DefaultModuleNames[rel] = d.Value
 		}

--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -127,11 +127,13 @@ func (sl *swiftLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 
 const moduleNamingConventionDirective = "swift_module_naming_convention"
 const defaultModuleNameDirective = "swift_default_module_name"
+const swiftLibraryManualTag = "swift_library_manual_tag"
 
 func (*swiftLang) KnownDirectives() []string {
 	return []string{
 		moduleNamingConventionDirective,
 		defaultModuleNameDirective,
+		swiftLibraryManualTag,
 	}
 }
 
@@ -148,6 +150,8 @@ func (*swiftLang) Configure(c *config.Config, rel string, f *rule.File) {
 			} else {
 				sc.ModuleNamingConvention = swiftcfg.MatchCaseModuleNamingConvention
 			}
+		case swiftLibraryManualTag:
+			sc.SwiftLibraryManualTagDisabled = d.Value == "disabled"
 		case defaultModuleNameDirective:
 			sc.DefaultModuleNames[rel] = d.Value
 		}

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -65,7 +65,7 @@ func genRulesFromSrcFiles(sc *swiftcfg.SwiftConfig, args language.GenerateArgs) 
 
 	// Generate the rules from sources:
 	defaultName, defaultModuleName := defaultNameAndModuleName(args)
-	rules = swift.RulesFromSrcs(args, srcs, defaultName, defaultModuleName, sc.SwiftLibraryManualTagDisabled)
+	rules = swift.RulesFromSrcs(args, srcs, defaultName, defaultModuleName, sc.SwiftLibraryTags)
 	result.Gen = append(result.Gen, rules...)
 	result.Imports = swift.Imports(result.Gen)
 	result.Empty = generateEmpty(args, srcs)

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -65,7 +65,7 @@ func genRulesFromSrcFiles(sc *swiftcfg.SwiftConfig, args language.GenerateArgs) 
 
 	// Generate the rules from sources:
 	defaultName, defaultModuleName := defaultNameAndModuleName(args)
-	rules = swift.RulesFromSrcs(args, srcs, defaultName, defaultModuleName)
+	rules = swift.RulesFromSrcs(args, srcs, defaultName, defaultModuleName, sc.SwiftLibraryManualTagDisabled)
 	result.Gen = append(result.Gen, rules...)
 	result.Imports = swift.Imports(result.Gen)
 	result.Empty = generateEmpty(args, srcs)

--- a/gazelle/internal/swift/rules_common.go
+++ b/gazelle/internal/swift/rules_common.go
@@ -14,16 +14,20 @@ func rulesForLibraryModule(
 	srcs []string,
 	swiftImports []string,
 	shouldSetVis bool,
+	swiftLibraryManualTagDisabled bool,
 	buildFile *rule.File,
 ) []*rule.Rule {
 	name, moduleName := ruleNameAndModuleName(buildFile, LibraryRuleKind, defaultName, defaultModuleName)
 	r := rule.NewRule(LibraryRuleKind, name)
 	setCommonSwiftAttrs(r, moduleName, srcs, swiftImports)
 	setVisibilityAttr(r, shouldSetVis, []string{"//visibility:public"})
-	// Mark swift_library targets as manual. We do this so that they are always
-	// built from a leaf node which can provide critical configuration
-	// information.
-	r.SetAttr("tags", []string{"manual"})
+	if !swiftLibraryManualTagDisabled {
+		// Mark swift_library targets as manual. We do this so that they are always
+		// built from a leaf node which can provide critical configuration
+		// information.
+		r.SetAttr("tags", []string{"manual"})
+	}
+
 	return []*rule.Rule{r}
 }
 

--- a/gazelle/internal/swift/rules_common.go
+++ b/gazelle/internal/swift/rules_common.go
@@ -14,18 +14,15 @@ func rulesForLibraryModule(
 	srcs []string,
 	swiftImports []string,
 	shouldSetVis bool,
-	swiftLibraryManualTagDisabled bool,
+	swiftLibraryTags []string,
 	buildFile *rule.File,
 ) []*rule.Rule {
 	name, moduleName := ruleNameAndModuleName(buildFile, LibraryRuleKind, defaultName, defaultModuleName)
 	r := rule.NewRule(LibraryRuleKind, name)
 	setCommonSwiftAttrs(r, moduleName, srcs, swiftImports)
 	setVisibilityAttr(r, shouldSetVis, []string{"//visibility:public"})
-	if !swiftLibraryManualTagDisabled {
-		// Mark swift_library targets as manual. We do this so that they are always
-		// built from a leaf node which can provide critical configuration
-		// information.
-		r.SetAttr("tags", []string{"manual"})
+	if len(swiftLibraryTags) > 0 {
+		r.SetAttr("tags", swiftLibraryTags)
 	}
 
 	return []*rule.Rule{r}

--- a/gazelle/internal/swift/rules_from_protos.go
+++ b/gazelle/internal/swift/rules_from_protos.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
-// RulesFromSrcs returns the Bazel build rule declarations for the provided source files.
+// RulesFromProtos returns the Bazel build rule declarations for the provided source files.
 func RulesFromProtos(args language.GenerateArgs) []*rule.Rule {
 
 	// Extract information about proto files.

--- a/gazelle/internal/swift/rules_from_srcs.go
+++ b/gazelle/internal/swift/rules_from_srcs.go
@@ -15,7 +15,7 @@ func RulesFromSrcs(
 	srcs []string,
 	defaultName string,
 	defaultModuleName string,
-	swiftLibraryManualTagDisabled bool,
+	swiftLibraryTags []string,
 ) []*rule.Rule {
 	fileInfos := swiftpkg.NewSwiftFileInfosFromRelPaths(args.Dir, srcs)
 	swiftImports, moduleType := collectSwiftInfo(fileInfos)
@@ -25,7 +25,7 @@ func RulesFromSrcs(
 	var rules []*rule.Rule
 	switch moduleType {
 	case LibraryModuleType:
-		rules = rulesForLibraryModule(defaultName, defaultModuleName, srcs, swiftImports, shouldSetVis, swiftLibraryManualTagDisabled, args.File)
+		rules = rulesForLibraryModule(defaultName, defaultModuleName, srcs, swiftImports, shouldSetVis, swiftLibraryTags, args.File)
 	case BinaryModuleType:
 		rules = rulesForBinaryModule(defaultName, defaultModuleName, srcs, swiftImports, shouldSetVis, args.File)
 	case TestModuleType:

--- a/gazelle/internal/swift/rules_from_srcs.go
+++ b/gazelle/internal/swift/rules_from_srcs.go
@@ -15,6 +15,7 @@ func RulesFromSrcs(
 	srcs []string,
 	defaultName string,
 	defaultModuleName string,
+	swiftLibraryManualTagDisabled bool,
 ) []*rule.Rule {
 	fileInfos := swiftpkg.NewSwiftFileInfosFromRelPaths(args.Dir, srcs)
 	swiftImports, moduleType := collectSwiftInfo(fileInfos)
@@ -24,7 +25,7 @@ func RulesFromSrcs(
 	var rules []*rule.Rule
 	switch moduleType {
 	case LibraryModuleType:
-		rules = rulesForLibraryModule(defaultName, defaultModuleName, srcs, swiftImports, shouldSetVis, args.File)
+		rules = rulesForLibraryModule(defaultName, defaultModuleName, srcs, swiftImports, shouldSetVis, swiftLibraryManualTagDisabled, args.File)
 	case BinaryModuleType:
 		rules = rulesForBinaryModule(defaultName, defaultModuleName, srcs, swiftImports, shouldSetVis, args.File)
 	case TestModuleType:

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -47,8 +47,9 @@ type SwiftConfig struct {
 	// The default behavior uses the name verbatim while PascalCase will convert snake_case to PascalCase.
 	ModuleNamingConvention string
 
-	// Whether the default behavior to tag generated swift library targets as manual should be disabled.
-	SwiftLibraryManualTagDisabled bool
+	// The set of tags to apply to generated swift library targets.
+	// Defailts to ["manual"]
+	SwiftLibraryTags []string
 
 	// Mapping of relative path to default module name. These values are populated from directives
 	// that can be applied to

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -43,7 +43,12 @@ type SwiftConfig struct {
 
 	GenerateSwiftDepsForWorkspace bool
 
+	// The naming convention to apply to the module names derived from the directory names.
+	// The default behavior uses the name verbatim while PascalCase will convert snake_case to PascalCase.
 	ModuleNamingConvention string
+
+	// Whether the default behavior to tag generated swift library targets as manual should be disabled.
+	SwiftLibraryManualTagDisabled bool
 
 	// Mapping of relative path to default module name. These values are populated from directives
 	// that can be applied to

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -48,7 +48,7 @@ type SwiftConfig struct {
 	ModuleNamingConvention string
 
 	// The set of tags to apply to generated swift library targets.
-	// Defailts to ["manual"]
+	// Defaults to ["manual"]
 	SwiftLibraryTags []string
 
 	// Mapping of relative path to default module name. These values are populated from directives


### PR DESCRIPTION
This PR introduces a directive to disable the addition of the manual tag to generated swift_library targets.

I understand the intent behind the tag and am ok with keeping it the default. But for more advanced users who understand that they need to pass the apple platform type configuration, it is useful to be able to build globs of these targets without a dedicated build test target.