### PR TITLE
chore(perf): refactor checking path for directory

### DIFF
--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -780,12 +780,19 @@ def _new_swift_src_info_from_sources(repository_ctx, target_path, sources):
         target_path,
     )
 
+    # Identify the directories
+    directories = repository_files.list_directories_under(
+        repository_ctx,
+        target_path,
+    )
+    dirs_set = sets.make(directories)
+
     # The paths should be relative to the target not the root of the workspace.
     # Do not include directories in the output.
     discovered_res_files = [
         f
         for f in all_target_files
-        if not repository_files.is_directory(repository_ctx, f) and
+        if not sets.contains(dirs_set, f) and
            resource_files.is_auto_discovered_resource(f)
     ]
 

--- a/swiftpkg/internal/repository_files.bzl
+++ b/swiftpkg/internal/repository_files.bzl
@@ -162,8 +162,6 @@ def _copy_directory(repository_ctx, src, dest):
         ],
     )
 
-# GH582: Refactor _is_directory to be like _path_exists.
-
 def _is_directory(repository_ctx, path):
     """Determine if the provided path is a directory.
 
@@ -174,20 +172,11 @@ def _is_directory(repository_ctx, path):
     Returns:
         A `bool` specifying whether the path is a directory.
     """
-    args = ["bash", "-c", "if [[ -d ${TARGET_PATH} ]]; then echo TRUE; else echo FALSE; fi"]
     exec_result = repository_ctx.execute(
-        args,
-        environment = {"TARGET_PATH": path},
+        ["test", "-d", path],
         quiet = True,
     )
-    if exec_result.return_code != 0:
-        fail("Failed while checking if '{path}' is a directory. stderr:\n{stderr}".format(
-            path = path,
-            stderr = exec_result.stderr,
-        ))
-    if exec_result.stdout.find("TRUE") >= 0:
-        return True
-    return False
+    return exec_result.return_code == 0
 
 def _file_type(repository_ctx, path):
     """Output the file type.


### PR DESCRIPTION
- Instead of shelling out to test each path, the new code finds all of the directories under the target in one shell call. The result is then added to a set and the set is checked.
  - The starlark profile for the `soto_example` dropped from 350 seconds to 46 seconds.
- Simplified the implementation for `repository_files.is_directory()`.

Closes #582.