### PR TITLE
fix: recursively find all local Swift packages

### DIFF
--- a/examples/pkg_manifest_minimal/MODULE.bazel
+++ b/examples/pkg_manifest_minimal/MODULE.bazel
@@ -48,6 +48,7 @@ swift_deps.from_file(
 use_repo(
     swift_deps,
     "swiftpkg_my_local_package",
+    "swiftpkg_myamazingmodule",
     "swiftpkg_notthatamazingmodule",
     "swiftpkg_swift_argument_parser",
     "swiftpkg_swift_log",

--- a/examples/pkg_manifest_minimal/MODULE.bazel
+++ b/examples/pkg_manifest_minimal/MODULE.bazel
@@ -48,6 +48,7 @@ swift_deps.from_file(
 use_repo(
     swift_deps,
     "swiftpkg_my_local_package",
+    "swiftpkg_notthatamazingmodule",
     "swiftpkg_swift_argument_parser",
     "swiftpkg_swift_log",
     "swiftpkg_swiftformat",

--- a/examples/pkg_manifest_minimal/MODULE.bazel.lock
+++ b/examples/pkg_manifest_minimal/MODULE.bazel.lock
@@ -1723,7 +1723,14 @@
               "name": "apple_support~1.11.1~apple_cc_configure_extension~local_config_apple_cc_toolchains"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~1.11.1",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@bazel_features~1.3.0//private:extensions.bzl%version_extension": {
@@ -1751,12 +1758,13 @@
               }
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
+        "bzlTransitiveDigest": "mcsWHq3xORJexV5/4eCvNOLxFOQKV6eli3fkr+tEaqE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1774,7 +1782,14 @@
               "name": "bazel_tools~cc_configure_extension~local_config_cc_toolchains"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_tools",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
@@ -1792,7 +1807,8 @@
               "remote_xcode": ""
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
@@ -1808,12 +1824,13 @@
               "name": "bazel_tools~sh_configure_extension~local_config_sh"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@buildifier_prebuilt~6.0.0.1//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "rw0w83IFOd+utieoxefELpxmQT7CxmI9Bd1pKxwbgZE=",
+        "bzlTransitiveDigest": "e/ywZz1v92DyiMnlC9hasz8Co0tsLhzEkfjuKBqw0WY=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1929,7 +1946,19 @@
               "sha256": "9ffa62ea1f55f420c36eeef1427f71a34a5d24332cb861753b2b59c66d6343e2"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "buildifier_prebuilt~6.0.0.1",
+            "bazel_skylib",
+            "bazel_skylib~1.5.0"
+          ],
+          [
+            "buildifier_prebuilt~6.0.0.1",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@gazelle~0.35.0//:extensions.bzl%go_deps": {
@@ -2435,7 +2464,8 @@
           "explicitRootModuleDirectDeps": [],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO"
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@gazelle~0.35.0//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
@@ -2469,12 +2499,13 @@
               "go_env": {}
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_go~0.44.0//go:extensions.bzl%go_sdk": {
       "os:osx,arch:x86_64": {
-        "bzlTransitiveDigest": "HOJ7KCV+gzdiDP50kTBrioqp+Vdoj42MzmZF65s69fg=",
+        "bzlTransitiveDigest": "GI6yMOM2hDU7hVAHmfnV90TgIqJguaDlemn2az5C07E=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2641,7 +2672,34 @@
               "version": "1.21.1"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~1.3.0",
+            "bazel_features_globals",
+            "bazel_features~1.3.0~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~1.3.0",
+            "bazel_features_version",
+            "bazel_features~1.3.0~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~0.44.0",
+            "bazel_features",
+            "bazel_features~1.3.0"
+          ],
+          [
+            "rules_go~0.44.0",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go~0.44.0",
+            "io_bazel_rules_go",
+            "rules_go~0.44.0"
+          ]
+        ]
       },
       "os:linux,arch:amd64": {
         "bzlTransitiveDigest": "wAwW6XZIoVPOQe/IpXiRXSa2CpAwXsZu+j9Fz3NSdkg=",
@@ -2811,12 +2869,13 @@
               "version": "1.21.1"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_java~7.1.0//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "iUIRqCK7tkhvcDJCAfPPqSd06IHG0a8HQD0xeQyVAqw=",
+        "bzlTransitiveDigest": "D02GmifxnV/IhYgspsJMDZ/aE8HxAjXgek5gi6FSto4=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3351,14 +3410,26 @@
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\n"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java~7.1.0",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_java~7.1.0",
+            "remote_java_tools",
+            "rules_java~7.1.0~toolchains~remote_java_tools"
+          ]
+        ]
       }
     },
     "@@rules_swift_package_manager~override//:extensions.bzl%swift_deps": {
       "general": {
-        "bzlTransitiveDigest": "a13Oc0hXT+L5cvojiIZIfzIFXt+8RemLnU6Rf/kkLXI=",
+        "bzlTransitiveDigest": "OmiOT7B3ywH2LEV4ZCse+/mCMxCmJzCfvuAzIaohDpc=",
         "accumulatedFileDigests": {
-          "@@//:swift_deps_index.json": "0be2fd76c1955b0e51d3dbff726364802b4c9f89194d7c92f6a29371b2d129ee"
+          "@@//:swift_deps_index.json": "6edcfdfc2ce965f354e705f600ffc24b2022f1796fa7af2ea12ecf04389d635b"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3368,7 +3439,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_swiftformat",
               "bazel_package_name": "swiftpkg_swiftformat",
-              "commit": "cac06079ce883170ab44cb021faad298daeec2a5",
+              "commit": "fef156a6135e584985ed26713dd2e9ee41f952cb",
               "remote": "https://github.com/nicklockwood/SwiftFormat",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3398,7 +3469,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_swift_argument_parser",
               "bazel_package_name": "swiftpkg_swift_argument_parser",
-              "commit": "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+              "commit": "c8ed701b513cf5177118a175d85fbbbcd707ab41",
               "remote": "https://github.com/apple/swift-argument-parser",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3418,7 +3489,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_swift_log",
               "bazel_package_name": "swiftpkg_swift_log",
-              "commit": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+              "commit": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
               "remote": "https://github.com/apple/swift-log",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3432,7 +3503,195 @@
               "patches": []
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift_package_manager~override",
+            "bazel_skylib",
+            "bazel_skylib~1.5.0"
+          ],
+          [
+            "rules_swift_package_manager~override",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift_package_manager~override",
+            "cgrindel_bazel_starlib",
+            "cgrindel_bazel_starlib~0.19.0"
+          ]
+        ]
+      }
+    },
+    "@@rules_swift~1.15.1//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "JXT9csgB0VHkXU94H+OROIY4q5dpOW0Di+C2YoFqVTM=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_grpc_grpc_swift": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_grpc_grpc_swift",
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_extras",
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_protobuf",
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_ssl",
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_atomics",
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_http2",
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_transport_services",
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~build_bazel_rules_swift_index_import",
+              "build_file": "@@rules_swift~1.15.1//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio",
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_log",
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_collections",
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "bzlFile": "@@rules_swift~1.15.1//swift/internal:swift_autoconfiguration.bzl",
+            "ruleClassName": "swift_autoconfiguration",
+            "attributes": {
+              "name": "rules_swift~1.15.1~non_module_deps~build_bazel_rules_swift_local_config"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift~1.15.1",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift~1.15.1",
+            "build_bazel_rules_swift",
+            "rules_swift~1.15.1"
+          ]
+        ]
       }
     }
   }

--- a/examples/pkg_manifest_minimal/MODULE.bazel.lock
+++ b/examples/pkg_manifest_minimal/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "b5c7d18c8ee3075b2c71eb05f521692974d9f33cdeb7746aa8cd40885c200c65",
+  "moduleFileHash": "67cd70034750757a69bec989047d2ede8216726dd50017306f97fbc0fe9eda10",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -53,6 +53,7 @@
           },
           "imports": {
             "swiftpkg_my_local_package": "swiftpkg_my_local_package",
+            "swiftpkg_notthatamazingmodule": "swiftpkg_notthatamazingmodule",
             "swiftpkg_swift_argument_parser": "swiftpkg_swift_argument_parser",
             "swiftpkg_swift_log": "swiftpkg_swift_log",
             "swiftpkg_swiftformat": "swiftpkg_swiftformat"
@@ -3429,10 +3430,20 @@
       "general": {
         "bzlTransitiveDigest": "OmiOT7B3ywH2LEV4ZCse+/mCMxCmJzCfvuAzIaohDpc=",
         "accumulatedFileDigests": {
-          "@@//:swift_deps_index.json": "6edcfdfc2ce965f354e705f600ffc24b2022f1796fa7af2ea12ecf04389d635b"
+          "@@//:swift_deps_index.json": "c325e7c044577736ef25aa200a361e2ad69c90a5c134d95ba76b4ebaac42cbc3"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
+          "swiftpkg_notthatamazingmodule": {
+            "bzlFile": "@@rules_swift_package_manager~override//swiftpkg/internal:local_swift_package.bzl",
+            "ruleClassName": "local_swift_package",
+            "attributes": {
+              "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_notthatamazingmodule",
+              "bazel_package_name": "swiftpkg_notthatamazingmodule",
+              "path": "third_party/NotThatAmazingModule",
+              "dependencies_index": "@@//:swift_deps_index.json"
+            }
+          },
           "swiftpkg_swiftformat": {
             "bzlFile": "@@rules_swift_package_manager~override//swiftpkg/internal:swift_package.bzl",
             "ruleClassName": "swift_package",

--- a/examples/pkg_manifest_minimal/MODULE.bazel.lock
+++ b/examples/pkg_manifest_minimal/MODULE.bazel.lock
@@ -3428,7 +3428,7 @@
     },
     "@@rules_swift_package_manager~override//:extensions.bzl%swift_deps": {
       "general": {
-        "bzlTransitiveDigest": "OmiOT7B3ywH2LEV4ZCse+/mCMxCmJzCfvuAzIaohDpc=",
+        "bzlTransitiveDigest": "fQ4QEnw7wUS6PjXU5ISPiiwkZtsVlfcYdYom95RfGx8=",
         "accumulatedFileDigests": {
           "@@//:swift_deps_index.json": "c325e7c044577736ef25aa200a361e2ad69c90a5c134d95ba76b4ebaac42cbc3"
         },

--- a/examples/pkg_manifest_minimal/MODULE.bazel.lock
+++ b/examples/pkg_manifest_minimal/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "67cd70034750757a69bec989047d2ede8216726dd50017306f97fbc0fe9eda10",
+  "moduleFileHash": "ddb5bd14cb1859d2c02f2222fad02c0186ff9394b112ee8b41bc6a9a155cda46",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -53,6 +53,7 @@
           },
           "imports": {
             "swiftpkg_my_local_package": "swiftpkg_my_local_package",
+            "swiftpkg_myamazingmodule": "swiftpkg_myamazingmodule",
             "swiftpkg_notthatamazingmodule": "swiftpkg_notthatamazingmodule",
             "swiftpkg_swift_argument_parser": "swiftpkg_swift_argument_parser",
             "swiftpkg_swift_log": "swiftpkg_swift_log",
@@ -3428,9 +3429,9 @@
     },
     "@@rules_swift_package_manager~override//:extensions.bzl%swift_deps": {
       "general": {
-        "bzlTransitiveDigest": "fQ4QEnw7wUS6PjXU5ISPiiwkZtsVlfcYdYom95RfGx8=",
+        "bzlTransitiveDigest": "RAXmIOdYeEgAIU2uKKJFxO3Uqo7xvnGxHmOD276y14c=",
         "accumulatedFileDigests": {
-          "@@//:swift_deps_index.json": "c325e7c044577736ef25aa200a361e2ad69c90a5c134d95ba76b4ebaac42cbc3"
+          "@@//:swift_deps_index.json": "b64b8be73263a8636a1cdf9c75ba7e82bb94c3f0b4d42b6c981eb3afa2afac67"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3471,6 +3472,16 @@
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_my_local_package",
               "bazel_package_name": "swiftpkg_my_local_package",
               "path": "third_party/my_local_package",
+              "dependencies_index": "@@//:swift_deps_index.json"
+            }
+          },
+          "swiftpkg_myamazingmodule": {
+            "bzlFile": "@@rules_swift_package_manager~override//swiftpkg/internal:local_swift_package.bzl",
+            "ruleClassName": "local_swift_package",
+            "attributes": {
+              "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_myamazingmodule",
+              "bazel_package_name": "swiftpkg_myamazingmodule",
+              "path": "third_party/MyAmazingModule",
               "dependencies_index": "@@//:swift_deps_index.json"
             }
           },

--- a/examples/pkg_manifest_minimal/Package.swift
+++ b/examples/pkg_manifest_minimal/Package.swift
@@ -9,5 +9,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.5.4"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.53.1"),
         .package(path: "third_party/my_local_package"),
+        .package(path: "third_party/NotThatAmazingModule"),
     ]
 )

--- a/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
@@ -8,6 +8,7 @@ swift_binary(
     deps = [
         "//Sources/MyLibrary",
         "@swiftpkg_my_local_package//:Sources_GreetingsFramework",
+        "@swiftpkg_notthatamazingmodule//:Sources_NotThatAmazingModule",
         "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser",
     ],
 )

--- a/examples/pkg_manifest_minimal/Sources/MyExecutable/MyExecutable.swift
+++ b/examples/pkg_manifest_minimal/Sources/MyExecutable/MyExecutable.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import GreetingsFramework
-import MyAmazingModule
 import MyLibrary
+import NotThatAmazingModule
 
 @main
 struct MyExecutable: AsyncParsableCommand {

--- a/examples/pkg_manifest_minimal/Sources/MyExecutable/MyExecutable.swift
+++ b/examples/pkg_manifest_minimal/Sources/MyExecutable/MyExecutable.swift
@@ -1,11 +1,15 @@
 import ArgumentParser
 import GreetingsFramework
+import MyAmazingModule
 import MyLibrary
 
 @main
 struct MyExecutable: AsyncParsableCommand {
     mutating func run() async throws {
-        let ng = NamedGreeting(MorningGreeting(), World())
-        print(ng.value)
+        let namedGreeting = NamedGreeting(MorningGreeting(), World())
+        print(namedGreeting.value)
+
+        let complexClass = ComplexClass(name: "Olivia", age: 30, favoriteColors: ["blue"])
+        print(complexClass.greet())
     }
 }

--- a/examples/pkg_manifest_minimal/swift_deps_index.json
+++ b/examples/pkg_manifest_minimal/swift_deps_index.json
@@ -1,6 +1,7 @@
 {
   "direct_dep_identities": [
     "my_local_package",
+    "myamazingmodule",
     "notthatamazingmodule",
     "swift-argument-parser",
     "swift-log",
@@ -26,6 +27,16 @@
       "package_identity": "my_local_package",
       "product_memberships": [
         "print-greeting"
+      ]
+    },
+    {
+      "name": "MyAmazingModule",
+      "c99name": "MyAmazingModule",
+      "src_type": "swift",
+      "label": "@swiftpkg_myamazingmodule//:Sources_MyAmazingModule",
+      "package_identity": "myamazingmodule",
+      "product_memberships": [
+        "MyAmazingModule"
       ]
     },
     {
@@ -143,6 +154,14 @@
       ]
     },
     {
+      "identity": "myamazingmodule",
+      "name": "MyAmazingModule",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_myamazingmodule//:Sources_MyAmazingModule"
+      ]
+    },
+    {
       "identity": "notthatamazingmodule",
       "name": "NotThatAmazingModule",
       "type": "library",
@@ -205,6 +224,13 @@
       "identity": "my_local_package",
       "local": {
         "path": "third_party/my_local_package"
+      }
+    },
+    {
+      "name": "swiftpkg_myamazingmodule",
+      "identity": "myamazingmodule",
+      "local": {
+        "path": "third_party/MyAmazingModule"
       }
     },
     {

--- a/examples/pkg_manifest_minimal/swift_deps_index.json
+++ b/examples/pkg_manifest_minimal/swift_deps_index.json
@@ -1,6 +1,7 @@
 {
   "direct_dep_identities": [
     "my_local_package",
+    "notthatamazingmodule",
     "swift-argument-parser",
     "swift-log",
     "swiftformat"
@@ -25,6 +26,16 @@
       "package_identity": "my_local_package",
       "product_memberships": [
         "print-greeting"
+      ]
+    },
+    {
+      "name": "NotThatAmazingModule",
+      "c99name": "NotThatAmazingModule",
+      "src_type": "swift",
+      "label": "@swiftpkg_notthatamazingmodule//:Sources_NotThatAmazingModule",
+      "package_identity": "notthatamazingmodule",
+      "product_memberships": [
+        "NotThatAmazingModule"
       ]
     },
     {
@@ -132,6 +143,14 @@
       ]
     },
     {
+      "identity": "notthatamazingmodule",
+      "name": "NotThatAmazingModule",
+      "type": "library",
+      "target_labels": [
+        "@swiftpkg_notthatamazingmodule//:Sources_NotThatAmazingModule"
+      ]
+    },
+    {
       "identity": "swift-argument-parser",
       "name": "ArgumentParser",
       "type": "library",
@@ -186,6 +205,13 @@
       "identity": "my_local_package",
       "local": {
         "path": "third_party/my_local_package"
+      }
+    },
+    {
+      "name": "swiftpkg_notthatamazingmodule",
+      "identity": "notthatamazingmodule",
+      "local": {
+        "path": "third_party/NotThatAmazingModule"
       }
     },
     {

--- a/examples/pkg_manifest_minimal/third_party/MyAmazingModule/.gitignore
+++ b/examples/pkg_manifest_minimal/third_party/MyAmazingModule/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/examples/pkg_manifest_minimal/third_party/MyAmazingModule/Package.swift
+++ b/examples/pkg_manifest_minimal/third_party/MyAmazingModule/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MyAmazingModule",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "MyAmazingModule",
+            targets: ["MyAmazingModule"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "MyAmazingModule"),
+        .testTarget(
+            name: "MyAmazingModuleTests",
+            dependencies: ["MyAmazingModule"]),
+    ]
+)

--- a/examples/pkg_manifest_minimal/third_party/MyAmazingModule/Sources/MyAmazingModule/MyAmazingModule.swift
+++ b/examples/pkg_manifest_minimal/third_party/MyAmazingModule/Sources/MyAmazingModule/MyAmazingModule.swift
@@ -1,0 +1,14 @@
+public class QuickSort {
+    public init() {}
+
+    public func sort(_ array: [Int]) -> [Int] {
+        if array.count <= 1 { return array }
+
+        let pivot = array[array.count/2]
+        let less = array.filter { $0 < pivot }
+        let equal = array.filter { $0 == pivot }
+        let greater = array.filter { $0 > pivot }
+
+        return sort(less) + equal + sort(greater)
+    }
+}

--- a/examples/pkg_manifest_minimal/third_party/MyAmazingModule/Tests/MyAmazingModuleTests/MyAmazingModuleTests.swift
+++ b/examples/pkg_manifest_minimal/third_party/MyAmazingModule/Tests/MyAmazingModuleTests/MyAmazingModuleTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import MyAmazingModule
+
+final class MyAmazingModuleTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}

--- a/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/.gitignore
+++ b/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Package.swift
+++ b/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NotThatAmazingModule",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "NotThatAmazingModule",
+            targets: ["NotThatAmazingModule"]
+        ),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(path: "../MyAmazingModule"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "NotThatAmazingModule",
+            dependencies: ["MyAmazingModule"]
+        ),
+        .testTarget(
+            name: "NotThatAmazingModuleTests",
+            dependencies: ["NotThatAmazingModule"]
+        ),
+    ]
+)

--- a/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Sources/NotThatAmazingModule/NotThatAmazingModule.swift
+++ b/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Sources/NotThatAmazingModule/NotThatAmazingModule.swift
@@ -1,25 +1,24 @@
 import MyAmazingModule
 
-
 public class ComplexClass {
     var name: String
     var age: Int
     var favoriteColors: [String]
-    
+
     public init(name: String, age: Int, favoriteColors: [String]) {
         self.name = name
         self.age = age
         self.favoriteColors = favoriteColors
     }
-    
+
     public func greet() {
         print("Hello, my name is \(name) and I'm \(age) years old.")
     }
-    
+
     public func addFavoriteColor(color: String) {
         favoriteColors.append(color)
     }
-    
+
     public func removeFavoriteColor(color: String) {
         favoriteColors.removeAll { $0 == color }
     }

--- a/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Sources/NotThatAmazingModule/NotThatAmazingModule.swift
+++ b/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Sources/NotThatAmazingModule/NotThatAmazingModule.swift
@@ -1,0 +1,32 @@
+import MyAmazingModule
+
+
+public class ComplexClass {
+    var name: String
+    var age: Int
+    var favoriteColors: [String]
+    
+    public init(name: String, age: Int, favoriteColors: [String]) {
+        self.name = name
+        self.age = age
+        self.favoriteColors = favoriteColors
+    }
+    
+    public func greet() {
+        print("Hello, my name is \(name) and I'm \(age) years old.")
+    }
+    
+    public func addFavoriteColor(color: String) {
+        favoriteColors.append(color)
+    }
+    
+    public func removeFavoriteColor(color: String) {
+        favoriteColors.removeAll { $0 == color }
+    }
+
+    public func sortFavoriteColors() {
+        let colorCodes = favoriteColors.map { $0.hashValue }
+        let sortedColorCodes = MyAmazingModule.QuickSort().sort(colorCodes)
+        favoriteColors = sortedColorCodes.map { String(describing: $0) }
+    }
+}

--- a/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Tests/NotThatAmazingModuleTests/NotThatAmazingModuleTests.swift
+++ b/examples/pkg_manifest_minimal/third_party/NotThatAmazingModule/Tests/NotThatAmazingModuleTests/NotThatAmazingModuleTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import NotThatAmazingModule
+
+final class NotThatAmazingModuleTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}

--- a/swiftpkg/tests/pkginfo_ext_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_ext_deps_tests.bzl
@@ -7,31 +7,11 @@ load("//swiftpkg/internal:pkginfos.bzl", "pkginfos")
 _swift_arg_parser = pkginfos.new_dependency(
     identity = "swift-argument-parser",
     name = "SwiftArgumentParser",
-    type = "sourceControl",
-    url = "https://github.com/apple/swift-argument-parser",
-    requirement = pkginfos.new_dependency_requirement(
-        ranges = [
-            pkginfos.new_version_range(
-                lower = "1.2.0",
-                upper = "2.0.0",
-            ),
-        ],
-    ),
 )
 
 _super_cool_pkg = pkginfos.new_dependency(
     identity = "super-cool-package",
     name = "SuperCoolPackage",
-    type = "sourceControl",
-    url = "https://github.com/example/super-cool-package",
-    requirement = pkginfos.new_dependency_requirement(
-        ranges = [
-            pkginfos.new_version_range(
-                lower = "0.0.0",
-                upper = "1.0.0",
-            ),
-        ],
-    ),
 )
 
 _ext_deps = [_swift_arg_parser, _super_cool_pkg]

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -22,13 +22,6 @@ pkginfo_target_deps = make_pkginfo_target_deps(
 _external_dep = pkginfos.new_dependency(
     identity = "example-swift-package",
     name = "ASwiftPackage",
-    type = "sourceControl",
-    url = "https://github.com/example/swift-package",
-    requirement = pkginfos.new_dependency_requirement(
-        ranges = [
-            pkginfos.new_version_range("1.2.0", "2.0.0"),
-        ],
-    ),
 )
 
 _target_by_name = pkginfos.new_by_name_reference("Baz")

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -30,13 +30,6 @@ def _new_from_parsed_json_for_swift_targets_test(ctx):
             pkginfos.new_dependency(
                 identity = "swift-argument-parser",
                 name = "SwiftArgumentParser",
-                type = "sourceControl",
-                url = "https://github.com/apple/swift-argument-parser",
-                requirement = pkginfos.new_dependency_requirement(
-                    ranges = [
-                        pkginfos.new_version_range("1.2.0", "2.0.0"),
-                    ],
-                ),
             ),
         ],
         products = [

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -38,13 +38,6 @@ _pkg_info = pkginfos.new(
         pkginfos.new_dependency(
             identity = "swift-argument-parser",
             name = "SwiftArgumentParser",
-            type = "sourceControl",
-            url = "https://github.com/apple/swift-argument-parser.git",
-            requirement = pkginfos.new_dependency_requirement(
-                ranges = [
-                    pkginfos.new_version_range("0.3.1", "0.4.0"),
-                ],
-            ),
         ),
     ],
     products = [


### PR DESCRIPTION
A local Swift package could have local Swift packages. We need find those and include them in the list of dependencies.

- Incorporate @brentleyjones fix from #876 to better handle file system dependencies in the Starlark code.
- Update the Gazelle plugin's `update-repos` action to recursively find all of the file system dependencies.
- Add example of a local package that has a local package dependency to `pkg_manifest_minimal`. Thanks to @lucasmarcal-faire for providing a repro that was the basis for this modification.

Closes #868.
Closes #876.