### PR TITLE
fix: only add dependency when unresolved

### DIFF
--- a/bzlmod/workspace/Sources/MyExecutable/MyExecutable.swift
+++ b/bzlmod/workspace/Sources/MyExecutable/MyExecutable.swift
@@ -3,6 +3,11 @@ import Logging
 import MyLibrary
 import RegexBuilder
 
+// Because we build on macos/linux this needs to be conditionally imported to test an edge case
+#if canImport(os)
+import os
+#endif
+
 @main
 struct MyExecutable: AsyncParsableCommand {
     struct Plugin { }
@@ -10,5 +15,9 @@ struct MyExecutable: AsyncParsableCommand {
         let output = "Hello, \(World().name)!"
         let logger = Logger(label: "com.example.BestExampleApp.main")
         logger.info("\(output)")
+
+        #if canImport(os)
+        os_log("This is a debug message.", log: OSLog.default, type: .debug)
+        #endif
     }
 }

--- a/gazelle/internal/swift/dependency_index.go
+++ b/gazelle/internal/swift/dependency_index.go
@@ -275,8 +275,15 @@ func (di *DependencyIndex) ResolveModulesToProducts(
 		}
 		sort.Sort(sort.Reverse(psrs))
 		selectedPsr := psrs[0]
-		selectedPiks = append(selectedPiks, selectedPsr.pik)
-		modulesToResolve = modulesToResolve.Difference(selectedPsr.intersect)
+
+		if selectedPsr.intersectCnt > 0 {
+			// We found a product that contains at least one of the modules that we are trying to
+			// resolve. Add it to the list of selected products and remove the modules that it
+			// contains from the list of modules that we are trying to resolve.
+			selectedPiks = append(selectedPiks, selectedPsr.pik)
+			modulesToResolve = modulesToResolve.Difference(selectedPsr.intersect)
+		}
+
 		potentialPikSet.Remove(selectedPsr.pik)
 	}
 


### PR DESCRIPTION
Works towards the issues in #742.

This particular bug can be seen when adding an `import` to a built-in framework when it is not already in the `builtin_modules.go` file.

For example, adding `import os` would warn with:

```
gazelle: Unable to find dependency labels for os
```

Which is correct **but** it would also erroneously add a dependency in the generated `BUILD.bazel` file for `@swiftpkg_swift_argument_parser//:Plugins_GenerateManual` which then fails the build entirely.

The reason for this bug is because the logic in `dependency_index.go` was not ensuring that the product being added as a dep was actually a product that needed to be resolved.

In the case where all modules are resolvable (i.e. all builtin frameworks accounted for) this isn't hit as the list of `modulesToResolve` is exhausted before any unused products are ever considered.