### PR TITLE
fix: do not load the index file in the gazelle plugin if not in fix or update mode

### DIFF
--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -28,6 +28,7 @@ func (*swiftLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) 
 
 	switch cmd {
 	case "fix", "update":
+		sc.ShouldLoadDependencyIndex = true
 		fs.StringVar(
 			&sc.ResolutionLogPath,
 			"resolution_log",
@@ -111,8 +112,10 @@ func (sl *swiftLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 
 	// Attempt to load the module index. This is created by update-repos if the client is using
 	// external Swift packages (e.g. swift_pacakge).
-	if err = sc.LoadDependencyIndex(); err != nil {
-		return err
+	if sc.ShouldLoadDependencyIndex {
+		if err = sc.LoadDependencyIndex(); err != nil {
+			return err
+		}
 	}
 	// Index any of repository rules (e.g. http_archive) that may contain Swift targets.
 	for _, r := range c.Repos {

--- a/gazelle/internal/swiftcfg/swift_config.go
+++ b/gazelle/internal/swiftcfg/swift_config.go
@@ -23,9 +23,10 @@ const (
 
 // A SwiftConfig represents the Swift-specific configuration for the Gazelle extension.
 type SwiftConfig struct {
-	SwiftBinPath         string
-	ModuleFilesCollector ModuleFilesCollector
-	DependencyIndex      *swift.DependencyIndex
+	SwiftBinPath              string
+	ModuleFilesCollector      ModuleFilesCollector
+	ShouldLoadDependencyIndex bool
+	DependencyIndex           *swift.DependencyIndex
 	// DependencyIndexRel is the path relative to the RepoRoot to the dependency index
 	DependencyIndexRel string
 	// DependencyIndexPath is the full path to the dependency index


### PR DESCRIPTION
The `update-repos` mode writes the file creating it from scratch. This makes the plugin more tolerant to index format changes.
