### PR TITLE
chore: add more Xcode 14.3.1 CI exceptions

### DIFF
--- a/.github/actions/set_up_macos/action.yml
+++ b/.github/actions/set_up_macos/action.yml
@@ -18,8 +18,11 @@ runs:
     - name: Override Xcode Version
       shell: bash
       run: |
-        # GH762: Investigate why these examples fail on CI with Xcode 15
-        if [[ "${{ inputs.test_target }}" = "@@//examples:shake_ios_example_test_bazel_.bazelversion" ]] || 
+        # GH762: Investigate why these examples timeout on CI with Xcode 15
+        if [[ "${{ inputs.test_target }}" = "@@//examples:lottie_ios_example_test_bazel_.bazelversion" ]] ||
+           [[ "${{ inputs.test_target }}" = "@@//examples:messagekit_example_test_bazel_.bazelversion" ]] ||
+           [[ "${{ inputs.test_target }}" = "@@//examples:resources_example_test_bazel_.bazelversion" ]] ||
+           [[ "${{ inputs.test_target }}" = "@@//examples:shake_ios_example_test_bazel_.bazelversion" ]] ||
            [[ "${{ inputs.test_target }}" = "@@//examples:stripe_example_test_bazel_.bazelversion" ]]; then
           sudo xcode-select -s /Applications/Xcode_14.3.1.app/Contents/Developer
         fi


### PR DESCRIPTION
These are also occasionally timing out.

See the CI runs for https://github.com/cgrindel/rules_swift_package_manager/pull/755

Maybe Xcode 15.1 will improve things...