### PR TITLE
wip: support executable target with unit tests

### DIFF
--- a/bzlmod/workspace/Package.swift
+++ b/bzlmod/workspace/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "MySwiftPackage",
+    platforms: [
+        .macOS(.v12),
+    ],
     products: [
         .executable(name: "my-executable", targets: ["MyExecutable"]),
     ],
@@ -20,6 +23,12 @@ let package = Package(
                 "MyLibrary",
             ],
             path: "Sources/MyExecutable",
+            exclude: ["BUILD.bazel"]
+        ),
+        .testTarget(
+            name: "MyExecutableTests",
+            dependencies: ["MyExecutable"],
+            path: "Tests/MyExecutableTests",
             exclude: ["BUILD.bazel"]
         ),
         .target(

--- a/bzlmod/workspace/Tests/MyExecutableTests/BUILD.bazel
+++ b/bzlmod/workspace/Tests/MyExecutableTests/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+
+swift_test(
+    name = "MyExecutableTests",
+    srcs = [
+        "MyExecutableTests.swift",
+        "main.swift",
+    ],
+    module_name = "MyExecutableTests",
+    deps = ["//Sources/MyExecutable"],
+)

--- a/bzlmod/workspace/Tests/MyExecutableTests/MyExecutableTests.swift
+++ b/bzlmod/workspace/Tests/MyExecutableTests/MyExecutableTests.swift
@@ -1,0 +1,13 @@
+@testable import MyExecutable
+import XCTest
+
+final class MyExecutableTests: XCTestCase {
+    func testMyExecutable() throws {
+        MyExecutable.main()
+        XCTAssertEqual(MyExecutable.configuration.commandName, "my-executable")
+    }
+
+    static var allTests = [
+      ("testMyExecutable", testMyExecutable),
+    ]
+}

--- a/bzlmod/workspace/Tests/MyExecutableTests/main.swift
+++ b/bzlmod/workspace/Tests/MyExecutableTests/main.swift
@@ -1,0 +1,7 @@
+#if os(Linux)
+import XCTest
+
+XCTMain([
+    testCase(MyExecutableTests.allTests),
+])
+#endif


### PR DESCRIPTION
Showcases an issue with an `executableTarget` and a `testTarget` which depends on the executable. 

In this scenario gazelle plugin will generate a `swift_binary` and a `swift_test` accordingly. The `swift_test` will depend on `swift_binary` which leads a module not found build error:

```
Tests/MyExecutableTests/MyExecutableTests.swift:1:18: error: no such module 'MyExecutable'
@testable import MyExecutable
                 ^
```