### PR TITLE
chore: update CI to use Xcode 15 and Swift 5.9

### DIFF
--- a/.github/actions/set_up_macos/action.yml
+++ b/.github/actions/set_up_macos/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   xcode_version:
     description: The version of Xcode to use.
-    default: '14.3.1'
+    default: '15.0.1'
 
 runs:
   using: composite
@@ -18,7 +18,7 @@ runs:
     - name: Confirm Xcode Version
       shell: bash
       run: |
-        # Print used xCode version
+        # Print used Xcode version
         xcode-select -print-path
         xcodebuild -version
     - uses: cgrindel/gha_set_up_bazel@v1

--- a/.github/actions/set_up_ubuntu/action.yml
+++ b/.github/actions/set_up_ubuntu/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   swift_release_tag:
     description: The Swift release tag.
-    default: "swift-5.7.2-RELEASE"
+    default: "swift-5.9.1-RELEASE"
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ startsWith(matrix.runner, 'macos') }}
         with:
           repo_name: rules_swift_package_manager
-          xcode_version: "14.2"
+          xcode_version: 15.0.1
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
           buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
@@ -133,7 +133,7 @@ jobs:
         if: ${{ startsWith(matrix.runner, 'macos') }}
         with:
           repo_name: rules_swift_package_manager
-          xcode_version: "14.2"
+          xcode_version: 15.0.1
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
           buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -15,6 +15,9 @@ build --incompatible_strict_action_env=true
 common --enable_bzlmod
 build --@cgrindel_bazel_starlib//bzlmod:enabled
 
+# Set minimum macOS version
+build --macos_minimum_os=10.15 --host_macos_minimum_os=10.15
+
 # Remote Cache
 build:cache --bes_results_url=https://app.buildbuddy.io/invocation/
 build:cache --bes_backend=grpcs://remote.buildbuddy.io


### PR DESCRIPTION
This is required to add more examples that use Xcode 15 / Swift 5.9 features, like macros.

Also fix a typo.