### PR TITLE
chore: update CI to only configure remote cache auth if secret is set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,9 @@ jobs:
           repo_name: rules_swift_package_manager
           xcode_version: "14.2"
       - uses: ./.github/actions/configure_remote_cache_auth
+        if: ${{ secrets.BUILDBUDDY_API_KEY != '' }}
         with:
-          buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/execute_test
         with:
           bzlmod_enabled: ${{ matrix.bzlmod_enabled }}
@@ -135,6 +136,7 @@ jobs:
           repo_name: rules_swift_package_manager
           xcode_version: "14.2"
       - uses: ./.github/actions/configure_remote_cache_auth
+        if: ${{ secrets.BUILDBUDDY_API_KEY != '' }}
         with:
-          buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/tidy_and_test


### PR DESCRIPTION
Because PRs from forks don't have access to secrets from the main repo.

> Due to the dangers inherent to automatic processing of PRs, GitHub’s
> standard `pull_request` workflow trigger by default prevents write
> permissions and secrets access to the target repository.

See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
