### PR TITLE
chore: add SwiftUIFlow to the resources_example

### DIFF
--- a/examples/resources_example/MODULE.bazel
+++ b/examples/resources_example/MODULE.bazel
@@ -52,5 +52,6 @@ use_repo(
     "swiftpkg_another_package_with_resources",
     "swiftpkg_googlesignin_ios",
     "swiftpkg_package_with_resources",
+    "swiftpkg_swiftuiflow",
 )
 # swift_deps END

--- a/examples/resources_example/Package.resolved
+++ b/examples/resources_example/Package.resolved
@@ -35,6 +35,14 @@
         "revision" : "cee3c709307912d040bd1e06ca919875a92339c6",
         "version" : "2.0.0"
       }
+    },
+    {
+      "identity" : "swiftuiflow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ciaranrobrien/SwiftUIFlow.git",
+      "state" : {
+        "revision" : "b300d3c0110116f3520066dfb8dcf3006cf593c3"
+      }
     }
   ],
   "version" : 2

--- a/examples/resources_example/Package.swift
+++ b/examples/resources_example/Package.swift
@@ -8,5 +8,9 @@ let package = Package(
         .package(path: "third_party/package_with_resources"),
         .package(path: "third_party/another_package_with_resources"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "7.0.0"),
+        .package(
+            url: "https://github.com/ciaranrobrien/SwiftUIFlow.git",
+            revision: "b300d3c0110116f3520066dfb8dcf3006cf593c3"
+        ),
     ]
 )

--- a/examples/resources_example/Sources/MyApp/BUILD.bazel
+++ b/examples/resources_example/Sources/MyApp/BUILD.bazel
@@ -14,6 +14,7 @@ swift_library(
         "@swiftpkg_another_package_with_resources//:MoreCoolUI",
         "@swiftpkg_googlesignin_ios//:GoogleSignInSwift_Sources_GoogleSignInSwift",
         "@swiftpkg_package_with_resources//:Sources_CoolUI",
+        "@swiftpkg_swiftuiflow//:Sources_SwiftUIFlow",
     ],
 )
 

--- a/examples/resources_example/Sources/MyApp/MyApp.swift
+++ b/examples/resources_example/Sources/MyApp/MyApp.swift
@@ -2,6 +2,7 @@ import CoolUI
 import GoogleSignInSwift
 import MoreCoolUI
 import SwiftUI
+import SwiftUIFlow
 
 @main
 struct MyApp: App {

--- a/examples/resources_example/swift_deps_index.json
+++ b/examples/resources_example/swift_deps_index.json
@@ -2,7 +2,8 @@
   "direct_dep_identities": [
     "another_package_with_resources",
     "googlesignin-ios",
-    "package_with_resources"
+    "package_with_resources",
+    "swiftuiflow"
   ],
   "modules": [
     {
@@ -121,6 +122,16 @@
       "product_memberships": [
         "CoolUI"
       ]
+    },
+    {
+      "name": "SwiftUIFlow",
+      "c99name": "SwiftUIFlow",
+      "src_type": "swift",
+      "label": "@swiftpkg_swiftuiflow//:Sources_SwiftUIFlow",
+      "package_identity": "swiftuiflow",
+      "product_memberships": [
+        "SwiftUIFlow"
+      ]
     }
   ],
   "products": [
@@ -220,6 +231,14 @@
       "target_labels": [
         "@swiftpkg_package_with_resources//:Sources_CoolUI"
       ]
+    },
+    {
+      "identity": "swiftuiflow",
+      "name": "SwiftUIFlow",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_swiftuiflow//:Sources_SwiftUIFlow"
+      ]
     }
   ],
   "packages": [
@@ -271,6 +290,14 @@
       "identity": "package_with_resources",
       "local": {
         "path": "third_party/package_with_resources"
+      }
+    },
+    {
+      "name": "swiftpkg_swiftuiflow",
+      "identity": "swiftuiflow",
+      "remote": {
+        "commit": "b300d3c0110116f3520066dfb8dcf3006cf593c3",
+        "remote": "https://github.com/ciaranrobrien/SwiftUIFlow.git"
       }
     }
   ]


### PR DESCRIPTION
Demonstrate that [SwiftUIFlow](https://github.com/ciaranrobrien/SwiftUIFlow) appears to work properly with `rules_swift_package_manager`.

Related to #732.