### PR TITLE
chore: extend argument parser example

### DIFF
--- a/bzlmod/workspace/Package.swift
+++ b/bzlmod/workspace/Package.swift
@@ -4,8 +4,35 @@ import PackageDescription
 
 let package = Package(
     name: "MySwiftPackage",
+    products: [
+        .executable(name: "my-executable", targets: ["MyExecutable"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
         .package(url: "https://github.com/apple/swift-log", from: "1.5.3"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyExecutable",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Logging", package: "swift-log"),
+                "MyLibrary",
+            ],
+            path: "Sources/MyExecutable",
+            exclude: ["BUILD.bazel"]
+        ),
+        .target(
+            name: "MyLibrary",
+            dependencies: [],
+            path: "Sources/MyLibrary",
+            exclude: ["BUILD.bazel"]
+        ),
+        .testTarget(
+            name: "MyLibraryTests",
+            dependencies: ["MyLibrary"],
+            path: "Tests/MyLibraryTests",
+            exclude: ["BUILD.bazel"]
+        )
     ]
 )

--- a/bzlmod/workspace/Sources/MyExecutable/BUILD.bazel
+++ b/bzlmod/workspace/Sources/MyExecutable/BUILD.bazel
@@ -9,6 +9,7 @@ swift_binary(
     deps = [
         "//Sources/MyLibrary",
         "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser",
+        "@swiftpkg_swift_log//:Sources_Logging",
     ],
 )
 

--- a/bzlmod/workspace/Sources/MyExecutable/MyExecutable.swift
+++ b/bzlmod/workspace/Sources/MyExecutable/MyExecutable.swift
@@ -1,10 +1,14 @@
 import ArgumentParser
+import Logging
 import MyLibrary
+import RegexBuilder
 
 @main
 struct MyExecutable: AsyncParsableCommand {
+    struct Plugin { }
     mutating func run() async throws {
         let output = "Hello, \(World().name)!"
-        print(output)
+        let logger = Logger(label: "com.example.BestExampleApp.main")
+        logger.info("\(output)")
     }
 }


### PR DESCRIPTION
Extends the `MyExecutable` example to demonstrate a bug when `import RegexBuilder` is used. It seems to be unable to find the dependency label for `RegexBuilder` and then erroneously adds a dep for `"@swiftpkg_swift_argument_parser//:Plugins_GenerateManual"` which fails to build.
