### PR TITLE
fix: link type detection for frameworks

### DIFF
--- a/swiftpkg/internal/artifact_infos.bzl
+++ b/swiftpkg/internal/artifact_infos.bzl
@@ -110,21 +110,16 @@ def _link_type(repository_ctx, path):
     file_type = repository_files.file_type(repository_ctx, path)
 
     # static Examples:
-    # current ar archive random library
-    # current ar archive
-    if file_type.find("ar archive") > 0:
+    #   current ar archive random library
+    #   current ar archive
+    # dynamic Examples:
+    #   dynamically linked shared library
+    if file_type.find("ar archive") >= 0:
         link_type = link_types.static
-    elif file_type.find("dynamically linked shared library") > 0:
+    elif file_type.find("dynamic") >= 0:
         link_type = link_types.dynamic
     else:
         link_type = link_types.unknown
-
-    # DEBUG BEGIN
-    print("*** CHUCK ===================")
-    print("*** CHUCK path: ", path)
-    print("*** CHUCK link_type: ", link_type)
-
-    # DEBUG END
     return link_type
 
 def _new_xcframework_info_from_files(repository_ctx, path):

--- a/swiftpkg/internal/artifact_infos.bzl
+++ b/swiftpkg/internal/artifact_infos.bzl
@@ -115,12 +115,10 @@ def _link_type(repository_ctx, path):
     # dynamic Examples:
     #   dynamically linked shared library
     if file_type.find("ar archive") >= 0:
-        link_type = link_types.static
+        return link_types.static
     elif file_type.find("dynamic") >= 0:
-        link_type = link_types.dynamic
-    else:
-        link_type = link_types.unknown
-    return link_type
+        return link_types.dynamic
+    return link_types.unknown
 
 def _new_xcframework_info_from_files(repository_ctx, path):
     """Return a `struct` descrbing an xcframework from the files at the \

--- a/swiftpkg/internal/artifact_infos.bzl
+++ b/swiftpkg/internal/artifact_infos.bzl
@@ -89,17 +89,43 @@ def _new_framework_info_from_files(repository_ctx, path):
     )
     if len(binary_files) == 0:
         fail("No binary files were found for framework at {}".format(path))
-    file_type = repository_files.file_type(repository_ctx, binary_files[0])
-    if file_type.find("ar archive random library") > 0:
-        link_type = link_types.static
-    elif file_type.find("dynamically linked shared library"):
-        link_type = link_types.dynamic
-    else:
-        link_type = link_types.unknown
+    link_type = _link_type(repository_ctx, binary_files[0])
+
     return _new_framework_info(
         path = path,
         link_type = link_type,
     )
+
+def _link_type(repository_ctx, path):
+    """Determine the link type for the framework binary file.
+
+    Args:
+        repository_ctx: A `repository_ctx` instance.
+        path: The path to a framework binary file under a `XXX.framework`
+            directory as a `string`.
+
+    Returns:
+        The link type for the framework as a `string`.
+    """
+    file_type = repository_files.file_type(repository_ctx, path)
+
+    # static Examples:
+    # current ar archive random library
+    # current ar archive
+    if file_type.find("ar archive") > 0:
+        link_type = link_types.static
+    elif file_type.find("dynamically linked shared library") > 0:
+        link_type = link_types.dynamic
+    else:
+        link_type = link_types.unknown
+
+    # DEBUG BEGIN
+    print("*** CHUCK ===================")
+    print("*** CHUCK path: ", path)
+    print("*** CHUCK link_type: ", link_type)
+
+    # DEBUG END
+    return link_type
 
 def _new_xcframework_info_from_files(repository_ctx, path):
     """Return a `struct` descrbing an xcframework from the files at the \
@@ -139,6 +165,7 @@ artifact_infos = struct(
     new_framework_info = _new_framework_info,
     new_xcframework_info = _new_xcframework_info,
     new_xcframework_info_from_files = _new_xcframework_info_from_files,
+    link_type = _link_type,
 )
 
 link_types = struct(

--- a/swiftpkg/tests/BUILD.bazel
+++ b/swiftpkg/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load(":artifact_infos_tests.bzl", "artifact_infos_test_suite")
 load(":bazel_apple_platforms_tests.bzl", "bazel_apple_platforms_test_suite")
 load(":bazel_repo_names_tests.bzl", "bazel_repo_names_test_suite")
 load(":build_decls_tests.bzl", "build_decls_test_suite")
@@ -21,6 +22,8 @@ load(":swiftpkg_build_files_tests.bzl", "swiftpkg_build_files_test_suite")
 load(":validations_tests.bzl", "validations_test_suite")
 
 bzlformat_pkg(name = "bzlformat")
+
+artifact_infos_test_suite()
 
 bazel_apple_platforms_test_suite()
 

--- a/swiftpkg/tests/artifact_infos_tests.bzl
+++ b/swiftpkg/tests/artifact_infos_tests.bzl
@@ -1,11 +1,49 @@
 """Tests for `artifact_infos` module."""
 
-load("@bazel_skylib//lib:unittest.bzl", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//swiftpkg/internal:artifact_infos.bzl", "artifact_infos", "link_types")
+load(":testutils.bzl", "testutils")
 
 def _link_type_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    tests = [
+        struct(
+            msg = "current ar archive",
+            file_type = """\
+path/to/framework/binary/FooBar (for architecture x86_64):	current ar archive
+path/to/framework/binary/FooBar (for architecture arm64):	current ar archive
+""",
+            exp = link_types.static,
+        ),
+        struct(
+            msg = "current ar archive random library",
+            file_type = """\
+Mach-O universal binary with 2 architectures: [x86_64:current ar archive random library] [arm64:current ar archive random library]
+path/to/framework/binary/FooBar (for architecture x86_64):	current ar archive random library
+path/to/framework/binary/FooBar (for architecture arm64):	current ar archive random library
+""",
+            exp = link_types.static,
+        ),
+        struct(
+            msg = "dynamically linked shared library",
+            file_type = "dynamically linked shared library",
+            exp = link_types.dynamic,
+        ),
+        struct(
+            msg = "unknown",
+            file_type = "no idea what this is",
+            exp = link_types.unknown,
+        ),
+    ]
+    for t in tests:
+        path = "path/to/framework/binary/FooBar"
+        stub_repository_ctx = testutils.new_stub_repository_ctx(
+            repo_name = "chicken",
+            file_type_results = {path: t.file_type},
+        )
+        actual = artifact_infos.link_type(stub_repository_ctx, "path/to/framework/binary/FooBar")
+        asserts.equals(env, t.exp, actual, t.msg)
 
     return unittest.end(env)
 

--- a/swiftpkg/tests/artifact_infos_tests.bzl
+++ b/swiftpkg/tests/artifact_infos_tests.bzl
@@ -1,0 +1,18 @@
+"""Tests for `artifact_infos` module."""
+
+load("@bazel_skylib//lib:unittest.bzl", "unittest")
+
+def _link_type_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+link_type_test = unittest.make(_link_type_test)
+
+def artifact_infos_test_suite(name = "artifact_infos_tests"):
+    return unittest.suite(
+        name,
+        link_type_test,
+    )

--- a/swiftpkg/tests/testutils.bzl
+++ b/swiftpkg/tests/testutils.bzl
@@ -11,7 +11,8 @@ def _new_stub_repository_ctx(
         repo_name,
         file_contents = {},
         find_results = {},
-        is_directory_results = {}):
+        is_directory_results = {},
+        file_type_results = {}):
     def read(path):
         return file_contents.get(path, "")
 
@@ -34,6 +35,11 @@ def _new_stub_repository_ctx(
             exec_result = _new_exec_result(
                 stdout = "\n".join(results),
             )
+        elif args_len == 3 and args[0] == "file" and args[1] == "--brief":
+            # Expected command: `file --brief path`
+            path = args[2]
+            results = file_type_results.get(path, "")
+            exec_result = _new_exec_result(stdout = results)
         else:
             exec_result = _new_exec_result()
         return exec_result


### PR DESCRIPTION
- The `find()` result for the file type results was broken. It was not detecting matches at the front of the string and it was not checking the dynamic result properly.
- Relaxed the static check to support additional file type results found in the wild.
- Add unit tests.

[Related Slack thread](https://bazelbuild.slack.com/archives/C05NZSHE7FU/p1698959858859589)