### PR TITLE
chore: add mapping for driverkit

### DIFF
--- a/config_settings/spm/platform/platforms.bzl
+++ b/config_settings/spm/platform/platforms.bzl
@@ -49,7 +49,8 @@ _PLATFORM_INFOS = [
     # Treat `maccatalyst` as an alias of sorts for macos. This will be handled
     # in the `platforms.label` function.
     _platform_info(spm = "maccatalyst", bzl = None, os = None),
-    # Not sure how to map driverkit
+    # Map `driverkit` as `macos`. This will be handled in the
+    # `platforms.label()` function.
     _platform_info(spm = "driverkit", bzl = None, os = None),
 ]
 
@@ -67,6 +68,8 @@ def _label(name):
     # that use iOS frameworks. Treat it like iOS for now.
     if name == "maccatalyst":
         name = "ios"
+    if name == "driverkit":
+        name = "macos"
     return "@rules_swift_package_manager//config_settings/spm/platform:{}".format(name)
 
 platforms = struct(

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -43,6 +43,7 @@ swift_binary(
     deps = [
         "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwiftLogBackend",
         "@swiftpkg_libwebp_xcode//:libwebp",
+        "@swiftpkg_opencombine//:Sources_OpenCombine",
         "@swiftpkg_swift_log//:Sources_Logging",
     ],
 )

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -48,9 +48,9 @@ use_repo(
     swift_deps,
     "swiftpkg_cocoalumberjack",
     "swiftpkg_libwebp_xcode",
+    "swiftpkg_opencombine",
     "swiftpkg_swift_log",
 )
-
 # swift_deps END
 swift_deps.configure_package(
     name = "swiftpkg_libwebp_xcode",

--- a/examples/interesting_deps/Package.resolved
+++ b/examples/interesting_deps/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",

--- a/examples/interesting_deps/Package.swift
+++ b/examples/interesting_deps/Package.swift
@@ -8,5 +8,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.5.3"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.3.2"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.8.1"),
+        .package(url: "https://github.com/OpenCombine/OpenCombine", from: "0.14.0"),
     ]
 )

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -2,6 +2,7 @@ import CocoaLumberjack
 import CocoaLumberjackSwiftLogBackend
 import libwebp
 import Logging
+import OpenCombine
 
 // Configure DDLog to be the backend for the swift-log.
 DDLog.add(DDTTYLogger.sharedInstance!)

--- a/examples/interesting_deps/swift_deps_index.json
+++ b/examples/interesting_deps/swift_deps_index.json
@@ -2,6 +2,7 @@
   "direct_dep_identities": [
     "cocoalumberjack",
     "libwebp-xcode",
+    "opencombine",
     "swift-log"
   ],
   "modules": [
@@ -58,6 +59,64 @@
       ]
     },
     {
+      "name": "COpenCombineHelpers",
+      "c99name": "COpenCombineHelpers",
+      "src_type": "clang",
+      "label": "@swiftpkg_opencombine//:Sources_COpenCombineHelpers",
+      "package_identity": "opencombine",
+      "product_memberships": [
+        "OpenCombine",
+        "OpenCombineDispatch",
+        "OpenCombineFoundation",
+        "OpenCombineShim"
+      ]
+    },
+    {
+      "name": "OpenCombine",
+      "c99name": "OpenCombine",
+      "src_type": "swift",
+      "label": "@swiftpkg_opencombine//:Sources_OpenCombine",
+      "package_identity": "opencombine",
+      "product_memberships": [
+        "OpenCombine",
+        "OpenCombineDispatch",
+        "OpenCombineFoundation",
+        "OpenCombineShim"
+      ]
+    },
+    {
+      "name": "OpenCombineDispatch",
+      "c99name": "OpenCombineDispatch",
+      "src_type": "swift",
+      "label": "@swiftpkg_opencombine//:Sources_OpenCombineDispatch",
+      "package_identity": "opencombine",
+      "product_memberships": [
+        "OpenCombineDispatch",
+        "OpenCombineShim"
+      ]
+    },
+    {
+      "name": "OpenCombineFoundation",
+      "c99name": "OpenCombineFoundation",
+      "src_type": "swift",
+      "label": "@swiftpkg_opencombine//:Sources_OpenCombineFoundation",
+      "package_identity": "opencombine",
+      "product_memberships": [
+        "OpenCombineFoundation",
+        "OpenCombineShim"
+      ]
+    },
+    {
+      "name": "OpenCombineShim",
+      "c99name": "OpenCombineShim",
+      "src_type": "swift",
+      "label": "@swiftpkg_opencombine//:Sources_OpenCombineShim",
+      "package_identity": "opencombine",
+      "product_memberships": [
+        "OpenCombineShim"
+      ]
+    },
+    {
       "name": "Logging",
       "c99name": "Logging",
       "src_type": "swift",
@@ -102,6 +161,38 @@
       ]
     },
     {
+      "identity": "opencombine",
+      "name": "OpenCombine",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_opencombine//:Sources_OpenCombine"
+      ]
+    },
+    {
+      "identity": "opencombine",
+      "name": "OpenCombineDispatch",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_opencombine//:Sources_OpenCombineDispatch"
+      ]
+    },
+    {
+      "identity": "opencombine",
+      "name": "OpenCombineFoundation",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_opencombine//:Sources_OpenCombineFoundation"
+      ]
+    },
+    {
+      "identity": "opencombine",
+      "name": "OpenCombineShim",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_opencombine//:Sources_OpenCombineShim"
+      ]
+    },
+    {
       "identity": "swift-log",
       "name": "Logging",
       "type": "library",
@@ -128,6 +219,16 @@
         "remote": "https://github.com/SDWebImage/libwebp-Xcode.git",
         "version": "1.3.2"
       }
+    },
+    {
+      "name": "swiftpkg_opencombine",
+      "identity": "opencombine",
+      "remote": {
+        "commit": "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "remote": "https://github.com/OpenCombine/OpenCombine",
+        "version": "0.14.0"
+      },
+      "cxxLanguageStandard": "c++17"
     },
     {
       "name": "swiftpkg_swift_log",


### PR DESCRIPTION
- Add mapping for `driverkit` treating it as a `macos` platform.
- Add [OpenCombine package](https://github.com/OpenCombine/OpenCombine) to the `interesting_deps` example. It references `driverkit`.

Closes #379.