### PR TITLE
fix: read and apply per target Cxx settings and consolidate private includes

### DIFF
--- a/examples/interesting_deps/.bazelrc
+++ b/examples/interesting_deps/.bazelrc
@@ -6,3 +6,6 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Required by geos
+build --cxxopt='-std=c++11'

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -42,6 +42,7 @@ swift_binary(
     visibility = ["//swift:__subpackages__"],
     deps = [
         "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwiftLogBackend",
+        "@swiftpkg_geoswift//:Sources_GEOSwift",
         "@swiftpkg_libwebp_xcode//:libwebp",
         "@swiftpkg_opencombine//:Sources_OpenCombine",
         "@swiftpkg_swift_log//:Sources_Logging",

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -47,6 +47,7 @@ swift_deps.from_file(
 use_repo(
     swift_deps,
     "swiftpkg_cocoalumberjack",
+    "swiftpkg_geoswift",
     "swiftpkg_libwebp_xcode",
     "swiftpkg_opencombine",
     "swiftpkg_swift_log",

--- a/examples/interesting_deps/Package.resolved
+++ b/examples/interesting_deps/Package.resolved
@@ -10,6 +10,24 @@
       }
     },
     {
+      "identity" : "geos",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GEOSwift/geos.git",
+      "state" : {
+        "revision" : "f510e634c822116fca615064d889300dba40d761",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "geoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GEOSwift/GEOSwift",
+      "state" : {
+        "revision" : "2d23ede8c82c067655d3a9f0221bc73f08cd399a",
+        "version" : "10.1.0"
+      }
+    },
+    {
       "identity" : "libwebp-xcode",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/libwebp-Xcode.git",

--- a/examples/interesting_deps/Package.swift
+++ b/examples/interesting_deps/Package.swift
@@ -5,9 +5,10 @@ import PackageDescription
 let package = Package(
     name: "MySwiftPackage",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log", from: "1.5.3"),
-        .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.3.2"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.8.1"),
+        .package(url: "https://github.com/GEOSwift/GEOSwift", from: "10.1.0"),
         .package(url: "https://github.com/OpenCombine/OpenCombine", from: "0.14.0"),
+        .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.3.2"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.5.3"),
     ]
 )

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -1,5 +1,6 @@
 import CocoaLumberjack
 import CocoaLumberjackSwiftLogBackend
+import GEOSwift
 import libwebp
 import Logging
 import OpenCombine

--- a/examples/interesting_deps/swift_deps_index.json
+++ b/examples/interesting_deps/swift_deps_index.json
@@ -1,6 +1,7 @@
 {
   "direct_dep_identities": [
     "cocoalumberjack",
+    "geoswift",
     "libwebp-xcode",
     "opencombine",
     "swift-log"
@@ -46,6 +47,26 @@
       "package_identity": "cocoalumberjack",
       "product_memberships": [
         "CocoaLumberjackSwift"
+      ]
+    },
+    {
+      "name": "geos",
+      "c99name": "geos",
+      "src_type": "clang",
+      "label": "@swiftpkg_geos//:Sources_geos",
+      "package_identity": "geos",
+      "product_memberships": [
+        "geos"
+      ]
+    },
+    {
+      "name": "GEOSwift",
+      "c99name": "GEOSwift",
+      "src_type": "swift",
+      "label": "@swiftpkg_geoswift//:Sources_GEOSwift",
+      "package_identity": "geoswift",
+      "product_memberships": [
+        "GEOSwift"
       ]
     },
     {
@@ -153,6 +174,22 @@
       ]
     },
     {
+      "identity": "geoswift",
+      "name": "GEOSwift",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_geoswift//:Sources_GEOSwift"
+      ]
+    },
+    {
+      "identity": "geos",
+      "name": "geos",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_geos//:Sources_geos"
+      ]
+    },
+    {
       "identity": "libwebp-xcode",
       "name": "libwebp",
       "type": "library",
@@ -209,6 +246,25 @@
         "commit": "67ec5818a757aba4d7c534e21a905d878d128dbf",
         "remote": "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
         "version": "3.8.1"
+      }
+    },
+    {
+      "name": "swiftpkg_geos",
+      "identity": "geos",
+      "remote": {
+        "commit": "f510e634c822116fca615064d889300dba40d761",
+        "remote": "https://github.com/GEOSwift/geos.git",
+        "version": "8.1.0"
+      },
+      "cxxLanguageStandard": "c++11"
+    },
+    {
+      "name": "swiftpkg_geoswift",
+      "identity": "geoswift",
+      "remote": {
+        "commit": "2d23ede8c82c067655d3a9f0221bc73f08cd399a",
+        "remote": "https://github.com/GEOSwift/GEOSwift",
+        "version": "10.1.0"
       }
     },
     {

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -183,6 +183,26 @@ def _relativize_paths(paths_list, relative_to):
         for path in paths_list
     ]
 
+def _reduce_paths(path_list):
+    # Reduce the paths to the smallest number of paths with a common parent.
+    # By sorting the paths, the shortest paths should be first.
+    path_list = sorted(path_list)
+    result_set = sets.make()
+
+    def _starts_with_any_in_result(path):
+        for rpath in sets.to_list(result_set):
+            if path.startswith(rpath):
+                return True
+        return False
+
+    for path in path_list:
+        if sets.contains(result_set, path):
+            continue
+        if _starts_with_any_in_result(path):
+            continue
+        sets.insert(result_set, path)
+    return sorted(sets.to_list(result_set))
+
 def _collect_files(
         repository_ctx,
         all_srcs,
@@ -281,7 +301,19 @@ def _collect_files(
     srcs = sets.to_list(srcs_set)
     others = sets.to_list(others_set)
     public_includes = sets.to_list(public_includes_set)
+
+    # TODO(chuck): FIX ME!
     private_includes = sets.to_list(private_includes_set)
+    # private_includes = _reduce_paths(
+    #     path_list = sets.to_list(private_includes_set),
+    # )
+
+    # DEBUG BEGIN
+    print("*** CHUCK private_includes: ")
+    for idx, item in enumerate(private_includes):
+        print("*** CHUCK", idx, ":", item)
+
+    # DEBUG END
 
     # Textual headers
     textual_hdrs = []
@@ -308,5 +340,6 @@ clang_files = struct(
     is_include_hdr = _is_include_hdr,
     is_public_modulemap = _is_public_modulemap,
     is_under_path = _is_under_path,
+    reduce_paths = _reduce_paths,
     relativize = _relativize,
 )

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -189,6 +189,7 @@ def _reduce_paths(path_list):
     path_list = sorted(path_list)
     result_set = sets.make()
 
+    # buildifier: disable=uninitialized
     def _starts_with_any_in_result(path):
         for rpath in sets.to_list(result_set):
             if path.startswith(rpath):

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -301,19 +301,9 @@ def _collect_files(
     srcs = sets.to_list(srcs_set)
     others = sets.to_list(others_set)
     public_includes = sets.to_list(public_includes_set)
-
-    # TODO(chuck): FIX ME!
-    private_includes = sets.to_list(private_includes_set)
-    # private_includes = _reduce_paths(
-    #     path_list = sets.to_list(private_includes_set),
-    # )
-
-    # DEBUG BEGIN
-    print("*** CHUCK private_includes: ")
-    for idx, item in enumerate(private_includes):
-        print("*** CHUCK", idx, ":", item)
-
-    # DEBUG END
+    private_includes = _reduce_paths(
+        path_list = sets.to_list(private_includes_set),
+    )
 
     # Textual headers
     textual_hdrs = []

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -282,8 +282,6 @@ def _new_target_from_json_maps(
             ]
 
     elif module_type == module_types.clang:
-        # other_hdr_srch_paths = clang_settings.hdr_srch_paths + \
-        #                        cxx_settings.hdr_srch_paths
         other_hdr_srch_paths = []
         if clang_settings != None:
             other_hdr_srch_paths.extend(clang_settings.hdr_srch_paths)
@@ -929,12 +927,6 @@ def _new_clang_src_info_from_sources(
 
     # Look for header files that are not under the target path
     extra_hdr_dirs = []
-
-    # if clang_settings != None:
-    #     extra_hdr_dirs.extend(lists.flatten([
-    #         [paths.join(target_path, path) for path in bs.values]
-    #         for bs in clang_settings.hdr_srch_paths
-    #     ]))
     extra_hdr_dirs.extend(lists.flatten([
         [paths.join(target_path, path) for path in bs.values]
         for bs in other_hdr_srch_paths

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -206,7 +206,8 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         for p in clang_src_info.private_includes
     ]
 
-    if target.clang_settings != None:
+    all_settings = lists.compact([target.clang_settings, target.cxx_settings])
+    for settings in all_settings:
         defines.extend(lists.flatten([
             bzl_selects.new_from_build_setting(
                 bs,
@@ -214,7 +215,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                 # are already escaped.
                 values_map_fn = scg.normalize_define_value,
             )
-            for bs in target.clang_settings.defines
+            for bs in settings.defines
         ]))
 
         # Need to convert the headerSearchPaths to be relative to the
@@ -229,7 +230,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                 ],
                 condition = bs.condition,
             )
-            for bs in target.clang_settings.hdr_srch_paths
+            for bs in settings.hdr_srch_paths
         ]
         local_includes.extend(lists.flatten([
             bzl_selects.new_from_build_setting(bs)
@@ -238,7 +239,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
 
         copts.extend(lists.flatten([
             bzl_selects.new_from_build_setting(bs)
-            for bs in target.clang_settings.unsafe_flags
+            for bs in settings.unsafe_flags
         ]))
 
     linkopts = []

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -177,6 +177,61 @@ def _find_magical_public_hdr_dir_test(ctx):
 
 find_magical_public_hdr_dir_test = unittest.make(_find_magical_public_hdr_dir_test)
 
+def _reduce_paths_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            msg = "empty paths",
+            paths = [],
+            exp = [],
+        ),
+        struct(
+            msg = "single path",
+            paths = ["Sources/geos/include"],
+            exp = ["Sources/geos/include"],
+        ),
+        struct(
+            msg = "duplicate paths",
+            paths = [
+                "Sources/geos/include",
+                "Sources/geos/include",
+            ],
+            exp = ["Sources/geos/include"],
+        ),
+        struct(
+            msg = "consolidate paths",
+            paths = [
+                "Sources/geos/include/geos/geomgraph",
+                "Sources/geos/include/geos/geomgraph/index",
+                "Sources/geos/include/geos/operation",
+                "Sources/geos/include",
+            ],
+            exp = ["Sources/geos/include"],
+        ),
+        struct(
+            msg = "consolidate paths, multiple results",
+            paths = [
+                "Sources/geos/include/geos/geomgraph",
+                "Sources/geos/include/geos/geomgraph/index",
+                "Sources/geos/include/geos/operation",
+                "Sources/geos/include",
+                "Sources/geos/src/deps/ryu",
+            ],
+            exp = [
+                "Sources/geos/include",
+                "Sources/geos/src/deps/ryu",
+            ],
+        ),
+    ]
+    for t in tests:
+        actual = clang_files.reduce_paths(t.paths)
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+reduce_paths_test = unittest.make(_reduce_paths_test)
+
 def clang_files_test_suite():
     return unittest.suite(
         "clang_files_tests",
@@ -186,4 +241,5 @@ def clang_files_test_suite():
         relativize_test,
         is_under_path_test,
         find_magical_public_hdr_dir_test,
+        reduce_paths_test,
     )


### PR DESCRIPTION
- Read and apply Cxx settings for Swift package targets.
- Consolidate the list of private includes for clang targets to smallest possible number by removing those with a common parent leaving the shortest of the common parent paths.
- Add [GEOSwift package](https://github.com/GEOSwift/GEOSwift) to the `interesting_deps` example.

Closes #674.