### PR TITLE
fix: only ignore `DEBUG` conditional compilation

### DIFF
--- a/examples/ios_sim/MODULE.bazel
+++ b/examples/ios_sim/MODULE.bazel
@@ -57,6 +57,7 @@ swift_deps.from_file(
 )
 use_repo(
     swift_deps,
+    "swiftpkg_rxswift",
     "swiftpkg_swift_markdown",
     "swiftpkg_swift_nio",
 )

--- a/examples/ios_sim/MODULE.bazel.lock
+++ b/examples/ios_sim/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "294537f485a65818616457441772bc83cb5ec5bdf1f6af0f4f8cdc58a0d8e07f",
+  "moduleFileHash": "e85bd1c42e23b2999f8b875e0f9e9e218e3ef56bf2325dfb5c8c1e1bc4c5f4cd",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -52,6 +52,7 @@
             "column": 27
           },
           "imports": {
+            "swiftpkg_rxswift": "swiftpkg_rxswift",
             "swiftpkg_swift_markdown": "swiftpkg_swift_markdown",
             "swiftpkg_swift_nio": "swiftpkg_swift_nio"
           },
@@ -3870,12 +3871,32 @@
     },
     "@@rules_swift_package_manager~override//:extensions.bzl%swift_deps": {
       "general": {
-        "bzlTransitiveDigest": "a13Oc0hXT+L5cvojiIZIfzIFXt+8RemLnU6Rf/kkLXI=",
+        "bzlTransitiveDigest": "Y8ckz+OYIxdrElO/RaUEkSoBbDPbzAWU3jxJtO+cq0w=",
         "accumulatedFileDigests": {
-          "@@//:swift_deps_index.json": "ca3d3f04faa5448d1f8359590d3bf246c9e50ae01395712912e7b281df986854"
+          "@@//:swift_deps_index.json": "dafe909d52a0a1b03c3533d3f1c56e565ad68fab371c0a7cd477fecf4240e72d"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
+          "swiftpkg_rxswift": {
+            "bzlFile": "@@rules_swift_package_manager~override//swiftpkg/internal:swift_package.bzl",
+            "ruleClassName": "swift_package",
+            "attributes": {
+              "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_rxswift",
+              "bazel_package_name": "swiftpkg_rxswift",
+              "commit": "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+              "remote": "https://github.com/ReactiveX/RxSwift.git",
+              "dependencies_index": "@@//:swift_deps_index.json",
+              "init_submodules": false,
+              "recursive_init_submodules": false,
+              "patch_args": [
+                "-p0"
+              ],
+              "patch_cmds": [],
+              "patch_cmds_win": [],
+              "patch_tool": "",
+              "patches": []
+            }
+          },
           "swiftpkg_swift_markdown": {
             "bzlFile": "@@rules_swift_package_manager~override//swiftpkg/internal:swift_package.bzl",
             "ruleClassName": "swift_package",
@@ -4135,6 +4156,41 @@
             "ruleClassName": "swift_autoconfiguration",
             "attributes": {
               "name": "rules_swift~1.13.0~non_module_deps~build_bazel_rules_swift_local_config"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_xcodeproj~1.15.0//xcodeproj:extensions.bzl%internal": {
+      "general": {
+        "bzlTransitiveDigest": "SSk2tc0T++1ic+3iwwPdiccTs6C+43dMisXSSrMFBkM=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_xcodeproj_generated": {
+            "bzlFile": "@@rules_xcodeproj~1.15.0//xcodeproj:repositories.bzl",
+            "ruleClassName": "generated_files_repo",
+            "attributes": {
+              "name": "rules_xcodeproj~1.15.0~internal~rules_xcodeproj_generated"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_xcodeproj~1.15.0//xcodeproj:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "SSk2tc0T++1ic+3iwwPdiccTs6C+43dMisXSSrMFBkM=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_xcodeproj_index_import": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_xcodeproj~1.15.0~non_module_deps~rules_xcodeproj_index_import",
+              "build_file_content": "load(\"@bazel_skylib//rules:native_binary.bzl\", \"native_binary\")\n\nnative_binary(\n    name = \"index_import\",\n    src = \"index-import\",\n    out = \"index-import\",\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15",
+              "url": "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
             }
           }
         }

--- a/examples/ios_sim/Package.resolved
+++ b/examples/ios_sim/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "version" : "6.6.0"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",

--- a/examples/ios_sim/Package.swift
+++ b/examples/ios_sim/Package.swift
@@ -7,5 +7,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", exact: "2.62.0"),
         .package(url: "https://github.com/apple/swift-markdown.git", exact: "0.3.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", exact: "6.6.0"),
     ]
 )

--- a/examples/ios_sim/Tests/FooTests/BUILD.bazel
+++ b/examples/ios_sim/Tests/FooTests/BUILD.bazel
@@ -11,6 +11,7 @@ swift_library(
     module_name = "FooTests",
     deps = [
         "//Sources/Foo",
+        "@swiftpkg_rxswift//:Sources_RxTest",
         "@swiftpkg_swift_markdown//:Sources_Markdown",
         "@swiftpkg_swift_nio//:Sources_NIO",
     ],

--- a/examples/ios_sim/Tests/FooTests/BarTests.swift
+++ b/examples/ios_sim/Tests/FooTests/BarTests.swift
@@ -1,5 +1,6 @@
 @testable import Foo
 import NIO
+import RxTest
 import XCTest
 
 class BarTests: XCTestCase {

--- a/examples/ios_sim/swift_deps_index.json
+++ b/examples/ios_sim/swift_deps_index.json
@@ -1,9 +1,87 @@
 {
   "direct_dep_identities": [
+    "rxswift",
     "swift-markdown",
     "swift-nio"
   ],
   "modules": [
+    {
+      "name": "RxBlocking",
+      "c99name": "RxBlocking",
+      "src_type": "swift",
+      "label": "@swiftpkg_rxswift//:Sources_RxBlocking",
+      "package_identity": "rxswift",
+      "product_memberships": [
+        "RxBlocking",
+        "RxBlocking-Dynamic"
+      ]
+    },
+    {
+      "name": "RxCocoa",
+      "c99name": "RxCocoa",
+      "src_type": "swift",
+      "label": "@swiftpkg_rxswift//:Sources_RxCocoa",
+      "modulemap_label": "@swiftpkg_rxswift//:Sources_RxCocoa_modulemap",
+      "package_identity": "rxswift",
+      "product_memberships": [
+        "RxCocoa",
+        "RxCocoa-Dynamic"
+      ]
+    },
+    {
+      "name": "RxCocoaRuntime",
+      "c99name": "RxCocoaRuntime",
+      "src_type": "objc",
+      "label": "@swiftpkg_rxswift//:Sources_RxCocoaRuntime",
+      "package_identity": "rxswift",
+      "product_memberships": [
+        "RxCocoa",
+        "RxCocoa-Dynamic"
+      ]
+    },
+    {
+      "name": "RxRelay",
+      "c99name": "RxRelay",
+      "src_type": "swift",
+      "label": "@swiftpkg_rxswift//:Sources_RxRelay",
+      "package_identity": "rxswift",
+      "product_memberships": [
+        "RxCocoa",
+        "RxRelay",
+        "RxCocoa-Dynamic",
+        "RxRelay-Dynamic"
+      ]
+    },
+    {
+      "name": "RxSwift",
+      "c99name": "RxSwift",
+      "src_type": "swift",
+      "label": "@swiftpkg_rxswift//:Sources_RxSwift",
+      "package_identity": "rxswift",
+      "product_memberships": [
+        "RxSwift",
+        "RxCocoa",
+        "RxRelay",
+        "RxBlocking",
+        "RxTest",
+        "RxSwift-Dynamic",
+        "RxCocoa-Dynamic",
+        "RxRelay-Dynamic",
+        "RxBlocking-Dynamic",
+        "RxTest-Dynamic"
+      ]
+    },
+    {
+      "name": "RxTest",
+      "c99name": "RxTest",
+      "src_type": "swift",
+      "label": "@swiftpkg_rxswift//:Sources_RxTest",
+      "package_identity": "rxswift",
+      "product_memberships": [
+        "RxTest",
+        "RxTest-Dynamic"
+      ]
+    },
     {
       "name": "Atomics",
       "c99name": "Atomics",
@@ -412,6 +490,86 @@
   ],
   "products": [
     {
+      "identity": "rxswift",
+      "name": "RxBlocking",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxBlocking"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxBlocking-Dynamic",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxBlocking"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxCocoa",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxCocoa"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxCocoa-Dynamic",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxCocoa"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxRelay",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxRelay"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxRelay-Dynamic",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxRelay"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxSwift",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxSwift"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxSwift-Dynamic",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxSwift"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxTest",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxTest"
+      ]
+    },
+    {
+      "identity": "rxswift",
+      "name": "RxTest-Dynamic",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_rxswift//:Sources_RxTest"
+      ]
+    },
+    {
       "identity": "swift-atomics",
       "name": "Atomics",
       "type": "library",
@@ -573,6 +731,15 @@
     }
   ],
   "packages": [
+    {
+      "name": "swiftpkg_rxswift",
+      "identity": "rxswift",
+      "remote": {
+        "commit": "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "remote": "https://github.com/ReactiveX/RxSwift.git",
+        "version": "6.6.0"
+      }
+    },
     {
       "name": "swiftpkg_swift_atomics",
       "identity": "swift-atomics",

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -794,6 +794,11 @@ def _new_swift_src_info_from_sources(
         if has_objc_directive and imports_xctest:
             break
 
+    # DEBUG BEGIN
+    imports_xctest = False
+
+    # DEBUG END
+
     # Find any auto-discoverable resources under the target
     all_target_files = repository_files.list_files_under(
         repository_ctx,

--- a/swiftpkg/internal/swift_files.bzl
+++ b/swiftpkg/internal/swift_files.bzl
@@ -135,6 +135,9 @@ def _collect_conditional_compilation(contents, idx):
 Did not find the end of the conditional compilation block starting at {}.\
 """.format(idx))
 
+# Then length of `#if` plus a single space
+_POUND_IF_OFFSET = 4
+
 def _is_code(contents, target_idx):
     skip_to = -1
     for idx in range(0, len(contents)):
@@ -160,7 +163,8 @@ def _is_code(contents, target_idx):
             elif _look_ahead(contents, idx, "/*") >= 0:
                 skip_to = _collect_multiline_comment(contents, idx)
         elif char == "#":
-            if _look_ahead(contents, idx, "#if") >= 0:
+            if _look_ahead(contents, idx, "#if") >= 0 and \
+               _look_ahead(contents, idx + _POUND_IF_OFFSET, "DEBUG") >= 0:
                 skip_to = _collect_conditional_compilation(contents, idx)
 
     return False

--- a/swiftpkg/tests/swift_files_tests.bzl
+++ b/swiftpkg/tests/swift_files_tests.bzl
@@ -144,7 +144,7 @@ import XCTest
             exp = True,
         ),
         struct(
-            msg = "inside conditional compilation",
+            msg = "inside DEBUG conditional compilation",
             imp = "XCTest",
             content = """\
 #if DEBUG
@@ -152,6 +152,28 @@ import XCTest
       import Chicken
     #endif
     import XCTest
+#endif
+""",
+            exp = False,
+        ),
+        struct(
+            msg = "inside non-DEBUG conditional compilation",
+            imp = "XCTest",
+            content = """\
+#if !os(watchOS)
+    import XCTest
+#endif
+""",
+            exp = True,
+        ),
+        struct(
+            msg = "inside multi-level non-DEBUG conditional compilation",
+            imp = "XCTest",
+            content = """\
+#if !os(watchOS)
+    #if DEBUG
+        import XCTest
+    #endif
 #endif
 """,
             exp = False,


### PR DESCRIPTION
When evaluating whether a source file has a certain import, we will only ignore imports in conditional compilation blocks if it is keying off of `DEBUG`.

- Add [RxSwift](https://github.com/ReactiveX/RxSwift) to the `ios_sim` example.
- Update `swift_files.has_import()` to only ignore code in a conditional compilation block if the evaluator is `DEBUG`.

Closes #791.