### PR TITLE
fix: only configure remote cache if the API key is available

### DIFF
--- a/.github/actions/configure_remote_cache_auth/action.yml
+++ b/.github/actions/configure_remote_cache_auth/action.yml
@@ -9,6 +9,7 @@ runs:
   using: composite
   steps:
     - name: Write the BuildBuddy API Auth
+      if: ${{ inputs.buildbuddy_api_key != '' }}
       shell: bash
       env:
         BUILDBUDDY_API_KEY: ${{ inputs.BUILDBUDDY_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           xcode_version: "14.2"
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
-          buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/execute_test
         with:
           bzlmod_enabled: ${{ matrix.bzlmod_enabled }}
@@ -136,5 +136,5 @@ jobs:
           xcode_version: "14.2"
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
-          buildbuddy_api_key: ${{  secrets.BUILDBUDDY_API_KEY }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/tidy_and_test

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -47,3 +47,5 @@ build --enable_platform_specific_config
 build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
 build:macos --crosstool_top=@local_config_apple_cc//:toolchain
 build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain
+
+# TODO: REMOVE ME!


### PR DESCRIPTION
Copied over a change proposed in #740.
