### PR TITLE
feat: use `swift_library_group` for library products

### DIFF
--- a/examples/firebase_example/abtesting/SharedApp/BUILD.bazel
+++ b/examples/firebase_example/abtesting/SharedApp/BUILD.bazel
@@ -16,7 +16,7 @@ swift_library(
         # app. This example does not compile without it.
         # https://firebase.google.com/docs/ios/setup#add-sdks
         # keep
-        "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig_Swift_FirebaseRemoteConfig",
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsSwiftWrap_FirebaseAnalyticsSwiftTarget",  # keep
+        "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsSwift",  # keep
+        "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig",
     ],
 )

--- a/examples/firebase_example/analytics/AnalyticsExample/BUILD.bazel
+++ b/examples/firebase_example/analytics/AnalyticsExample/BUILD.bazel
@@ -18,7 +18,7 @@ swift_library(
     module_name = "AnalyticsExample",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = ["@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsWithoutAdIdSupportWrap_FirebaseAnalyticsWithoutAdIdSupportTarget"],
+    deps = ["@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWithoutAdIdSupport"],
 )
 
 ios_application(

--- a/examples/firebase_example/appdistribution/AppDistributionExample/BUILD.bazel
+++ b/examples/firebase_example/appdistribution/AppDistributionExample/BUILD.bazel
@@ -13,7 +13,7 @@ swift_library(
     visibility = ["//visibility:public"],
     # GH202: Incomplete deps are generated.
     deps = [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAppDistributionWrap_FirebaseAppDistributionTarget",
+        "@swiftpkg_firebase_ios_sdk//:FirebaseAppDistribution-Beta",
     ],
 )
 

--- a/examples/firebase_example/crashlytics/BUILD.bazel
+++ b/examples/firebase_example/crashlytics/BUILD.bazel
@@ -17,8 +17,8 @@ swift_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
-        "@swiftpkg_firebase_ios_sdk//:Crashlytics_FirebaseCrashlytics",
-        "@swiftpkg_reachability.swift//:Sources_Reachability",
+        "@swiftpkg_firebase_ios_sdk//:FirebaseCrashlytics",
+        "@swiftpkg_reachability.swift//:Reachability",
     ],
 )
 

--- a/examples/firebase_example/swift_deps_index.json
+++ b/examples/firebase_example/swift_deps_index.json
@@ -8,7 +8,7 @@
       "name": "abseil",
       "c99name": "abseil",
       "src_type": "binary",
-      "label": "@swiftpkg_abseil_cpp_binary//:remote_archive_abseil.zip_abseil",
+      "label": "@swiftpkg_abseil_cpp_binary//:abseil.rspm",
       "package_identity": "abseil-cpp-binary",
       "product_memberships": [
         "abseil"
@@ -18,7 +18,7 @@
       "name": "AppCheckCore",
       "c99name": "AppCheckCore",
       "src_type": "objc",
-      "label": "@swiftpkg_app_check//:AppCheckCore_Sources_AppCheckCore",
+      "label": "@swiftpkg_app_check//:AppCheckCore.rspm",
       "package_identity": "app-check",
       "product_memberships": [
         "AppCheckCore"
@@ -28,7 +28,279 @@
       "name": "Firebase",
       "c99name": "Firebase",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:CoreOnly_Sources_Firebase",
+      "label": "@swiftpkg_firebase_ios_sdk//:Firebase.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalytics",
+        "FirebaseAnalyticsWithoutAdIdSupport",
+        "FirebaseAnalyticsSwift",
+        "FirebaseAuth",
+        "FirebaseAppCheck",
+        "FirebaseAppDistribution-Beta",
+        "FirebaseAuthCombine-Community",
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFunctionsCombine-Community",
+        "FirebaseStorageCombine-Community",
+        "FirebaseCrashlytics",
+        "FirebaseDatabase",
+        "FirebaseDatabaseSwift",
+        "FirebaseDynamicLinks",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift",
+        "FirebaseFunctions",
+        "FirebaseInAppMessaging-Beta",
+        "FirebaseInAppMessagingSwift-Beta",
+        "FirebaseInstallations",
+        "FirebaseMessaging",
+        "FirebaseMLModelDownloader",
+        "FirebasePerformance",
+        "FirebaseRemoteConfig",
+        "FirebaseRemoteConfigSwift",
+        "FirebaseStorage"
+      ]
+    },
+    {
+      "name": "FirebaseABTesting",
+      "c99name": "FirebaseABTesting",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseABTesting.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseInAppMessaging-Beta",
+        "FirebaseInAppMessagingSwift-Beta",
+        "FirebasePerformance",
+        "FirebaseRemoteConfig",
+        "FirebaseRemoteConfigSwift"
+      ]
+    },
+    {
+      "name": "FirebaseAnalytics",
+      "c99name": "FirebaseAnalytics",
+      "src_type": "binary",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalytics.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalytics",
+        "FirebaseAnalyticsWithoutAdIdSupport",
+        "FirebaseAnalyticsSwift"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsOnDeviceConversionTarget",
+      "c99name": "FirebaseAnalyticsOnDeviceConversionTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsOnDeviceConversionTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalyticsOnDeviceConversion"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsSwift",
+      "c99name": "FirebaseAnalyticsSwift",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsSwift.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalyticsSwift"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsSwiftTarget",
+      "c99name": "FirebaseAnalyticsSwiftTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsSwiftTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalyticsSwift"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsTarget",
+      "c99name": "FirebaseAnalyticsTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalytics"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsWithoutAdIdSupportTarget",
+      "c99name": "FirebaseAnalyticsWithoutAdIdSupportTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWithoutAdIdSupportTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalyticsWithoutAdIdSupport"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsWithoutAdIdSupportWrapper",
+      "c99name": "FirebaseAnalyticsWithoutAdIdSupportWrapper",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWithoutAdIdSupportWrapper.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalyticsWithoutAdIdSupport"
+      ]
+    },
+    {
+      "name": "FirebaseAnalyticsWrapper",
+      "c99name": "FirebaseAnalyticsWrapper",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWrapper.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalytics",
+        "FirebaseAnalyticsSwift"
+      ]
+    },
+    {
+      "name": "FirebaseAppCheck",
+      "c99name": "FirebaseAppCheck",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppCheck.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAppCheck"
+      ]
+    },
+    {
+      "name": "FirebaseAppCheckInterop",
+      "c99name": "FirebaseAppCheckInterop",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppCheckInterop.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAuth",
+        "FirebaseAppCheck",
+        "FirebaseAuthCombine-Community",
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFunctionsCombine-Community",
+        "FirebaseStorageCombine-Community",
+        "FirebaseDatabase",
+        "FirebaseDatabaseSwift",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift",
+        "FirebaseFunctions",
+        "FirebaseStorage"
+      ]
+    },
+    {
+      "name": "FirebaseAppDistribution",
+      "c99name": "FirebaseAppDistribution",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppDistribution.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAppDistribution-Beta"
+      ]
+    },
+    {
+      "name": "FirebaseAppDistributionTarget",
+      "c99name": "FirebaseAppDistributionTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppDistributionTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAppDistribution-Beta"
+      ]
+    },
+    {
+      "name": "FirebaseAuth",
+      "c99name": "FirebaseAuth",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuth.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAuth",
+        "FirebaseAuthCombine-Community"
+      ]
+    },
+    {
+      "name": "FirebaseAuthCombineSwift",
+      "c99name": "FirebaseAuthCombineSwift",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuthCombineSwift.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuthCombineSwift.rspm_modulemap",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAuthCombine-Community"
+      ]
+    },
+    {
+      "name": "FirebaseAuthInterop",
+      "c99name": "FirebaseAuthInterop",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuthInterop.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFunctionsCombine-Community",
+        "FirebaseStorageCombine-Community",
+        "FirebaseFunctions",
+        "FirebaseStorage"
+      ]
+    },
+    {
+      "name": "FirebaseCore",
+      "c99name": "FirebaseCore",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCore.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseAnalytics",
+        "FirebaseAnalyticsWithoutAdIdSupport",
+        "FirebaseAnalyticsSwift",
+        "FirebaseAuth",
+        "FirebaseAppCheck",
+        "FirebaseAppDistribution-Beta",
+        "FirebaseAuthCombine-Community",
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFunctionsCombine-Community",
+        "FirebaseStorageCombine-Community",
+        "FirebaseCrashlytics",
+        "FirebaseDatabase",
+        "FirebaseDatabaseSwift",
+        "FirebaseDynamicLinks",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift",
+        "FirebaseFunctions",
+        "FirebaseInAppMessaging-Beta",
+        "FirebaseInAppMessagingSwift-Beta",
+        "FirebaseInstallations",
+        "FirebaseMessaging",
+        "FirebaseMLModelDownloader",
+        "FirebasePerformance",
+        "FirebaseRemoteConfig",
+        "FirebaseRemoteConfigSwift",
+        "FirebaseStorage"
+      ]
+    },
+    {
+      "name": "FirebaseCoreExtension",
+      "c99name": "FirebaseCoreExtension",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCoreExtension.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFunctionsCombine-Community",
+        "FirebaseStorageCombine-Community",
+        "FirebaseCrashlytics",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift",
+        "FirebaseFunctions",
+        "FirebasePerformance",
+        "FirebaseStorage"
+      ]
+    },
+    {
+      "name": "FirebaseCoreInternal",
+      "c99name": "FirebaseCoreInternal",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCoreInternal.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseCoreInternal.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseAnalytics",
@@ -63,272 +335,21 @@
       "name": "FirebaseCrashlytics",
       "c99name": "FirebaseCrashlytics",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:Crashlytics_FirebaseCrashlytics",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCrashlytics.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseCrashlytics"
       ]
     },
     {
-      "name": "FirebaseABTesting",
-      "c99name": "FirebaseABTesting",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseABTesting_Sources_FirebaseABTesting",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseInAppMessaging-Beta",
-        "FirebaseInAppMessagingSwift-Beta",
-        "FirebasePerformance",
-        "FirebaseRemoteConfig",
-        "FirebaseRemoteConfigSwift"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsOnDeviceConversionTarget",
-      "c99name": "FirebaseAnalyticsOnDeviceConversionTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsOnDeviceConversionWrapper_FirebaseAnalyticsOnDeviceConversionTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalyticsOnDeviceConversion"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsSwift",
-      "c99name": "FirebaseAnalyticsSwift",
+      "name": "FirebaseDatabase",
+      "c99name": "FirebaseDatabase",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsSwift_Sources_FirebaseAnalyticsSwift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
-        "FirebaseAnalyticsSwift"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsWithoutAdIdSupportWrapper",
-      "c99name": "FirebaseAnalyticsWithoutAdIdSupportWrapper",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWithoutAdIdSupportWrapper_FirebaseAnalyticsWithoutAdIdSupportWrapper",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalyticsWithoutAdIdSupport"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsWrapper",
-      "c99name": "FirebaseAnalyticsWrapper",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWrapper_FirebaseAnalyticsWrapper",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalytics",
-        "FirebaseAnalyticsSwift"
-      ]
-    },
-    {
-      "name": "FirebaseAppCheckInterop",
-      "c99name": "FirebaseAppCheckInterop",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppCheck_Interop_FirebaseAppCheckInterop",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAuth",
-        "FirebaseAppCheck",
-        "FirebaseAuthCombine-Community",
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFunctionsCombine-Community",
-        "FirebaseStorageCombine-Community",
         "FirebaseDatabase",
-        "FirebaseDatabaseSwift",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift",
-        "FirebaseFunctions",
-        "FirebaseStorage"
-      ]
-    },
-    {
-      "name": "FirebaseAppCheck",
-      "c99name": "FirebaseAppCheck",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppCheck_Sources_FirebaseAppCheck",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAppCheck"
-      ]
-    },
-    {
-      "name": "FirebaseAppDistribution",
-      "c99name": "FirebaseAppDistribution",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppDistribution_Sources_FirebaseAppDistribution",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAppDistribution-Beta"
-      ]
-    },
-    {
-      "name": "FirebaseAuthInterop",
-      "c99name": "FirebaseAuthInterop",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuth_Interop_FirebaseAuthInterop",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFunctionsCombine-Community",
-        "FirebaseStorageCombine-Community",
-        "FirebaseFunctions",
-        "FirebaseStorage"
-      ]
-    },
-    {
-      "name": "FirebaseAuth",
-      "c99name": "FirebaseAuth",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuth_Sources_FirebaseAuth",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAuth",
-        "FirebaseAuthCombine-Community"
-      ]
-    },
-    {
-      "name": "FirebaseAuthCombineSwift",
-      "c99name": "FirebaseAuthCombineSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Auth_FirebaseAuthCombineSwift",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Auth_FirebaseAuthCombineSwift_modulemap",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAuthCombine-Community"
-      ]
-    },
-    {
-      "name": "FirebaseFirestoreCombineSwift",
-      "c99name": "FirebaseFirestoreCombineSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Firestore_FirebaseFirestoreCombineSwift",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Firestore_FirebaseFirestoreCombineSwift_modulemap",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFirestoreCombine-Community"
-      ]
-    },
-    {
-      "name": "FirebaseFunctionsCombineSwift",
-      "c99name": "FirebaseFunctionsCombineSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Functions_FirebaseFunctionsCombineSwift",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Functions_FirebaseFunctionsCombineSwift_modulemap",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFunctionsCombine-Community"
-      ]
-    },
-    {
-      "name": "FirebaseStorageCombineSwift",
-      "c99name": "FirebaseStorageCombineSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Storage_FirebaseStorageCombineSwift",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Storage_FirebaseStorageCombineSwift_modulemap",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseStorageCombine-Community"
-      ]
-    },
-    {
-      "name": "FirebaseCoreExtension",
-      "c99name": "FirebaseCoreExtension",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCore_Extension_FirebaseCoreExtension",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFunctionsCombine-Community",
-        "FirebaseStorageCombine-Community",
-        "FirebaseCrashlytics",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift",
-        "FirebaseFunctions",
-        "FirebasePerformance",
-        "FirebaseStorage"
-      ]
-    },
-    {
-      "name": "FirebaseCoreInternal",
-      "c99name": "FirebaseCoreInternal",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCore_Internal_Sources_FirebaseCoreInternal",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseCore_Internal_Sources_FirebaseCoreInternal_modulemap",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalytics",
-        "FirebaseAnalyticsWithoutAdIdSupport",
-        "FirebaseAnalyticsSwift",
-        "FirebaseAuth",
-        "FirebaseAppCheck",
-        "FirebaseAppDistribution-Beta",
-        "FirebaseAuthCombine-Community",
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFunctionsCombine-Community",
-        "FirebaseStorageCombine-Community",
-        "FirebaseCrashlytics",
-        "FirebaseDatabase",
-        "FirebaseDatabaseSwift",
-        "FirebaseDynamicLinks",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift",
-        "FirebaseFunctions",
-        "FirebaseInAppMessaging-Beta",
-        "FirebaseInAppMessagingSwift-Beta",
-        "FirebaseInstallations",
-        "FirebaseMessaging",
-        "FirebaseMLModelDownloader",
-        "FirebasePerformance",
-        "FirebaseRemoteConfig",
-        "FirebaseRemoteConfigSwift",
-        "FirebaseStorage"
-      ]
-    },
-    {
-      "name": "FirebaseCore",
-      "c99name": "FirebaseCore",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCore_Sources_FirebaseCore",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalytics",
-        "FirebaseAnalyticsWithoutAdIdSupport",
-        "FirebaseAnalyticsSwift",
-        "FirebaseAuth",
-        "FirebaseAppCheck",
-        "FirebaseAppDistribution-Beta",
-        "FirebaseAuthCombine-Community",
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFunctionsCombine-Community",
-        "FirebaseStorageCombine-Community",
-        "FirebaseCrashlytics",
-        "FirebaseDatabase",
-        "FirebaseDatabaseSwift",
-        "FirebaseDynamicLinks",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift",
-        "FirebaseFunctions",
-        "FirebaseInAppMessaging-Beta",
-        "FirebaseInAppMessagingSwift-Beta",
-        "FirebaseInstallations",
-        "FirebaseMessaging",
-        "FirebaseMLModelDownloader",
-        "FirebasePerformance",
-        "FirebaseRemoteConfig",
-        "FirebaseRemoteConfigSwift",
-        "FirebaseStorage"
-      ]
-    },
-    {
-      "name": "FirebaseDatabaseSwift",
-      "c99name": "FirebaseDatabaseSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabaseSwift_Sources_FirebaseDatabaseSwift",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
         "FirebaseDatabaseSwift"
       ]
     },
@@ -336,7 +357,7 @@
       "name": "FirebaseDatabaseInternal",
       "c99name": "FirebaseDatabaseInternal",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase_Sources_FirebaseDatabaseInternal",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabaseInternal.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseDatabase",
@@ -344,14 +365,12 @@
       ]
     },
     {
-      "name": "FirebaseDatabase",
-      "c99name": "FirebaseDatabase",
+      "name": "FirebaseDatabaseSwift",
+      "c99name": "FirebaseDatabaseSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase_Swift_Sources_FirebaseDatabase",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase_Swift_Sources_FirebaseDatabase_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabaseSwift.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
-        "FirebaseDatabase",
         "FirebaseDatabaseSwift"
       ]
     },
@@ -359,17 +378,63 @@
       "name": "FirebaseDynamicLinks",
       "c99name": "FirebaseDynamicLinks",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDynamicLinks_Sources_FirebaseDynamicLinks",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDynamicLinks.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseDynamicLinks"
       ]
     },
     {
+      "name": "FirebaseDynamicLinksTarget",
+      "c99name": "FirebaseDynamicLinksTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDynamicLinksTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseDynamicLinks"
+      ]
+    },
+    {
+      "name": "FirebaseFirestore",
+      "c99name": "FirebaseFirestore",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestore.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestore.rspm_modulemap",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift"
+      ]
+    },
+    {
+      "name": "FirebaseFirestoreCombineSwift",
+      "c99name": "FirebaseFirestoreCombineSwift",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreCombineSwift.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreCombineSwift.rspm_modulemap",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFirestoreCombine-Community"
+      ]
+    },
+    {
+      "name": "FirebaseFirestoreInternal",
+      "c99name": "FirebaseFirestoreInternal",
+      "src_type": "binary",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreInternal.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift"
+      ]
+    },
+    {
       "name": "FirebaseFirestoreInternalWrapper",
       "c99name": "FirebaseFirestoreInternalWrapper",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreInternal_FirebaseFirestoreInternalWrapper",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreInternalWrapper.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseFirestoreCombine-Community",
@@ -381,7 +446,7 @@
       "name": "FirebaseFirestoreSwift",
       "c99name": "FirebaseFirestoreSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreSwift_Sources_FirebaseFirestoreSwift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreSwift.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseFirestoreCombine-Community",
@@ -389,11 +454,33 @@
       ]
     },
     {
+      "name": "FirebaseFirestoreSwiftTarget",
+      "c99name": "FirebaseFirestoreSwiftTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreSwiftTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFirestoreSwift"
+      ]
+    },
+    {
+      "name": "FirebaseFirestoreTarget",
+      "c99name": "FirebaseFirestoreTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseFirestoreCombine-Community",
+        "FirebaseFirestore",
+        "FirebaseFirestoreSwift"
+      ]
+    },
+    {
       "name": "FirebaseFunctions",
       "c99name": "FirebaseFunctions",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctions_Sources_FirebaseFunctions",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctions_Sources_FirebaseFunctions_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctions.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctions.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseFunctionsCombine-Community",
@@ -401,12 +488,25 @@
       ]
     },
     {
-      "name": "FirebaseInAppMessagingSwift",
-      "c99name": "FirebaseInAppMessagingSwift",
+      "name": "FirebaseFunctionsCombineSwift",
+      "c99name": "FirebaseFunctionsCombineSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessagingSwift_Sources_FirebaseInAppMessagingSwift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctionsCombineSwift.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctionsCombineSwift.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
+        "FirebaseFunctionsCombine-Community"
+      ]
+    },
+    {
+      "name": "FirebaseInAppMessaging",
+      "c99name": "FirebaseInAppMessaging",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging.rspm_modulemap",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseInAppMessaging-Beta",
         "FirebaseInAppMessagingSwift-Beta"
       ]
     },
@@ -414,7 +514,7 @@
       "name": "FirebaseInAppMessagingInternal",
       "c99name": "FirebaseInAppMessagingInternal",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging_Sources_FirebaseInAppMessagingInternal",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessagingInternal.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseInAppMessaging-Beta",
@@ -422,22 +522,30 @@
       ]
     },
     {
-      "name": "FirebaseInAppMessaging",
-      "c99name": "FirebaseInAppMessaging",
+      "name": "FirebaseInAppMessagingSwift",
+      "c99name": "FirebaseInAppMessagingSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging_Swift_Source_FirebaseInAppMessaging",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging_Swift_Source_FirebaseInAppMessaging_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessagingSwift.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
-        "FirebaseInAppMessaging-Beta",
         "FirebaseInAppMessagingSwift-Beta"
+      ]
+    },
+    {
+      "name": "FirebaseInAppMessagingTarget",
+      "c99name": "FirebaseInAppMessagingTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessagingTarget.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseInAppMessaging-Beta"
       ]
     },
     {
       "name": "FirebaseInAppMessaging_iOS",
       "c99name": "FirebaseInAppMessaging_iOS",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging_iOS_FirebaseInAppMessaging_iOS",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging_iOS.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseInAppMessaging-Beta",
@@ -448,7 +556,7 @@
       "name": "FirebaseInstallations",
       "c99name": "FirebaseInstallations",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInstallations_Source_Library_FirebaseInstallations",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInstallations.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseAnalytics",
@@ -470,18 +578,28 @@
       "name": "FirebaseMLModelDownloader",
       "c99name": "FirebaseMLModelDownloader",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMLModelDownloader_Sources_FirebaseMLModelDownloader",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseMLModelDownloader_Sources_FirebaseMLModelDownloader_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMLModelDownloader.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseMLModelDownloader.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseMLModelDownloader"
       ]
     },
     {
+      "name": "FirebaseMessaging",
+      "c99name": "FirebaseMessaging",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMessaging.rspm",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseMessaging"
+      ]
+    },
+    {
       "name": "FirebaseMessagingInterop",
       "c99name": "FirebaseMessagingInterop",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMessaging_Interop_FirebaseMessagingInterop",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMessagingInterop.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseFunctionsCombine-Community",
@@ -489,32 +607,34 @@
       ]
     },
     {
-      "name": "FirebaseMessaging",
-      "c99name": "FirebaseMessaging",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMessaging_Sources_FirebaseMessaging",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseMessaging"
-      ]
-    },
-    {
       "name": "FirebasePerformance",
       "c99name": "FirebasePerformance",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebasePerformance_Sources_FirebasePerformance",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebasePerformance.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebasePerformance"
       ]
     },
     {
-      "name": "FirebaseRemoteConfigSwift",
-      "c99name": "FirebaseRemoteConfigSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfigSwift_Sources_FirebaseRemoteConfigSwift",
+      "name": "FirebasePerformanceTarget",
+      "c99name": "FirebasePerformanceTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebasePerformanceTarget.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
+        "FirebasePerformance"
+      ]
+    },
+    {
+      "name": "FirebaseRemoteConfig",
+      "c99name": "FirebaseRemoteConfig",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig.rspm_modulemap",
+      "package_identity": "firebase-ios-sdk",
+      "product_memberships": [
+        "FirebaseRemoteConfig",
         "FirebaseRemoteConfigSwift"
       ]
     },
@@ -522,7 +642,7 @@
       "name": "FirebaseRemoteConfigInternal",
       "c99name": "FirebaseRemoteConfigInternal",
       "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig_Sources_FirebaseRemoteConfigInternal",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfigInternal.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebasePerformance",
@@ -531,22 +651,21 @@
       ]
     },
     {
-      "name": "FirebaseRemoteConfig",
-      "c99name": "FirebaseRemoteConfig",
+      "name": "FirebaseRemoteConfigSwift",
+      "c99name": "FirebaseRemoteConfigSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig_Swift_FirebaseRemoteConfig",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig_Swift_FirebaseRemoteConfig_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfigSwift.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
-        "FirebaseRemoteConfig",
         "FirebaseRemoteConfigSwift"
       ]
     },
     {
-      "name": "FirebaseSessionsObjC",
-      "c99name": "FirebaseSessionsObjC",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseSessions_FirebaseSessionsObjC",
+      "name": "FirebaseSessions",
+      "c99name": "FirebaseSessions",
+      "src_type": "swift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseSessions.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseSessions.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseCrashlytics",
@@ -554,11 +673,10 @@
       ]
     },
     {
-      "name": "FirebaseSessions",
-      "c99name": "FirebaseSessions",
-      "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseSessions_Sources_FirebaseSessions",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseSessions_Sources_FirebaseSessions_modulemap",
+      "name": "FirebaseSessionsObjC",
+      "c99name": "FirebaseSessionsObjC",
+      "src_type": "objc",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseSessionsObjC.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseCrashlytics",
@@ -569,7 +687,7 @@
       "name": "FirebaseSharedSwift",
       "c99name": "FirebaseSharedSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseSharedSwift_Sources_FirebaseSharedSwift",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseSharedSwift.rspm",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseFirestoreCombine-Community",
@@ -587,8 +705,8 @@
       "name": "FirebaseStorage",
       "c99name": "FirebaseStorage",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorage_Sources_FirebaseStorage",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorage_Sources_FirebaseStorage_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorage.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorage.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
         "FirebaseStorageCombine-Community",
@@ -596,169 +714,21 @@
       ]
     },
     {
-      "name": "FirebaseFirestore",
-      "c99name": "FirebaseFirestore",
+      "name": "FirebaseStorageCombineSwift",
+      "c99name": "FirebaseStorageCombineSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_firebase_ios_sdk//:Firestore_Swift_Source_FirebaseFirestore",
-      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:Firestore_Swift_Source_FirebaseFirestore_modulemap",
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorageCombineSwift.rspm",
+      "modulemap_label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorageCombineSwift.rspm_modulemap",
       "package_identity": "firebase-ios-sdk",
       "product_memberships": [
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsSwiftTarget",
-      "c99name": "FirebaseAnalyticsSwiftTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsSwiftWrap_FirebaseAnalyticsSwiftTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalyticsSwift"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsWithoutAdIdSupportTarget",
-      "c99name": "FirebaseAnalyticsWithoutAdIdSupportTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsWithoutAdIdSupportWrap_FirebaseAnalyticsWithoutAdIdSupportTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalyticsWithoutAdIdSupport"
-      ]
-    },
-    {
-      "name": "FirebaseAnalyticsTarget",
-      "c99name": "FirebaseAnalyticsTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsWrap_FirebaseAnalyticsTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalytics"
-      ]
-    },
-    {
-      "name": "FirebaseAppDistributionTarget",
-      "c99name": "FirebaseAppDistributionTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAppDistributionWrap_FirebaseAppDistributionTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAppDistribution-Beta"
-      ]
-    },
-    {
-      "name": "FirebaseDynamicLinksTarget",
-      "c99name": "FirebaseDynamicLinksTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseDynamicLinksWrap_FirebaseDynamicLinksTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseDynamicLinks"
-      ]
-    },
-    {
-      "name": "FirebaseFirestoreSwiftTarget",
-      "c99name": "FirebaseFirestoreSwiftTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseFirestoreSwiftWrap_FirebaseFirestoreSwiftTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFirestoreSwift"
-      ]
-    },
-    {
-      "name": "FirebaseFirestoreTarget",
-      "c99name": "FirebaseFirestoreTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseFirestoreWrap_FirebaseFirestoreTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift"
-      ]
-    },
-    {
-      "name": "FirebaseInAppMessagingTarget",
-      "c99name": "FirebaseInAppMessagingTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseInAppMessagingWrap_FirebaseInAppMessagingTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseInAppMessaging-Beta"
-      ]
-    },
-    {
-      "name": "FirebasePerformanceTarget",
-      "c99name": "FirebasePerformanceTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebasePerformanceWrap_FirebasePerformanceTarget",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebasePerformance"
-      ]
-    },
-    {
-      "name": "FirebaseAnalytics",
-      "c99name": "FirebaseAnalytics",
-      "src_type": "binary",
-      "label": "@swiftpkg_firebase_ios_sdk//:remote_archive_FirebaseAnalytics.zip_FirebaseAnalytics",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseAnalytics",
-        "FirebaseAnalyticsWithoutAdIdSupport",
-        "FirebaseAnalyticsSwift"
-      ]
-    },
-    {
-      "name": "FirebaseFirestoreInternal",
-      "c99name": "FirebaseFirestoreInternal",
-      "src_type": "binary",
-      "label": "@swiftpkg_firebase_ios_sdk//:remote_archive_FirebaseFirestoreInternal.zip_FirebaseFirestoreInternal",
-      "package_identity": "firebase-ios-sdk",
-      "product_memberships": [
-        "FirebaseFirestoreCombine-Community",
-        "FirebaseFirestore",
-        "FirebaseFirestoreSwift"
-      ]
-    },
-    {
-      "name": "GoogleAppMeasurementOnDeviceConversionTarget",
-      "c99name": "GoogleAppMeasurementOnDeviceConversionTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementOnDeviceConversionWrapper_GoogleAppMeasurementOnDeviceConversionTarget",
-      "package_identity": "googleappmeasurement",
-      "product_memberships": [
-        "GoogleAppMeasurementOnDeviceConversion"
-      ]
-    },
-    {
-      "name": "GoogleAppMeasurementWithoutAdIdSupportTarget",
-      "c99name": "GoogleAppMeasurementWithoutAdIdSupportTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementWithoutAdIdSupportWrapper_GoogleAppMeasurementWithoutAdIdSupportTarget",
-      "package_identity": "googleappmeasurement",
-      "product_memberships": [
-        "GoogleAppMeasurementWithoutAdIdSupport"
-      ]
-    },
-    {
-      "name": "GoogleAppMeasurementTarget",
-      "c99name": "GoogleAppMeasurementTarget",
-      "src_type": "objc",
-      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementWrapper_GoogleAppMeasurementTarget",
-      "package_identity": "googleappmeasurement",
-      "product_memberships": [
-        "GoogleAppMeasurement"
+        "FirebaseStorageCombine-Community"
       ]
     },
     {
       "name": "GoogleAppMeasurement",
       "c99name": "GoogleAppMeasurement",
       "src_type": "binary",
-      "label": "@swiftpkg_googleappmeasurement//:remote_archive_GoogleAppMeasurement.zip_GoogleAppMeasurement",
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurement.rspm",
       "package_identity": "googleappmeasurement",
       "product_memberships": [
         "GoogleAppMeasurement",
@@ -769,7 +739,7 @@
       "name": "GoogleAppMeasurementIdentitySupport",
       "c99name": "GoogleAppMeasurementIdentitySupport",
       "src_type": "binary",
-      "label": "@swiftpkg_googleappmeasurement//:remote_archive_GoogleAppMeasurementIdentitySupport.zip_GoogleAppMeasurementIdentitySupport",
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementIdentitySupport.rspm",
       "package_identity": "googleappmeasurement",
       "product_memberships": [
         "GoogleAppMeasurement"
@@ -779,27 +749,67 @@
       "name": "GoogleAppMeasurementOnDeviceConversion",
       "c99name": "GoogleAppMeasurementOnDeviceConversion",
       "src_type": "binary",
-      "label": "@swiftpkg_googleappmeasurement//:remote_archive_GoogleAppMeasurementOnDeviceConversion.zip_GoogleAppMeasurementOnDeviceConversion",
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementOnDeviceConversion.rspm",
       "package_identity": "googleappmeasurement",
       "product_memberships": [
         "GoogleAppMeasurementOnDeviceConversion"
       ]
     },
     {
+      "name": "GoogleAppMeasurementOnDeviceConversionTarget",
+      "c99name": "GoogleAppMeasurementOnDeviceConversionTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementOnDeviceConversionTarget.rspm",
+      "package_identity": "googleappmeasurement",
+      "product_memberships": [
+        "GoogleAppMeasurementOnDeviceConversion"
+      ]
+    },
+    {
+      "name": "GoogleAppMeasurementTarget",
+      "c99name": "GoogleAppMeasurementTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementTarget.rspm",
+      "package_identity": "googleappmeasurement",
+      "product_memberships": [
+        "GoogleAppMeasurement"
+      ]
+    },
+    {
+      "name": "GoogleAppMeasurementWithoutAdIdSupportTarget",
+      "c99name": "GoogleAppMeasurementWithoutAdIdSupportTarget",
+      "src_type": "objc",
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementWithoutAdIdSupportTarget.rspm",
+      "package_identity": "googleappmeasurement",
+      "product_memberships": [
+        "GoogleAppMeasurementWithoutAdIdSupport"
+      ]
+    },
+    {
       "name": "GoogleDataTransport",
       "c99name": "GoogleDataTransport",
       "src_type": "objc",
-      "label": "@swiftpkg_googledatatransport//:GoogleDataTransport_GoogleDataTransport",
+      "label": "@swiftpkg_googledatatransport//:GoogleDataTransport.rspm",
       "package_identity": "googledatatransport",
       "product_memberships": [
         "GoogleDataTransport"
       ]
     },
     {
+      "name": "GoogleUtilities-AppDelegateSwizzler",
+      "c99name": "GoogleUtilities_AppDelegateSwizzler",
+      "src_type": "objc",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-AppDelegateSwizzler.rspm",
+      "package_identity": "googleutilities",
+      "product_memberships": [
+        "GULAppDelegateSwizzler"
+      ]
+    },
+    {
       "name": "GoogleUtilities-Environment",
       "c99name": "GoogleUtilities_Environment",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_Environment_GoogleUtilities-Environment",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-Environment.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULAppDelegateSwizzler",
@@ -814,20 +824,10 @@
       ]
     },
     {
-      "name": "GoogleUtilities-AppDelegateSwizzler",
-      "c99name": "GoogleUtilities_AppDelegateSwizzler",
-      "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_GoogleUtilities-AppDelegateSwizzler",
-      "package_identity": "googleutilities",
-      "product_memberships": [
-        "GULAppDelegateSwizzler"
-      ]
-    },
-    {
       "name": "GoogleUtilities-ISASwizzler",
       "c99name": "GoogleUtilities_ISASwizzler",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_ISASwizzler_GoogleUtilities-ISASwizzler",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-ISASwizzler.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULISASwizzler"
@@ -837,7 +837,7 @@
       "name": "GoogleUtilities-Logger",
       "c99name": "GoogleUtilities_Logger",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_Logger_GoogleUtilities-Logger",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-Logger.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULAppDelegateSwizzler",
@@ -854,7 +854,7 @@
       "name": "GoogleUtilities-MethodSwizzler",
       "c99name": "GoogleUtilities_MethodSwizzler",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_MethodSwizzler_GoogleUtilities-MethodSwizzler",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-MethodSwizzler.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULMethodSwizzler",
@@ -865,7 +865,7 @@
       "name": "GoogleUtilities-NSData",
       "c99name": "GoogleUtilities_NSData",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_NSData+zlib_GoogleUtilities-NSData",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-NSData.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULAppDelegateSwizzler",
@@ -877,7 +877,7 @@
       "name": "GoogleUtilities-Network",
       "c99name": "GoogleUtilities_Network",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_Network_GoogleUtilities-Network",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-Network.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULAppDelegateSwizzler",
@@ -888,7 +888,7 @@
       "name": "GoogleUtilities-Reachability",
       "c99name": "GoogleUtilities_Reachability",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_Reachability_GoogleUtilities-Reachability",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-Reachability.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULAppDelegateSwizzler",
@@ -900,7 +900,7 @@
       "name": "GoogleUtilities-SwizzlerTestHelpers",
       "c99name": "GoogleUtilities_SwizzlerTestHelpers",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_SwizzlerTestHelpers_GoogleUtilities-SwizzlerTestHelpers",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-SwizzlerTestHelpers.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULSwizzlerTestHelpers"
@@ -910,7 +910,7 @@
       "name": "GoogleUtilities-UserDefaults",
       "c99name": "GoogleUtilities_UserDefaults",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:GoogleUtilities_UserDefaults_GoogleUtilities-UserDefaults",
+      "label": "@swiftpkg_googleutilities//:GoogleUtilities-UserDefaults.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULUserDefaults"
@@ -920,7 +920,7 @@
       "name": "third-party-IsAppEncrypted",
       "c99name": "third_party_IsAppEncrypted",
       "src_type": "objc",
-      "label": "@swiftpkg_googleutilities//:third_party_IsAppEncrypted_third-party-IsAppEncrypted",
+      "label": "@swiftpkg_googleutilities//:third-party-IsAppEncrypted.rspm",
       "package_identity": "googleutilities",
       "product_memberships": [
         "GULAppDelegateSwizzler",
@@ -935,30 +935,10 @@
       ]
     },
     {
-      "name": "gRPC-CXX-Target",
-      "c99name": "gRPC_CXX_Target",
-      "src_type": "objc",
-      "label": "@swiftpkg_grpc_binary//:SwiftPM-PlatformExclude_gRPC-CXX-Target",
-      "package_identity": "grpc-binary",
-      "product_memberships": [
-        "gRPC-C++"
-      ]
-    },
-    {
-      "name": "gRPC-CXX-Wrapper",
-      "c99name": "gRPC_CXX_Wrapper",
-      "src_type": "objc",
-      "label": "@swiftpkg_grpc_binary//:gRPC-CXX-Wrapper_gRPC-CXX-Wrapper",
-      "package_identity": "grpc-binary",
-      "product_memberships": [
-        "gRPC-C++"
-      ]
-    },
-    {
       "name": "BoringSSL-GRPC",
       "c99name": "BoringSSL_GRPC",
       "src_type": "binary",
-      "label": "@swiftpkg_grpc_binary//:remote_archive_BoringSSL-GRPC.zip_BoringSSL-GRPC",
+      "label": "@swiftpkg_grpc_binary//:BoringSSL-GRPC.rspm",
       "package_identity": "grpc-binary",
       "product_memberships": [
         "gRPC-C++"
@@ -968,7 +948,27 @@
       "name": "gRPC-C++",
       "c99name": "gRPC_C__",
       "src_type": "binary",
-      "label": "@swiftpkg_grpc_binary//:remote_archive_gRPC-C++.zip_gRPC-C++",
+      "label": "@swiftpkg_grpc_binary//:gRPC-C++.rspm",
+      "package_identity": "grpc-binary",
+      "product_memberships": [
+        "gRPC-C++"
+      ]
+    },
+    {
+      "name": "gRPC-CXX-Target",
+      "c99name": "gRPC_CXX_Target",
+      "src_type": "objc",
+      "label": "@swiftpkg_grpc_binary//:gRPC-CXX-Target.rspm",
+      "package_identity": "grpc-binary",
+      "product_memberships": [
+        "gRPC-C++"
+      ]
+    },
+    {
+      "name": "gRPC-CXX-Wrapper",
+      "c99name": "gRPC_CXX_Wrapper",
+      "src_type": "objc",
+      "label": "@swiftpkg_grpc_binary//:gRPC-CXX-Wrapper.rspm",
       "package_identity": "grpc-binary",
       "product_memberships": [
         "gRPC-C++"
@@ -978,7 +978,7 @@
       "name": "gRPC-Core",
       "c99name": "gRPC_Core",
       "src_type": "binary",
-      "label": "@swiftpkg_grpc_binary//:remote_archive_gRPC-Core.zip_gRPC-Core",
+      "label": "@swiftpkg_grpc_binary//:gRPC-Core.rspm",
       "package_identity": "grpc-binary",
       "product_memberships": [
         "gRPC-Core",
@@ -989,7 +989,7 @@
       "name": "GTMSessionFetcherCore",
       "c99name": "GTMSessionFetcherCore",
       "src_type": "objc",
-      "label": "@swiftpkg_gtm_session_fetcher//:Sources_Core_GTMSessionFetcherCore",
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherCore.rspm",
       "package_identity": "gtm-session-fetcher",
       "product_memberships": [
         "GTMSessionFetcher",
@@ -1002,7 +1002,7 @@
       "name": "GTMSessionFetcherFull",
       "c99name": "GTMSessionFetcherFull",
       "src_type": "objc",
-      "label": "@swiftpkg_gtm_session_fetcher//:Sources_Full_GTMSessionFetcherFull",
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherFull.rspm",
       "package_identity": "gtm-session-fetcher",
       "product_memberships": [
         "GTMSessionFetcher",
@@ -1013,7 +1013,7 @@
       "name": "GTMSessionFetcherLogView",
       "c99name": "GTMSessionFetcherLogView",
       "src_type": "objc",
-      "label": "@swiftpkg_gtm_session_fetcher//:Sources_LogView_GTMSessionFetcherLogView",
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherLogView.rspm",
       "package_identity": "gtm-session-fetcher",
       "product_memberships": [
         "GTMSessionFetcherLogView"
@@ -1023,7 +1023,7 @@
       "name": "RecaptchaInterop",
       "c99name": "RecaptchaInterop",
       "src_type": "objc",
-      "label": "@swiftpkg_interop_ios_for_google_sdks//:RecaptchaEnterprise_RecaptchaInterop",
+      "label": "@swiftpkg_interop_ios_for_google_sdks//:RecaptchaInterop.rspm",
       "package_identity": "interop-ios-for-google-sdks",
       "product_memberships": [
         "RecaptchaInterop"
@@ -1033,7 +1033,7 @@
       "name": "leveldb",
       "c99name": "leveldb",
       "src_type": "clang",
-      "label": "@swiftpkg_leveldb//:leveldb",
+      "label": "@swiftpkg_leveldb//:leveldb.rspm",
       "package_identity": "leveldb",
       "product_memberships": [
         "leveldb"
@@ -1043,7 +1043,7 @@
       "name": "nanopb",
       "c99name": "nanopb",
       "src_type": "clang",
-      "label": "@swiftpkg_nanopb//:nanopb",
+      "label": "@swiftpkg_nanopb//:nanopb.rspm",
       "package_identity": "nanopb",
       "product_memberships": [
         "nanopb"
@@ -1053,7 +1053,7 @@
       "name": "FBLPromises",
       "c99name": "FBLPromises",
       "src_type": "objc",
-      "label": "@swiftpkg_promises//:Sources_FBLPromises",
+      "label": "@swiftpkg_promises//:FBLPromises.rspm",
       "package_identity": "promises",
       "product_memberships": [
         "FBLPromises",
@@ -1066,7 +1066,7 @@
       "name": "FBLPromisesTestHelpers",
       "c99name": "FBLPromisesTestHelpers",
       "src_type": "objc",
-      "label": "@swiftpkg_promises//:Sources_FBLPromisesTestHelpers",
+      "label": "@swiftpkg_promises//:FBLPromisesTestHelpers.rspm",
       "package_identity": "promises",
       "product_memberships": [
         "FBLPromisesTestHelpers"
@@ -1076,7 +1076,7 @@
       "name": "Promises",
       "c99name": "Promises",
       "src_type": "swift",
-      "label": "@swiftpkg_promises//:Sources_Promises",
+      "label": "@swiftpkg_promises//:Promises.rspm",
       "package_identity": "promises",
       "product_memberships": [
         "Promises",
@@ -1087,8 +1087,8 @@
       "name": "PromisesTestHelpers",
       "c99name": "PromisesTestHelpers",
       "src_type": "swift",
-      "label": "@swiftpkg_promises//:Sources_PromisesTestHelpers",
-      "modulemap_label": "@swiftpkg_promises//:Sources_PromisesTestHelpers_modulemap",
+      "label": "@swiftpkg_promises//:PromisesTestHelpers.rspm",
+      "modulemap_label": "@swiftpkg_promises//:PromisesTestHelpers.rspm_modulemap",
       "package_identity": "promises",
       "product_memberships": [
         "PromisesTestHelpers"
@@ -1098,27 +1098,17 @@
       "name": "Reachability",
       "c99name": "Reachability",
       "src_type": "swift",
-      "label": "@swiftpkg_reachability.swift//:Sources_Reachability",
+      "label": "@swiftpkg_reachability.swift//:Reachability.rspm",
       "package_identity": "reachability.swift",
       "product_memberships": [
         "Reachability"
       ]
     },
     {
-      "name": "SwiftProtobufPlugin",
-      "c99name": "SwiftProtobufPlugin",
-      "src_type": "unknown",
-      "label": "@swiftpkg_swift_protobuf//:Plugins_SwiftProtobufPlugin",
-      "package_identity": "swift-protobuf",
-      "product_memberships": [
-        "SwiftProtobufPlugin"
-      ]
-    },
-    {
       "name": "SwiftProtobuf",
       "c99name": "SwiftProtobuf",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_protobuf//:Sources_SwiftProtobuf",
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobuf.rspm",
       "package_identity": "swift-protobuf",
       "product_memberships": [
         "protoc-gen-swift",
@@ -1128,10 +1118,20 @@
       ]
     },
     {
+      "name": "SwiftProtobufPlugin",
+      "c99name": "SwiftProtobufPlugin",
+      "src_type": "unknown",
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPlugin.rspm",
+      "package_identity": "swift-protobuf",
+      "product_memberships": [
+        "SwiftProtobufPlugin"
+      ]
+    },
+    {
       "name": "SwiftProtobufPluginLibrary",
       "c99name": "SwiftProtobufPluginLibrary",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_protobuf//:Sources_SwiftProtobufPluginLibrary",
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPluginLibrary.rspm",
       "package_identity": "swift-protobuf",
       "product_memberships": [
         "protoc-gen-swift",
@@ -1143,7 +1143,7 @@
       "name": "protoc-gen-swift",
       "c99name": "protoc_gen_swift",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_protobuf//:Sources_protoc-gen-swift",
+      "label": "@swiftpkg_swift_protobuf//:protoc-gen-swift.rspm",
       "package_identity": "swift-protobuf",
       "product_memberships": [
         "protoc-gen-swift",
@@ -1156,490 +1156,367 @@
       "identity": "abseil-cpp-binary",
       "name": "abseil",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_abseil_cpp_binary//:remote_archive_abseil.zip_abseil"
-      ]
+      "label": "@swiftpkg_abseil_cpp_binary//:abseil"
     },
     {
       "identity": "app-check",
       "name": "AppCheckCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_app_check//:AppCheckCore_Sources_AppCheckCore"
-      ]
+      "label": "@swiftpkg_app_check//:AppCheckCore"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsWrap_FirebaseAnalyticsTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalytics"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAnalyticsOnDeviceConversion",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsOnDeviceConversionWrapper_FirebaseAnalyticsOnDeviceConversionTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsOnDeviceConversion"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAnalyticsSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsSwiftWrap_FirebaseAnalyticsSwiftTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsSwift"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAnalyticsWithoutAdIdSupport",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAnalyticsWithoutAdIdSupportWrap_FirebaseAnalyticsWithoutAdIdSupportTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAnalyticsWithoutAdIdSupport"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAppCheck",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseAppCheck_Sources_FirebaseAppCheck"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppCheck"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAppDistribution-Beta",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseAppDistributionWrap_FirebaseAppDistributionTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAppDistribution-Beta"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAuth",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseAuth_Sources_FirebaseAuth"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuth"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseAuthCombine-Community",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Auth_FirebaseAuthCombineSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseAuthCombine-Community"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseCrashlytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:Crashlytics_FirebaseCrashlytics"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseCrashlytics"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseDatabase",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase_Swift_Sources_FirebaseDatabase"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabase"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseDatabaseSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseDatabaseSwift_Sources_FirebaseDatabaseSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDatabaseSwift"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseDynamicLinks",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseDynamicLinksWrap_FirebaseDynamicLinksTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseDynamicLinks"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseFirestore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseFirestoreWrap_FirebaseFirestoreTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestore"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseFirestoreCombine-Community",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Firestore_FirebaseFirestoreCombineSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreCombine-Community"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseFirestoreSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseFirestoreSwiftWrap_FirebaseFirestoreSwiftTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFirestoreSwift"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseFunctions",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseFunctions_Sources_FirebaseFunctions"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctions"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseFunctionsCombine-Community",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Functions_FirebaseFunctionsCombineSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseFunctionsCombine-Community"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseInAppMessaging-Beta",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebaseInAppMessagingWrap_FirebaseInAppMessagingTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessaging-Beta"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseInAppMessagingSwift-Beta",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessagingSwift_Sources_FirebaseInAppMessagingSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInAppMessagingSwift-Beta"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseInstallations",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseInstallations_Source_Library_FirebaseInstallations"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseInstallations"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseMLModelDownloader",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseMLModelDownloader_Sources_FirebaseMLModelDownloader"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMLModelDownloader"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseMessaging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseMessaging_Sources_FirebaseMessaging"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseMessaging"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebasePerformance",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:SwiftPM-PlatformExclude_FirebasePerformanceWrap_FirebasePerformanceTarget"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebasePerformance"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseRemoteConfig",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig_Swift_FirebaseRemoteConfig"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfig"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseRemoteConfigSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfigSwift_Sources_FirebaseRemoteConfigSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseRemoteConfigSwift"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseStorage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseStorage_Sources_FirebaseStorage"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorage"
     },
     {
       "identity": "firebase-ios-sdk",
       "name": "FirebaseStorageCombine-Community",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_firebase_ios_sdk//:FirebaseCombineSwift_Sources_Storage_FirebaseStorageCombineSwift"
-      ]
+      "label": "@swiftpkg_firebase_ios_sdk//:FirebaseStorageCombine-Community"
     },
     {
       "identity": "googleappmeasurement",
       "name": "GoogleAppMeasurement",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementWrapper_GoogleAppMeasurementTarget"
-      ]
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurement"
     },
     {
       "identity": "googleappmeasurement",
       "name": "GoogleAppMeasurementOnDeviceConversion",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementOnDeviceConversionWrapper_GoogleAppMeasurementOnDeviceConversionTarget"
-      ]
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementOnDeviceConversion"
     },
     {
       "identity": "googleappmeasurement",
       "name": "GoogleAppMeasurementWithoutAdIdSupport",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementWithoutAdIdSupportWrapper_GoogleAppMeasurementWithoutAdIdSupportTarget"
-      ]
+      "label": "@swiftpkg_googleappmeasurement//:GoogleAppMeasurementWithoutAdIdSupport"
     },
     {
       "identity": "googledatatransport",
       "name": "GoogleDataTransport",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googledatatransport//:GoogleDataTransport_GoogleDataTransport"
-      ]
+      "label": "@swiftpkg_googledatatransport//:GoogleDataTransport"
     },
     {
       "identity": "googleutilities",
       "name": "GULAppDelegateSwizzler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_GoogleUtilities-AppDelegateSwizzler"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULAppDelegateSwizzler"
     },
     {
       "identity": "googleutilities",
       "name": "GULEnvironment",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_Environment_GoogleUtilities-Environment"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULEnvironment"
     },
     {
       "identity": "googleutilities",
       "name": "GULISASwizzler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_ISASwizzler_GoogleUtilities-ISASwizzler"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULISASwizzler"
     },
     {
       "identity": "googleutilities",
       "name": "GULLogger",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_Logger_GoogleUtilities-Logger"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULLogger"
     },
     {
       "identity": "googleutilities",
       "name": "GULMethodSwizzler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_MethodSwizzler_GoogleUtilities-MethodSwizzler"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULMethodSwizzler"
     },
     {
       "identity": "googleutilities",
       "name": "GULNSData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_NSData+zlib_GoogleUtilities-NSData"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULNSData"
     },
     {
       "identity": "googleutilities",
       "name": "GULNetwork",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_Network_GoogleUtilities-Network"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULNetwork"
     },
     {
       "identity": "googleutilities",
       "name": "GULReachability",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_Reachability_GoogleUtilities-Reachability"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULReachability"
     },
     {
       "identity": "googleutilities",
       "name": "GULSwizzlerTestHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_SwizzlerTestHelpers_GoogleUtilities-SwizzlerTestHelpers"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULSwizzlerTestHelpers"
     },
     {
       "identity": "googleutilities",
       "name": "GULUserDefaults",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googleutilities//:GoogleUtilities_UserDefaults_GoogleUtilities-UserDefaults"
-      ]
+      "label": "@swiftpkg_googleutilities//:GULUserDefaults"
     },
     {
       "identity": "grpc-binary",
       "name": "gRPC-C++",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_grpc_binary//:SwiftPM-PlatformExclude_gRPC-CXX-Target"
-      ]
+      "label": "@swiftpkg_grpc_binary//:gRPC-C++"
     },
     {
       "identity": "grpc-binary",
       "name": "gRPC-Core",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_grpc_binary//:remote_archive_gRPC-Core.zip_gRPC-Core"
-      ]
+      "label": "@swiftpkg_grpc_binary//:gRPC-Core"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcher",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_Core_GTMSessionFetcherCore",
-        "@swiftpkg_gtm_session_fetcher//:Sources_Full_GTMSessionFetcherFull"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcher"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcherCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_Core_GTMSessionFetcherCore"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherCore"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcherFull",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_Full_GTMSessionFetcherFull"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherFull"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcherLogView",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_LogView_GTMSessionFetcherLogView"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherLogView"
     },
     {
       "identity": "interop-ios-for-google-sdks",
       "name": "RecaptchaInterop",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_interop_ios_for_google_sdks//:RecaptchaEnterprise_RecaptchaInterop"
-      ]
+      "label": "@swiftpkg_interop_ios_for_google_sdks//:RecaptchaInterop"
     },
     {
       "identity": "leveldb",
       "name": "leveldb",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_leveldb//:leveldb"
-      ]
+      "label": "@swiftpkg_leveldb//:leveldb"
     },
     {
       "identity": "nanopb",
       "name": "nanopb",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_nanopb//:nanopb"
-      ]
+      "label": "@swiftpkg_nanopb//:nanopb"
     },
     {
       "identity": "promises",
       "name": "FBLPromises",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_promises//:Sources_FBLPromises"
-      ]
+      "label": "@swiftpkg_promises//:FBLPromises"
     },
     {
       "identity": "promises",
       "name": "FBLPromisesTestHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_promises//:Sources_FBLPromisesTestHelpers"
-      ]
+      "label": "@swiftpkg_promises//:FBLPromisesTestHelpers"
     },
     {
       "identity": "promises",
       "name": "Promises",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_promises//:Sources_Promises"
-      ]
+      "label": "@swiftpkg_promises//:Promises"
     },
     {
       "identity": "promises",
       "name": "PromisesTestHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_promises//:Sources_PromisesTestHelpers"
-      ]
+      "label": "@swiftpkg_promises//:PromisesTestHelpers"
     },
     {
       "identity": "reachability.swift",
       "name": "Reachability",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_reachability.swift//:Sources_Reachability"
-      ]
+      "label": "@swiftpkg_reachability.swift//:Reachability"
     },
     {
       "identity": "swift-protobuf",
       "name": "SwiftProtobuf",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Sources_SwiftProtobuf"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobuf"
     },
     {
       "identity": "swift-protobuf",
       "name": "SwiftProtobufPlugin",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Plugins_SwiftProtobufPlugin"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPlugin"
     },
     {
       "identity": "swift-protobuf",
       "name": "SwiftProtobufPluginLibrary",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Sources_SwiftProtobufPluginLibrary"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPluginLibrary"
     },
     {
       "identity": "swift-protobuf",
       "name": "protoc-gen-swift",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Sources_protoc-gen-swift"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:protoc-gen-swift"
     }
   ],
   "packages": [

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -41,11 +41,11 @@ swift_binary(
     srcs = ["main.swift"],
     visibility = ["//swift:__subpackages__"],
     deps = [
-        "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwiftLogBackend",
-        "@swiftpkg_geoswift//:Sources_GEOSwift",
+        "@swiftpkg_cocoalumberjack//:CocoaLumberjackSwiftLogBackend",
+        "@swiftpkg_geoswift//:GEOSwift",
         "@swiftpkg_libwebp_xcode//:libwebp",
-        "@swiftpkg_opencombine//:Sources_OpenCombine",
-        "@swiftpkg_swift_log//:Sources_Logging",
+        "@swiftpkg_opencombine//:OpenCombine",
+        "@swiftpkg_swift_log//:Logging",
     ],
 )
 

--- a/examples/interesting_deps/swift_deps_index.json
+++ b/examples/interesting_deps/swift_deps_index.json
@@ -11,7 +11,7 @@
       "name": "CocoaLumberjack",
       "c99name": "CocoaLumberjack",
       "src_type": "objc",
-      "label": "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjack",
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjack.rspm",
       "package_identity": "cocoalumberjack",
       "product_memberships": [
         "CocoaLumberjack",
@@ -23,7 +23,7 @@
       "name": "CocoaLumberjackSwift",
       "c99name": "CocoaLumberjackSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwift",
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjackSwift.rspm",
       "package_identity": "cocoalumberjack",
       "product_memberships": [
         "CocoaLumberjackSwift"
@@ -33,7 +33,7 @@
       "name": "CocoaLumberjackSwiftLogBackend",
       "c99name": "CocoaLumberjackSwiftLogBackend",
       "src_type": "swift",
-      "label": "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwiftLogBackend",
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjackSwiftLogBackend.rspm",
       "package_identity": "cocoalumberjack",
       "product_memberships": [
         "CocoaLumberjackSwiftLogBackend"
@@ -43,7 +43,7 @@
       "name": "CocoaLumberjackSwiftSupport",
       "c99name": "CocoaLumberjackSwiftSupport",
       "src_type": "clang",
-      "label": "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwiftSupport",
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjackSwiftSupport.rspm",
       "package_identity": "cocoalumberjack",
       "product_memberships": [
         "CocoaLumberjackSwift"
@@ -53,7 +53,7 @@
       "name": "geos",
       "c99name": "geos",
       "src_type": "clang",
-      "label": "@swiftpkg_geos//:Sources_geos",
+      "label": "@swiftpkg_geos//:geos.rspm",
       "package_identity": "geos",
       "product_memberships": [
         "geos"
@@ -63,7 +63,7 @@
       "name": "GEOSwift",
       "c99name": "GEOSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_geoswift//:Sources_GEOSwift",
+      "label": "@swiftpkg_geoswift//:GEOSwift.rspm",
       "package_identity": "geoswift",
       "product_memberships": [
         "GEOSwift"
@@ -73,7 +73,7 @@
       "name": "libwebp",
       "c99name": "libwebp",
       "src_type": "clang",
-      "label": "@swiftpkg_libwebp_xcode//:libwebp",
+      "label": "@swiftpkg_libwebp_xcode//:libwebp.rspm",
       "package_identity": "libwebp-xcode",
       "product_memberships": [
         "libwebp"
@@ -83,7 +83,7 @@
       "name": "COpenCombineHelpers",
       "c99name": "COpenCombineHelpers",
       "src_type": "clang",
-      "label": "@swiftpkg_opencombine//:Sources_COpenCombineHelpers",
+      "label": "@swiftpkg_opencombine//:COpenCombineHelpers.rspm",
       "package_identity": "opencombine",
       "product_memberships": [
         "OpenCombine",
@@ -96,7 +96,7 @@
       "name": "OpenCombine",
       "c99name": "OpenCombine",
       "src_type": "swift",
-      "label": "@swiftpkg_opencombine//:Sources_OpenCombine",
+      "label": "@swiftpkg_opencombine//:OpenCombine.rspm",
       "package_identity": "opencombine",
       "product_memberships": [
         "OpenCombine",
@@ -109,7 +109,7 @@
       "name": "OpenCombineDispatch",
       "c99name": "OpenCombineDispatch",
       "src_type": "swift",
-      "label": "@swiftpkg_opencombine//:Sources_OpenCombineDispatch",
+      "label": "@swiftpkg_opencombine//:OpenCombineDispatch.rspm",
       "package_identity": "opencombine",
       "product_memberships": [
         "OpenCombineDispatch",
@@ -120,7 +120,7 @@
       "name": "OpenCombineFoundation",
       "c99name": "OpenCombineFoundation",
       "src_type": "swift",
-      "label": "@swiftpkg_opencombine//:Sources_OpenCombineFoundation",
+      "label": "@swiftpkg_opencombine//:OpenCombineFoundation.rspm",
       "package_identity": "opencombine",
       "product_memberships": [
         "OpenCombineFoundation",
@@ -131,7 +131,7 @@
       "name": "OpenCombineShim",
       "c99name": "OpenCombineShim",
       "src_type": "swift",
-      "label": "@swiftpkg_opencombine//:Sources_OpenCombineShim",
+      "label": "@swiftpkg_opencombine//:OpenCombineShim.rspm",
       "package_identity": "opencombine",
       "product_memberships": [
         "OpenCombineShim"
@@ -141,7 +141,7 @@
       "name": "Logging",
       "c99name": "Logging",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_log//:Sources_Logging",
+      "label": "@swiftpkg_swift_log//:Logging.rspm",
       "package_identity": "swift-log",
       "product_memberships": [
         "Logging"
@@ -153,89 +153,67 @@
       "identity": "cocoalumberjack",
       "name": "CocoaLumberjack",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjack"
-      ]
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjack"
     },
     {
       "identity": "cocoalumberjack",
       "name": "CocoaLumberjackSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwift"
-      ]
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjackSwift"
     },
     {
       "identity": "cocoalumberjack",
       "name": "CocoaLumberjackSwiftLogBackend",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cocoalumberjack//:Sources_CocoaLumberjackSwiftLogBackend"
-      ]
+      "label": "@swiftpkg_cocoalumberjack//:CocoaLumberjackSwiftLogBackend"
     },
     {
       "identity": "geoswift",
       "name": "GEOSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_geoswift//:Sources_GEOSwift"
-      ]
+      "label": "@swiftpkg_geoswift//:GEOSwift"
     },
     {
       "identity": "geos",
       "name": "geos",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_geos//:Sources_geos"
-      ]
+      "label": "@swiftpkg_geos//:geos"
     },
     {
       "identity": "libwebp-xcode",
       "name": "libwebp",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_libwebp_xcode//:libwebp"
-      ]
+      "label": "@swiftpkg_libwebp_xcode//:libwebp"
     },
     {
       "identity": "opencombine",
       "name": "OpenCombine",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_opencombine//:Sources_OpenCombine"
-      ]
+      "label": "@swiftpkg_opencombine//:OpenCombine"
     },
     {
       "identity": "opencombine",
       "name": "OpenCombineDispatch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_opencombine//:Sources_OpenCombineDispatch"
-      ]
+      "label": "@swiftpkg_opencombine//:OpenCombineDispatch"
     },
     {
       "identity": "opencombine",
       "name": "OpenCombineFoundation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_opencombine//:Sources_OpenCombineFoundation"
-      ]
+      "label": "@swiftpkg_opencombine//:OpenCombineFoundation"
     },
     {
       "identity": "opencombine",
       "name": "OpenCombineShim",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_opencombine//:Sources_OpenCombineShim"
-      ]
+      "label": "@swiftpkg_opencombine//:OpenCombineShim"
     },
     {
       "identity": "swift-log",
       "name": "Logging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_log//:Sources_Logging"
-      ]
+      "label": "@swiftpkg_swift_log//:Logging"
     }
   ],
   "packages": [

--- a/examples/ios_sim/Sources/Foo/BUILD.bazel
+++ b/examples/ios_sim/Sources/Foo/BUILD.bazel
@@ -6,5 +6,5 @@ swift_library(
     module_name = "Foo",
     tags = ["manual"],
     visibility = ["//:__subpackages__"],
-    deps = ["@swiftpkg_swift_nio//:Sources_NIO"],
+    deps = ["@swiftpkg_swift_nio//:NIO"],
 )

--- a/examples/ios_sim/Tests/FooTests/BUILD.bazel
+++ b/examples/ios_sim/Tests/FooTests/BUILD.bazel
@@ -11,8 +11,8 @@ swift_library(
     module_name = "FooTests",
     deps = [
         "//Sources/Foo",
-        "@swiftpkg_swift_markdown//:Sources_Markdown",
-        "@swiftpkg_swift_nio//:Sources_NIO",
+        "@swiftpkg_swift_markdown//:Markdown",
+        "@swiftpkg_swift_nio//:NIO",
     ],
 )
 

--- a/examples/ios_sim/swift_deps_index.json
+++ b/examples/ios_sim/swift_deps_index.json
@@ -8,7 +8,7 @@
       "name": "Atomics",
       "c99name": "Atomics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_atomics//:Sources_Atomics",
+      "label": "@swiftpkg_swift_atomics//:Atomics.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -18,7 +18,7 @@
       "name": "_AtomicsShims",
       "c99name": "_AtomicsShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_atomics//:Sources__AtomicsShims",
+      "label": "@swiftpkg_swift_atomics//:_AtomicsShims.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -28,7 +28,7 @@
       "name": "api_test",
       "c99name": "api_test",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_cmark//:api_test_api_test",
+      "label": "@swiftpkg_swift_cmark//:api_test.rspm",
       "package_identity": "swift-cmark",
       "product_memberships": [
         "api_test"
@@ -38,7 +38,7 @@
       "name": "cmark-gfm-bin",
       "c99name": "cmark_gfm_bin",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_cmark//:bin_cmark-gfm-bin",
+      "label": "@swiftpkg_swift_cmark//:cmark-gfm-bin.rspm",
       "package_identity": "swift-cmark",
       "product_memberships": [
         "cmark-gfm-bin"
@@ -48,7 +48,7 @@
       "name": "cmark-gfm-extensions",
       "c99name": "cmark_gfm_extensions",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_cmark//:extensions_cmark-gfm-extensions",
+      "label": "@swiftpkg_swift_cmark//:cmark-gfm-extensions.rspm",
       "package_identity": "swift-cmark",
       "product_memberships": [
         "cmark-gfm-extensions",
@@ -60,7 +60,7 @@
       "name": "cmark-gfm",
       "c99name": "cmark_gfm",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_cmark//:src_cmark-gfm",
+      "label": "@swiftpkg_swift_cmark//:cmark-gfm.rspm",
       "package_identity": "swift-cmark",
       "product_memberships": [
         "cmark-gfm",
@@ -73,7 +73,7 @@
       "name": "Collections",
       "c99name": "Collections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_Collections",
+      "label": "@swiftpkg_swift_collections//:Collections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections"
@@ -83,7 +83,7 @@
       "name": "DequeModule",
       "c99name": "DequeModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_DequeModule",
+      "label": "@swiftpkg_swift_collections//:DequeModule.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -94,7 +94,7 @@
       "name": "OrderedCollections",
       "c99name": "OrderedCollections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_OrderedCollections",
+      "label": "@swiftpkg_swift_collections//:OrderedCollections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -105,7 +105,7 @@
       "name": "CAtomic",
       "c99name": "CAtomic",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_markdown//:Sources_CAtomic",
+      "label": "@swiftpkg_swift_markdown//:CAtomic.rspm",
       "package_identity": "swift-markdown",
       "product_memberships": [
         "Markdown"
@@ -115,7 +115,7 @@
       "name": "Markdown",
       "c99name": "Markdown",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_markdown//:Sources_Markdown",
+      "label": "@swiftpkg_swift_markdown//:Markdown.rspm",
       "package_identity": "swift-markdown",
       "product_memberships": [
         "Markdown"
@@ -125,7 +125,7 @@
       "name": "CNIOAtomics",
       "c99name": "CNIOAtomics",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOAtomics",
+      "label": "@swiftpkg_swift_nio//:CNIOAtomics.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -147,7 +147,7 @@
       "name": "CNIODarwin",
       "c99name": "CNIODarwin",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIODarwin",
+      "label": "@swiftpkg_swift_nio//:CNIODarwin.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -168,7 +168,7 @@
       "name": "CNIOLLHTTP",
       "c99name": "CNIOLLHTTP",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLLHTTP",
+      "label": "@swiftpkg_swift_nio//:CNIOLLHTTP.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -180,7 +180,7 @@
       "name": "CNIOLinux",
       "c99name": "CNIOLinux",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLinux",
+      "label": "@swiftpkg_swift_nio//:CNIOLinux.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -201,7 +201,7 @@
       "name": "CNIOSHA1",
       "c99name": "CNIOSHA1",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOSHA1",
+      "label": "@swiftpkg_swift_nio//:CNIOSHA1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -211,7 +211,7 @@
       "name": "CNIOWindows",
       "c99name": "CNIOWindows",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOWindows",
+      "label": "@swiftpkg_swift_nio//:CNIOWindows.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -232,7 +232,7 @@
       "name": "NIO",
       "c99name": "NIO",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIO",
+      "label": "@swiftpkg_swift_nio//:NIO.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -248,7 +248,7 @@
       "name": "NIOConcurrencyHelpers",
       "c99name": "NIOConcurrencyHelpers",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers",
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -270,7 +270,7 @@
       "name": "NIOCore",
       "c99name": "NIOCore",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOCore",
+      "label": "@swiftpkg_swift_nio//:NIOCore.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -291,7 +291,7 @@
       "name": "NIOEmbedded",
       "c99name": "NIOEmbedded",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOEmbedded",
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -308,7 +308,7 @@
       "name": "NIOFileSystem",
       "c99name": "NIOFileSystem",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOFileSystem",
+      "label": "@swiftpkg_swift_nio//:NIOFileSystem.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "_NIOFileSystem",
@@ -319,7 +319,7 @@
       "name": "NIOFileSystemFoundationCompat",
       "c99name": "NIOFileSystemFoundationCompat",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOFileSystemFoundationCompat",
+      "label": "@swiftpkg_swift_nio//:NIOFileSystemFoundationCompat.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "_NIOFileSystemFoundationCompat"
@@ -329,7 +329,7 @@
       "name": "NIOFoundationCompat",
       "c99name": "NIOFoundationCompat",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat",
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOFoundationCompat"
@@ -339,7 +339,7 @@
       "name": "NIOHTTP1",
       "c99name": "NIOHTTP1",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOHTTP1",
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -351,7 +351,7 @@
       "name": "NIOPosix",
       "c99name": "NIOPosix",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOPosix",
+      "label": "@swiftpkg_swift_nio//:NIOPosix.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -368,7 +368,7 @@
       "name": "NIOTLS",
       "c99name": "NIOTLS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTLS",
+      "label": "@swiftpkg_swift_nio//:NIOTLS.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTLS"
@@ -378,7 +378,7 @@
       "name": "NIOTestUtils",
       "c99name": "NIOTestUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTestUtils",
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTestUtils"
@@ -388,7 +388,7 @@
       "name": "NIOWebSocket",
       "c99name": "NIOWebSocket",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOWebSocket",
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -398,7 +398,7 @@
       "name": "_NIOBase64",
       "c99name": "_NIOBase64",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIOBase64",
+      "label": "@swiftpkg_swift_nio//:_NIOBase64.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -419,7 +419,7 @@
       "name": "_NIOConcurrency",
       "c99name": "_NIOConcurrency",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIOConcurrency",
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "_NIOConcurrency"
@@ -429,7 +429,7 @@
       "name": "_NIODataStructures",
       "c99name": "_NIODataStructures",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIODataStructures",
+      "label": "@swiftpkg_swift_nio//:_NIODataStructures.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -450,7 +450,7 @@
       "name": "CSystem",
       "c99name": "CSystem",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_system//:Sources_CSystem",
+      "label": "@swiftpkg_swift_system//:CSystem.rspm",
       "package_identity": "swift-system",
       "product_memberships": [
         "SystemPackage"
@@ -460,7 +460,7 @@
       "name": "SystemPackage",
       "c99name": "SystemPackage",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_system//:Sources_System_SystemPackage",
+      "label": "@swiftpkg_swift_system//:SystemPackage.rspm",
       "package_identity": "swift-system",
       "product_memberships": [
         "SystemPackage"
@@ -472,185 +472,139 @@
       "identity": "swift-atomics",
       "name": "Atomics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_atomics//:Sources_Atomics"
-      ]
+      "label": "@swiftpkg_swift_atomics//:Atomics"
     },
     {
       "identity": "swift-cmark",
       "name": "api_test",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_cmark//:api_test_api_test"
-      ]
+      "label": "@swiftpkg_swift_cmark//:api_test"
     },
     {
       "identity": "swift-cmark",
       "name": "cmark-gfm",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_cmark//:src_cmark-gfm"
-      ]
+      "label": "@swiftpkg_swift_cmark//:cmark-gfm"
     },
     {
       "identity": "swift-cmark",
       "name": "cmark-gfm-bin",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_cmark//:bin_cmark-gfm-bin"
-      ]
+      "label": "@swiftpkg_swift_cmark//:cmark-gfm-bin"
     },
     {
       "identity": "swift-cmark",
       "name": "cmark-gfm-extensions",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_cmark//:extensions_cmark-gfm-extensions"
-      ]
+      "label": "@swiftpkg_swift_cmark//:cmark-gfm-extensions"
     },
     {
       "identity": "swift-collections",
       "name": "Collections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_Collections"
-      ]
+      "label": "@swiftpkg_swift_collections//:Collections"
     },
     {
       "identity": "swift-collections",
       "name": "DequeModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_DequeModule"
-      ]
+      "label": "@swiftpkg_swift_collections//:DequeModule"
     },
     {
       "identity": "swift-collections",
       "name": "OrderedCollections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_OrderedCollections"
-      ]
+      "label": "@swiftpkg_swift_collections//:OrderedCollections"
     },
     {
       "identity": "swift-markdown",
       "name": "Markdown",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_markdown//:Sources_Markdown"
-      ]
+      "label": "@swiftpkg_swift_markdown//:Markdown"
     },
     {
       "identity": "swift-nio",
       "name": "NIO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIO"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIO"
     },
     {
       "identity": "swift-nio",
       "name": "NIOConcurrencyHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers"
     },
     {
       "identity": "swift-nio",
       "name": "NIOCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOCore"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOCore"
     },
     {
       "identity": "swift-nio",
       "name": "NIOEmbedded",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOEmbedded"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded"
     },
     {
       "identity": "swift-nio",
       "name": "NIOFoundationCompat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat"
     },
     {
       "identity": "swift-nio",
       "name": "NIOHTTP1",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOHTTP1"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1"
     },
     {
       "identity": "swift-nio",
       "name": "NIOPosix",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOPosix"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOPosix"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTLS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTLS"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTLS"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTestUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTestUtils"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils"
     },
     {
       "identity": "swift-nio",
       "name": "NIOWebSocket",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOWebSocket"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket"
     },
     {
       "identity": "swift-nio",
       "name": "_NIOConcurrency",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources__NIOConcurrency"
-      ]
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency"
     },
     {
       "identity": "swift-nio",
       "name": "_NIOFileSystem",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOFileSystem"
-      ]
+      "label": "@swiftpkg_swift_nio//:_NIOFileSystem"
     },
     {
       "identity": "swift-nio",
       "name": "_NIOFileSystemFoundationCompat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOFileSystemFoundationCompat"
-      ]
+      "label": "@swiftpkg_swift_nio//:_NIOFileSystemFoundationCompat"
     },
     {
       "identity": "swift-system",
       "name": "SystemPackage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_system//:Sources_System_SystemPackage"
-      ]
+      "label": "@swiftpkg_swift_system//:SystemPackage"
     }
   ],
   "packages": [

--- a/examples/lottie_ios_example/LottieExample/BUILD.bazel
+++ b/examples/lottie_ios_example/LottieExample/BUILD.bazel
@@ -13,10 +13,7 @@ swift_library(
     module_name = "LottieExample",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = [
-        "@swiftpkg_lottie_spm//:Sources__LottieStub",
-        "@swiftpkg_lottie_spm//:remote_archive_Lottie-Xcode-14.1.xcframework.zip_Lottie",
-    ],
+    deps = ["@swiftpkg_lottie_spm//:Lottie"],
 )
 
 ios_application(

--- a/examples/lottie_ios_example/swift_deps_index.json
+++ b/examples/lottie_ios_example/swift_deps_index.json
@@ -4,20 +4,20 @@
   ],
   "modules": [
     {
-      "name": "_LottieStub",
-      "c99name": "_LottieStub",
-      "src_type": "swift",
-      "label": "@swiftpkg_lottie_spm//:Sources__LottieStub",
+      "name": "Lottie",
+      "c99name": "Lottie",
+      "src_type": "binary",
+      "label": "@swiftpkg_lottie_spm//:Lottie.rspm",
       "package_identity": "lottie-spm",
       "product_memberships": [
         "Lottie"
       ]
     },
     {
-      "name": "Lottie",
-      "c99name": "Lottie",
-      "src_type": "binary",
-      "label": "@swiftpkg_lottie_spm//:remote_archive_Lottie-Xcode-14.1.xcframework.zip_Lottie",
+      "name": "_LottieStub",
+      "c99name": "_LottieStub",
+      "src_type": "swift",
+      "label": "@swiftpkg_lottie_spm//:_LottieStub.rspm",
       "package_identity": "lottie-spm",
       "product_memberships": [
         "Lottie"
@@ -29,10 +29,7 @@
       "identity": "lottie-spm",
       "name": "Lottie",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_lottie_spm//:remote_archive_Lottie-Xcode-14.1.xcframework.zip_Lottie",
-        "@swiftpkg_lottie_spm//:Sources__LottieStub"
-      ]
+      "label": "@swiftpkg_lottie_spm//:Lottie"
     }
   ],
   "packages": [

--- a/examples/messagekit_example/Sources/BUILD.bazel
+++ b/examples/messagekit_example/Sources/BUILD.bazel
@@ -43,8 +43,8 @@ swift_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
-        "@swiftpkg_kingfisher//:Sources_Kingfisher",
-        "@swiftpkg_messagekit//:Sources_MessageKit",
+        "@swiftpkg_kingfisher//:Kingfisher",
+        "@swiftpkg_messagekit//:MessageKit",
     ],
 )
 

--- a/examples/messagekit_example/swift_deps_index.json
+++ b/examples/messagekit_example/swift_deps_index.json
@@ -8,8 +8,8 @@
       "name": "InputBarAccessoryView",
       "c99name": "InputBarAccessoryView",
       "src_type": "swift",
-      "label": "@swiftpkg_inputbaraccessoryview//:Sources_InputBarAccessoryView",
-      "modulemap_label": "@swiftpkg_inputbaraccessoryview//:Sources_InputBarAccessoryView_modulemap",
+      "label": "@swiftpkg_inputbaraccessoryview//:InputBarAccessoryView.rspm",
+      "modulemap_label": "@swiftpkg_inputbaraccessoryview//:InputBarAccessoryView.rspm_modulemap",
       "package_identity": "inputbaraccessoryview",
       "product_memberships": [
         "InputBarAccessoryView"
@@ -19,49 +19,49 @@
       "name": "Kingfisher",
       "c99name": "Kingfisher",
       "src_type": "swift",
-      "label": "@swiftpkg_kingfisher//:Sources_Kingfisher",
-      "modulemap_label": "@swiftpkg_kingfisher//:Sources_Kingfisher_modulemap",
+      "label": "@swiftpkg_kingfisher//:Kingfisher.rspm",
+      "modulemap_label": "@swiftpkg_kingfisher//:Kingfisher.rspm_modulemap",
       "package_identity": "kingfisher",
       "product_memberships": [
         "Kingfisher"
       ]
     },
     {
-      "name": "SwiftFormatPlugin",
-      "c99name": "SwiftFormatPlugin",
-      "src_type": "unknown",
-      "label": "@swiftpkg_messagekit//:Plugins_SwiftFormatPlugin",
-      "package_identity": "messagekit",
-      "product_memberships": [
-        "SwiftFormatPlugin"
-      ]
-    },
-    {
-      "name": "SwiftLintPlugin",
-      "c99name": "SwiftLintPlugin",
-      "src_type": "unknown",
-      "label": "@swiftpkg_messagekit//:Plugins_SwiftLintPlugin",
-      "package_identity": "messagekit",
-      "product_memberships": [
-        "SwiftLintPlugin"
-      ]
-    },
-    {
       "name": "MessageKit",
       "c99name": "MessageKit",
       "src_type": "swift",
-      "label": "@swiftpkg_messagekit//:Sources_MessageKit",
-      "modulemap_label": "@swiftpkg_messagekit//:Sources_MessageKit_modulemap",
+      "label": "@swiftpkg_messagekit//:MessageKit.rspm",
+      "modulemap_label": "@swiftpkg_messagekit//:MessageKit.rspm_modulemap",
       "package_identity": "messagekit",
       "product_memberships": [
         "MessageKit"
       ]
     },
     {
+      "name": "SwiftFormatPlugin",
+      "c99name": "SwiftFormatPlugin",
+      "src_type": "unknown",
+      "label": "@swiftpkg_messagekit//:SwiftFormatPlugin.rspm",
+      "package_identity": "messagekit",
+      "product_memberships": [
+        "SwiftFormatPlugin"
+      ]
+    },
+    {
       "name": "SwiftLintBinary",
       "c99name": "SwiftLintBinary",
       "src_type": "binary",
-      "label": "@swiftpkg_messagekit//:remote_archive_SwiftLintBinary-macos.artifactbundle.zip_SwiftLintBinary",
+      "label": "@swiftpkg_messagekit//:SwiftLintBinary.rspm",
+      "package_identity": "messagekit",
+      "product_memberships": [
+        "SwiftLintPlugin"
+      ]
+    },
+    {
+      "name": "SwiftLintPlugin",
+      "c99name": "SwiftLintPlugin",
+      "src_type": "unknown",
+      "label": "@swiftpkg_messagekit//:SwiftLintPlugin.rspm",
       "package_identity": "messagekit",
       "product_memberships": [
         "SwiftLintPlugin"
@@ -71,7 +71,7 @@
       "name": "swiftformat",
       "c99name": "swiftformat",
       "src_type": "binary",
-      "label": "@swiftpkg_messagekit//:remote_archive_swiftformat.artifactbundle.zip_swiftformat",
+      "label": "@swiftpkg_messagekit//:swiftformat.rspm",
       "package_identity": "messagekit",
       "product_memberships": [
         "SwiftFormatPlugin"
@@ -83,41 +83,31 @@
       "identity": "inputbaraccessoryview",
       "name": "InputBarAccessoryView",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_inputbaraccessoryview//:Sources_InputBarAccessoryView"
-      ]
+      "label": "@swiftpkg_inputbaraccessoryview//:InputBarAccessoryView"
     },
     {
       "identity": "kingfisher",
       "name": "Kingfisher",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_kingfisher//:Sources_Kingfisher"
-      ]
+      "label": "@swiftpkg_kingfisher//:Kingfisher"
     },
     {
       "identity": "messagekit",
       "name": "MessageKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_messagekit//:Sources_MessageKit"
-      ]
+      "label": "@swiftpkg_messagekit//:MessageKit"
     },
     {
       "identity": "messagekit",
       "name": "SwiftFormatPlugin",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_messagekit//:Plugins_SwiftFormatPlugin"
-      ]
+      "label": "@swiftpkg_messagekit//:SwiftFormatPlugin"
     },
     {
       "identity": "messagekit",
       "name": "SwiftLintPlugin",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_messagekit//:Plugins_SwiftLintPlugin"
-      ]
+      "label": "@swiftpkg_messagekit//:SwiftLintPlugin"
     }
   ],
   "packages": [

--- a/examples/nimble_example/Sources/NimbleExample/BUILD.bazel
+++ b/examples/nimble_example/Sources/NimbleExample/BUILD.bazel
@@ -13,9 +13,8 @@ swift_library(
     module_name = "NimbleExample",
     tags = ["manual"],
     deps = [
-        "@swiftpkg_nimble//:Sources_Nimble",
-        "@swiftpkg_nimble//:Sources_NimbleObjectiveC",
-        "@swiftpkg_quick//:Sources_Quick",
+        "@swiftpkg_nimble//:Nimble",
+        "@swiftpkg_quick//:Quick",
     ],
 )
 

--- a/examples/nimble_example/swift_deps_index.json
+++ b/examples/nimble_example/swift_deps_index.json
@@ -8,7 +8,7 @@
       "name": "CwlCatchException",
       "c99name": "CwlCatchException",
       "src_type": "swift",
-      "label": "@swiftpkg_cwlcatchexception//:Sources_CwlCatchException",
+      "label": "@swiftpkg_cwlcatchexception//:CwlCatchException.rspm",
       "package_identity": "cwlcatchexception",
       "product_memberships": [
         "CwlCatchException"
@@ -18,7 +18,7 @@
       "name": "CwlCatchExceptionSupport",
       "c99name": "CwlCatchExceptionSupport",
       "src_type": "objc",
-      "label": "@swiftpkg_cwlcatchexception//:Sources_CwlCatchExceptionSupport",
+      "label": "@swiftpkg_cwlcatchexception//:CwlCatchExceptionSupport.rspm",
       "package_identity": "cwlcatchexception",
       "product_memberships": [
         "CwlCatchException"
@@ -28,7 +28,7 @@
       "name": "CwlMachBadInstructionHandler",
       "c99name": "CwlMachBadInstructionHandler",
       "src_type": "objc",
-      "label": "@swiftpkg_cwlpreconditiontesting//:Sources_CwlMachBadInstructionHandler",
+      "label": "@swiftpkg_cwlpreconditiontesting//:CwlMachBadInstructionHandler.rspm",
       "package_identity": "cwlpreconditiontesting",
       "product_memberships": [
         "CwlPreconditionTesting"
@@ -38,7 +38,7 @@
       "name": "CwlPosixPreconditionTesting",
       "c99name": "CwlPosixPreconditionTesting",
       "src_type": "swift",
-      "label": "@swiftpkg_cwlpreconditiontesting//:Sources_CwlPosixPreconditionTesting",
+      "label": "@swiftpkg_cwlpreconditiontesting//:CwlPosixPreconditionTesting.rspm",
       "package_identity": "cwlpreconditiontesting",
       "product_memberships": [
         "CwlPosixPreconditionTesting"
@@ -48,8 +48,8 @@
       "name": "CwlPreconditionTesting",
       "c99name": "CwlPreconditionTesting",
       "src_type": "swift",
-      "label": "@swiftpkg_cwlpreconditiontesting//:Sources_CwlPreconditionTesting",
-      "modulemap_label": "@swiftpkg_cwlpreconditiontesting//:Sources_CwlPreconditionTesting_modulemap",
+      "label": "@swiftpkg_cwlpreconditiontesting//:CwlPreconditionTesting.rspm",
+      "modulemap_label": "@swiftpkg_cwlpreconditiontesting//:CwlPreconditionTesting.rspm_modulemap",
       "package_identity": "cwlpreconditiontesting",
       "product_memberships": [
         "CwlPreconditionTesting"
@@ -59,8 +59,8 @@
       "name": "Nimble",
       "c99name": "Nimble",
       "src_type": "swift",
-      "label": "@swiftpkg_nimble//:Sources_Nimble",
-      "modulemap_label": "@swiftpkg_nimble//:Sources_Nimble_modulemap",
+      "label": "@swiftpkg_nimble//:Nimble.rspm",
+      "modulemap_label": "@swiftpkg_nimble//:Nimble.rspm_modulemap",
       "package_identity": "nimble",
       "product_memberships": [
         "Nimble"
@@ -70,7 +70,7 @@
       "name": "NimbleObjectiveC",
       "c99name": "NimbleObjectiveC",
       "src_type": "objc",
-      "label": "@swiftpkg_nimble//:Sources_NimbleObjectiveC",
+      "label": "@swiftpkg_nimble//:NimbleObjectiveC.rspm",
       "package_identity": "nimble",
       "product_memberships": [
         "Nimble"
@@ -80,8 +80,8 @@
       "name": "Quick",
       "c99name": "Quick",
       "src_type": "swift",
-      "label": "@swiftpkg_quick//:Sources_Quick",
-      "modulemap_label": "@swiftpkg_quick//:Sources_Quick_modulemap",
+      "label": "@swiftpkg_quick//:Quick.rspm",
+      "modulemap_label": "@swiftpkg_quick//:Quick.rspm_modulemap",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -91,7 +91,7 @@
       "name": "QuickObjCRuntime",
       "c99name": "QuickObjCRuntime",
       "src_type": "objc",
-      "label": "@swiftpkg_quick//:Sources_QuickObjCRuntime",
+      "label": "@swiftpkg_quick//:QuickObjCRuntime.rspm",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -103,43 +103,31 @@
       "identity": "cwlcatchexception",
       "name": "CwlCatchException",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cwlcatchexception//:Sources_CwlCatchException"
-      ]
+      "label": "@swiftpkg_cwlcatchexception//:CwlCatchException"
     },
     {
       "identity": "cwlpreconditiontesting",
       "name": "CwlPosixPreconditionTesting",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cwlpreconditiontesting//:Sources_CwlPosixPreconditionTesting"
-      ]
+      "label": "@swiftpkg_cwlpreconditiontesting//:CwlPosixPreconditionTesting"
     },
     {
       "identity": "cwlpreconditiontesting",
       "name": "CwlPreconditionTesting",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cwlpreconditiontesting//:Sources_CwlPreconditionTesting",
-        "@swiftpkg_cwlpreconditiontesting//:Sources_CwlMachBadInstructionHandler"
-      ]
+      "label": "@swiftpkg_cwlpreconditiontesting//:CwlPreconditionTesting"
     },
     {
       "identity": "nimble",
       "name": "Nimble",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_nimble//:Sources_Nimble",
-        "@swiftpkg_nimble//:Sources_NimbleObjectiveC"
-      ]
+      "label": "@swiftpkg_nimble//:Nimble"
     },
     {
       "identity": "quick",
       "name": "Quick",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_quick//:Sources_Quick"
-      ]
+      "label": "@swiftpkg_quick//:Quick"
     }
   ],
   "packages": [

--- a/examples/objc_code/BUILD.bazel
+++ b/examples/objc_code/BUILD.bazel
@@ -43,7 +43,7 @@ swift_binary(
     srcs = ["main.swift"],
     visibility = ["//swift:__subpackages__"],
     deps = [
-        "@swiftpkg_trustkit//:TrustKit_TrustKit",
+        "@swiftpkg_trustkit//:TrustKitStatic",
     ],
 )
 

--- a/examples/objc_code/swift_deps_index.json
+++ b/examples/objc_code/swift_deps_index.json
@@ -7,7 +7,7 @@
       "name": "TrustKit",
       "c99name": "TrustKit",
       "src_type": "objc",
-      "label": "@swiftpkg_trustkit//:TrustKit_TrustKit",
+      "label": "@swiftpkg_trustkit//:TrustKit.rspm",
       "package_identity": "trustkit",
       "product_memberships": [
         "TrustKit",
@@ -21,25 +21,19 @@
       "identity": "trustkit",
       "name": "TrustKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_trustkit//:TrustKit_TrustKit"
-      ]
+      "label": "@swiftpkg_trustkit//:TrustKit"
     },
     {
       "identity": "trustkit",
       "name": "TrustKitDynamic",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_trustkit//:TrustKit_TrustKit"
-      ]
+      "label": "@swiftpkg_trustkit//:TrustKitDynamic"
     },
     {
       "identity": "trustkit",
       "name": "TrustKitStatic",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_trustkit//:TrustKit_TrustKit"
-      ]
+      "label": "@swiftpkg_trustkit//:TrustKitStatic"
     }
   ],
   "packages": [

--- a/examples/phone_number_kit/Tests/PhoneNumberKitTests/BUILD.bazel
+++ b/examples/phone_number_kit/Tests/PhoneNumberKitTests/BUILD.bazel
@@ -7,7 +7,7 @@ swift_library(
     srcs = ["ParseTests.swift"],
     module_name = "PhoneNumberKitTests",
     tags = ["manual"],
-    deps = ["@swiftpkg_phonenumberkit//:PhoneNumberKit_PhoneNumberKit"],
+    deps = ["@swiftpkg_phonenumberkit//:PhoneNumberKit-Static"],
 )
 
 ios_unit_test(

--- a/examples/phone_number_kit/swift_deps_index.json
+++ b/examples/phone_number_kit/swift_deps_index.json
@@ -7,8 +7,8 @@
       "name": "PhoneNumberKit",
       "c99name": "PhoneNumberKit",
       "src_type": "swift",
-      "label": "@swiftpkg_phonenumberkit//:PhoneNumberKit_PhoneNumberKit",
-      "modulemap_label": "@swiftpkg_phonenumberkit//:PhoneNumberKit_PhoneNumberKit_modulemap",
+      "label": "@swiftpkg_phonenumberkit//:PhoneNumberKit.rspm",
+      "modulemap_label": "@swiftpkg_phonenumberkit//:PhoneNumberKit.rspm_modulemap",
       "package_identity": "phonenumberkit",
       "product_memberships": [
         "PhoneNumberKit",
@@ -22,25 +22,19 @@
       "identity": "phonenumberkit",
       "name": "PhoneNumberKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_phonenumberkit//:PhoneNumberKit_PhoneNumberKit"
-      ]
+      "label": "@swiftpkg_phonenumberkit//:PhoneNumberKit"
     },
     {
       "identity": "phonenumberkit",
       "name": "PhoneNumberKit-Dynamic",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_phonenumberkit//:PhoneNumberKit_PhoneNumberKit"
-      ]
+      "label": "@swiftpkg_phonenumberkit//:PhoneNumberKit-Dynamic"
     },
     {
       "identity": "phonenumberkit",
       "name": "PhoneNumberKit-Static",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_phonenumberkit//:PhoneNumberKit_PhoneNumberKit"
-      ]
+      "label": "@swiftpkg_phonenumberkit//:PhoneNumberKit-Static"
     }
   ],
   "packages": [

--- a/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyExecutable/BUILD.bazel
@@ -7,8 +7,8 @@ swift_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//Sources/MyLibrary",
-        "@swiftpkg_my_local_package//:Sources_GreetingsFramework",
-        "@swiftpkg_notthatamazingmodule//:Sources_NotThatAmazingModule",
-        "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser",
+        "@swiftpkg_my_local_package//:GreetingsFramework",
+        "@swiftpkg_notthatamazingmodule//:NotThatAmazingModule",
+        "@swiftpkg_swift_argument_parser//:ArgumentParser",
     ],
 )

--- a/examples/pkg_manifest_minimal/Sources/MyLibrary/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Sources/MyLibrary/BUILD.bazel
@@ -5,5 +5,5 @@ swift_library(
     srcs = ["World.swift"],
     module_name = "MyLibrary",
     visibility = ["//visibility:public"],
-    deps = ["@swiftpkg_my_local_package//:Sources_GreetingsFramework"],
+    deps = ["@swiftpkg_my_local_package//:GreetingsFramework"],
 )

--- a/examples/pkg_manifest_minimal/swift_deps_index.json
+++ b/examples/pkg_manifest_minimal/swift_deps_index.json
@@ -12,7 +12,7 @@
       "name": "GreetingsFramework",
       "c99name": "GreetingsFramework",
       "src_type": "swift",
-      "label": "@swiftpkg_my_local_package//:Sources_GreetingsFramework",
+      "label": "@swiftpkg_my_local_package//:GreetingsFramework.rspm",
       "package_identity": "my_local_package",
       "product_memberships": [
         "print-greeting",
@@ -23,7 +23,7 @@
       "name": "PrintGreeting",
       "c99name": "PrintGreeting",
       "src_type": "swift",
-      "label": "@swiftpkg_my_local_package//:Sources_PrintGreeting",
+      "label": "@swiftpkg_my_local_package//:PrintGreeting.rspm",
       "package_identity": "my_local_package",
       "product_memberships": [
         "print-greeting"
@@ -33,7 +33,7 @@
       "name": "MyAmazingModule",
       "c99name": "MyAmazingModule",
       "src_type": "swift",
-      "label": "@swiftpkg_myamazingmodule//:Sources_MyAmazingModule",
+      "label": "@swiftpkg_myamazingmodule//:MyAmazingModule.rspm",
       "package_identity": "myamazingmodule",
       "product_memberships": [
         "MyAmazingModule"
@@ -43,27 +43,17 @@
       "name": "NotThatAmazingModule",
       "c99name": "NotThatAmazingModule",
       "src_type": "swift",
-      "label": "@swiftpkg_notthatamazingmodule//:Sources_NotThatAmazingModule",
+      "label": "@swiftpkg_notthatamazingmodule//:NotThatAmazingModule.rspm",
       "package_identity": "notthatamazingmodule",
       "product_memberships": [
         "NotThatAmazingModule"
       ]
     },
     {
-      "name": "GenerateManual",
-      "c99name": "GenerateManual",
-      "src_type": "unknown",
-      "label": "@swiftpkg_swift_argument_parser//:Plugins_GenerateManual",
-      "package_identity": "swift-argument-parser",
-      "product_memberships": [
-        "GenerateManual"
-      ]
-    },
-    {
       "name": "ArgumentParser",
       "c99name": "ArgumentParser",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser",
+      "label": "@swiftpkg_swift_argument_parser//:ArgumentParser.rspm",
       "package_identity": "swift-argument-parser",
       "product_memberships": [
         "ArgumentParser",
@@ -74,7 +64,7 @@
       "name": "ArgumentParserToolInfo",
       "c99name": "ArgumentParserToolInfo",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_argument_parser//:Sources_ArgumentParserToolInfo",
+      "label": "@swiftpkg_swift_argument_parser//:ArgumentParserToolInfo.rspm",
       "package_identity": "swift-argument-parser",
       "product_memberships": [
         "ArgumentParser",
@@ -82,10 +72,20 @@
       ]
     },
     {
+      "name": "GenerateManual",
+      "c99name": "GenerateManual",
+      "src_type": "unknown",
+      "label": "@swiftpkg_swift_argument_parser//:GenerateManual.rspm",
+      "package_identity": "swift-argument-parser",
+      "product_memberships": [
+        "GenerateManual"
+      ]
+    },
+    {
       "name": "generate-manual",
       "c99name": "generate_manual",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_argument_parser//:Tools_generate-manual",
+      "label": "@swiftpkg_swift_argument_parser//:generate-manual.rspm",
       "package_identity": "swift-argument-parser",
       "product_memberships": [
         "GenerateManual"
@@ -95,7 +95,7 @@
       "name": "Logging",
       "c99name": "Logging",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_log//:Sources_Logging",
+      "label": "@swiftpkg_swift_log//:Logging.rspm",
       "package_identity": "swift-log",
       "product_memberships": [
         "Logging"
@@ -105,20 +105,10 @@
       "name": "CommandLineTool",
       "c99name": "CommandLineTool",
       "src_type": "swift",
-      "label": "@swiftpkg_swiftformat//:CommandLineTool_CommandLineTool",
+      "label": "@swiftpkg_swiftformat//:CommandLineTool.rspm",
       "package_identity": "swiftformat",
       "product_memberships": [
         "swiftformat",
-        "SwiftFormatPlugin"
-      ]
-    },
-    {
-      "name": "SwiftFormatPlugin",
-      "c99name": "SwiftFormatPlugin",
-      "src_type": "unknown",
-      "label": "@swiftpkg_swiftformat//:Plugins_SwiftFormatPlugin",
-      "package_identity": "swiftformat",
-      "product_memberships": [
         "SwiftFormatPlugin"
       ]
     },
@@ -126,12 +116,22 @@
       "name": "SwiftFormat",
       "c99name": "SwiftFormat",
       "src_type": "swift",
-      "label": "@swiftpkg_swiftformat//:Sources_SwiftFormat",
-      "modulemap_label": "@swiftpkg_swiftformat//:Sources_SwiftFormat_modulemap",
+      "label": "@swiftpkg_swiftformat//:SwiftFormat.rspm",
+      "modulemap_label": "@swiftpkg_swiftformat//:SwiftFormat.rspm_modulemap",
       "package_identity": "swiftformat",
       "product_memberships": [
         "swiftformat",
         "SwiftFormat",
+        "SwiftFormatPlugin"
+      ]
+    },
+    {
+      "name": "SwiftFormatPlugin",
+      "c99name": "SwiftFormatPlugin",
+      "src_type": "unknown",
+      "label": "@swiftpkg_swiftformat//:SwiftFormatPlugin.rspm",
+      "package_identity": "swiftformat",
+      "product_memberships": [
         "SwiftFormatPlugin"
       ]
     }
@@ -141,81 +141,61 @@
       "identity": "my_local_package",
       "name": "GreetingsFramework",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_my_local_package//:Sources_GreetingsFramework"
-      ]
+      "label": "@swiftpkg_my_local_package//:GreetingsFramework"
     },
     {
       "identity": "my_local_package",
       "name": "print-greeting",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_my_local_package//:Sources_PrintGreeting"
-      ]
+      "label": "@swiftpkg_my_local_package//:print-greeting"
     },
     {
       "identity": "myamazingmodule",
       "name": "MyAmazingModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_myamazingmodule//:Sources_MyAmazingModule"
-      ]
+      "label": "@swiftpkg_myamazingmodule//:MyAmazingModule"
     },
     {
       "identity": "notthatamazingmodule",
       "name": "NotThatAmazingModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_notthatamazingmodule//:Sources_NotThatAmazingModule"
-      ]
+      "label": "@swiftpkg_notthatamazingmodule//:NotThatAmazingModule"
     },
     {
       "identity": "swift-argument-parser",
       "name": "ArgumentParser",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser"
-      ]
+      "label": "@swiftpkg_swift_argument_parser//:ArgumentParser"
     },
     {
       "identity": "swift-argument-parser",
       "name": "GenerateManual",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_swift_argument_parser//:Plugins_GenerateManual"
-      ]
+      "label": "@swiftpkg_swift_argument_parser//:GenerateManual"
     },
     {
       "identity": "swift-log",
       "name": "Logging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_log//:Sources_Logging"
-      ]
+      "label": "@swiftpkg_swift_log//:Logging"
     },
     {
       "identity": "swiftformat",
       "name": "SwiftFormat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swiftformat//:Sources_SwiftFormat"
-      ]
+      "label": "@swiftpkg_swiftformat//:SwiftFormat"
     },
     {
       "identity": "swiftformat",
       "name": "SwiftFormatPlugin",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_swiftformat//:Plugins_SwiftFormatPlugin"
-      ]
+      "label": "@swiftpkg_swiftformat//:SwiftFormatPlugin"
     },
     {
       "identity": "swiftformat",
       "name": "swiftformat",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swiftformat//:CommandLineTool_CommandLineTool"
-      ]
+      "label": "@swiftpkg_swiftformat//:swiftformat"
     }
   ],
   "packages": [

--- a/examples/resources_example/MODULE.bazel.lock
+++ b/examples/resources_example/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "8eac54fb1e06f43d170844678240d92b9083ba2c7e90d5fc2032acc549992d4b",
+  "moduleFileHash": "078db646d204a7aa0a2afef07e118c77cfa8baa5251c18f804998b0cd1fcfe71",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -81,8 +81,8 @@
         "rules_swift_package_manager": "rules_swift_package_manager@_",
         "cgrindel_bazel_starlib": "cgrindel_bazel_starlib@0.19.0",
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "apple_support": "apple_support@1.11.1",
-        "build_bazel_rules_swift": "rules_swift@1.15.1",
+        "apple_support": "apple_support@1.12.0",
+        "build_bazel_rules_swift": "rules_swift@1.16.0",
         "build_bazel_rules_apple": "rules_apple@3.2.1",
         "bazel_skylib_gazelle_plugin": "bazel_skylib_gazelle_plugin@1.5.0",
         "bazel_gazelle": "gazelle@0.35.0",
@@ -156,10 +156,10 @@
         "cgrindel_bazel_starlib": "cgrindel_bazel_starlib@0.19.0",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "io_bazel_rules_go": "rules_go@0.44.0",
-        "apple_support": "apple_support@1.11.1",
+        "apple_support": "apple_support@1.12.0",
         "rules_cc": "rules_cc@0.0.9",
         "platforms": "platforms@0.0.7",
-        "build_bazel_rules_swift": "rules_swift@1.15.1",
+        "build_bazel_rules_swift": "rules_swift@1.16.0",
         "build_bazel_rules_apple": "rules_apple@3.2.1",
         "bazel_gazelle": "gazelle@0.35.0",
         "bazel_tools": "bazel_tools@_",
@@ -266,10 +266,10 @@
         }
       }
     },
-    "apple_support@1.11.1": {
+    "apple_support@1.12.0": {
       "name": "apple_support",
-      "version": "1.11.1",
-      "key": "apple_support@1.11.1",
+      "version": "1.12.0",
+      "key": "apple_support@1.12.0",
       "repoName": "build_bazel_apple_support",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [
@@ -279,9 +279,9 @@
         {
           "extensionBzlFile": "@build_bazel_apple_support//crosstool:setup.bzl",
           "extensionName": "apple_cc_configure_extension",
-          "usingModule": "apple_support@1.11.1",
+          "usingModule": "apple_support@1.12.0",
           "location": {
-            "file": "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/apple_support/1.12.0/MODULE.bazel",
             "line": 19,
             "column": 35
           },
@@ -305,23 +305,23 @@
         "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "apple_support~1.11.1",
+          "name": "apple_support~1.12.0",
           "urls": [
-            "https://github.com/bazelbuild/apple_support/releases/download/1.11.1/apple_support.1.11.1.tar.gz"
+            "https://github.com/bazelbuild/apple_support/releases/download/1.12.0/apple_support.1.12.0.tar.gz"
           ],
-          "integrity": "sha256-z01j85x7qQWfcOmVv1/hAZJn0/dzecIChWGl12Re9nw=",
+          "integrity": "sha256-EA0SYXqE68fuehDs87Pi/a2uvBZ62Toh+CCmy2AVjq0=",
           "strip_prefix": "",
           "remote_patches": {
-            "https://bcr.bazel.build/modules/apple_support/1.11.1/patches/module_dot_bazel_version.patch": "sha256-G9CcKWR97sA/vnt8STjg1YRdFBMHHLHVmUwuHe6f+bs="
+            "https://bcr.bazel.build/modules/apple_support/1.12.0/patches/module_dot_bazel_version.patch": "sha256-3XmsovSEa1wpKpWGFSDAhBawIG5gQBNKF221WV0Qzks="
           },
           "remote_patch_strip": 1
         }
       }
     },
-    "rules_swift@1.15.1": {
+    "rules_swift@1.16.0": {
       "name": "rules_swift",
-      "version": "1.15.1",
-      "key": "rules_swift@1.15.1",
+      "version": "1.16.0",
+      "key": "rules_swift@1.16.0",
       "repoName": "build_bazel_rules_swift",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [],
@@ -329,9 +329,9 @@
         {
           "extensionBzlFile": "@build_bazel_rules_swift//swift:extensions.bzl",
           "extensionName": "non_module_deps",
-          "usingModule": "rules_swift@1.15.1",
+          "usingModule": "rules_swift@1.16.0",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_swift/1.15.1/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel",
             "line": 18,
             "column": 32
           },
@@ -354,9 +354,9 @@
         {
           "extensionBzlFile": "@build_bazel_apple_support//crosstool:setup.bzl",
           "extensionName": "apple_cc_configure_extension",
-          "usingModule": "rules_swift@1.15.1",
+          "usingModule": "rules_swift@1.16.0",
           "location": {
-            "file": "https://bcr.bazel.build/modules/rules_swift/1.15.1/MODULE.bazel",
+            "file": "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel",
             "line": 32,
             "column": 35
           },
@@ -372,7 +372,7 @@
       "deps": {
         "bazel_features": "bazel_features@1.3.0",
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "build_bazel_apple_support": "apple_support@1.11.1",
+        "build_bazel_apple_support": "apple_support@1.12.0",
         "rules_cc": "rules_cc@0.0.9",
         "platforms": "platforms@0.0.7",
         "com_google_protobuf": "protobuf@21.7",
@@ -385,14 +385,14 @@
         "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
         "ruleClassName": "http_archive",
         "attributes": {
-          "name": "rules_swift~1.15.1",
+          "name": "rules_swift~1.16.0",
           "urls": [
-            "https://github.com/bazelbuild/rules_swift/releases/download/1.15.1/rules_swift.1.15.1.tar.gz"
+            "https://github.com/bazelbuild/rules_swift/releases/download/1.16.0/rules_swift.1.16.0.tar.gz"
           ],
-          "integrity": "sha256-4u7kY4OUg9/hsFzkBqTy+z/XSN3KoxHMh2j6fwQa8P8=",
+          "integrity": "sha256-eqvju++NLgfJ7gess4bwole9L3bqjiEAVoi1BtyNpns=",
           "strip_prefix": "",
           "remote_patches": {
-            "https://bcr.bazel.build/modules/rules_swift/1.15.1/patches/module_dot_bazel_version.patch": "sha256-rMxzgZs1JKbQr3jJYCgiTGhj7zN0SOZurnW50gFgONA="
+            "https://bcr.bazel.build/modules/rules_swift/1.16.0/patches/module_dot_bazel_version.patch": "sha256-66B/4JaIUXEe4yUstQpgvRbYzXLR9nJ+Z7AlzEkxLE4="
           },
           "remote_patch_strip": 1
         }
@@ -459,10 +459,10 @@
         }
       ],
       "deps": {
-        "build_bazel_apple_support": "apple_support@1.11.1",
+        "build_bazel_apple_support": "apple_support@1.12.0",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "platforms": "platforms@0.0.7",
-        "build_bazel_rules_swift": "rules_swift@1.15.1",
+        "build_bazel_rules_swift": "rules_swift@1.16.0",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -799,7 +799,7 @@
         "platforms": "platforms@0.0.7",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.3",
-        "build_bazel_apple_support": "apple_support@1.11.1",
+        "build_bazel_apple_support": "apple_support@1.12.0",
         "local_config_platform": "local_config_platform@_"
       }
     },
@@ -1705,30 +1705,30 @@
     }
   },
   "moduleExtensions": {
-    "@@apple_support~1.11.1//crosstool:setup.bzl%apple_cc_configure_extension": {
+    "@@apple_support~1.12.0//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "FOTImXZOLQw+EqKi3u13A1a5Wff22EtyCed2Cz1AiW0=",
+        "bzlTransitiveDigest": "TMkUP4/N3ZORvZrcDg9FxSoW9r/7+uDVH/SI2biRyJg=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "local_config_apple_cc": {
-            "bzlFile": "@@apple_support~1.11.1//crosstool:setup.bzl",
+            "bzlFile": "@@apple_support~1.12.0//crosstool:setup.bzl",
             "ruleClassName": "_apple_cc_autoconf",
             "attributes": {
-              "name": "apple_support~1.11.1~apple_cc_configure_extension~local_config_apple_cc"
+              "name": "apple_support~1.12.0~apple_cc_configure_extension~local_config_apple_cc"
             }
           },
           "local_config_apple_cc_toolchains": {
-            "bzlFile": "@@apple_support~1.11.1//crosstool:setup.bzl",
+            "bzlFile": "@@apple_support~1.12.0//crosstool:setup.bzl",
             "ruleClassName": "_apple_cc_autoconf_toolchains",
             "attributes": {
-              "name": "apple_support~1.11.1~apple_cc_configure_extension~local_config_apple_cc_toolchains"
+              "name": "apple_support~1.12.0~apple_cc_configure_extension~local_config_apple_cc_toolchains"
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
-            "apple_support~1.11.1",
+            "apple_support~1.12.0",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -1968,13 +1968,13 @@
         "bzlTransitiveDigest": "zP01muRk4s4xWGK3gNPXOyDMQkOPsIhu99akeKWFFQ0=",
         "accumulatedFileDigests": {
           "@@cgrindel_bazel_starlib~0.19.0//:go.sum": "0727e3bd41e30d078e0f0a4cecc353769997a0708df9eb6cbc7852d1b354c796",
-          "@@rules_swift_package_manager~override//:go.sum": "af3ca06e91b4025fb562dfd27139fad12c69bddd4383bdd9104a34fde64b11d5",
+          "@@rules_swift_package_manager~override//:go.sum": "d4edd30cacfea3691acf8373bc83b3a643ccae5284085a8cbce6d3933586b35c",
           "@@cgrindel_bazel_starlib~0.19.0//:go.mod": "db78d7d0340190c786236e901b5c792022ae8da223e42910dfcc5f6a2df577bf",
           "@@rules_go~0.44.0//:go.mod": "15454724af1504c4ce1782c2a7f423d596a1d8490125eb7c5bd9c95fea1991f0",
           "@@gazelle~0.35.0//:go.mod": "48dc6e771c3028ee1c18b9ffc81e596fd5f6d7e0016c5ef280e30f2821f60473",
           "@@gazelle~0.35.0//:go.sum": "7c4460e8ecb5dd8691a51d4fa2e9e4751108b933636497ce46db499fc2e7a88d",
           "@@rules_go~0.44.0//:go.sum": "b5938730bf7d3581421928b0385d99648dd9634becead96fca0594ac491b2f49",
-          "@@rules_swift_package_manager~override//:go.mod": "83b9681e4fbae80c42b81016536229ff999b07d877ff6d2cadd7e932655d593c"
+          "@@rules_swift_package_manager~override//:go.mod": "948db7237b4c72de4e224f20c6eb5630afe940fff1212f32d0fe556349f57598"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2133,9 +2133,9 @@
               "build_extra_args": [],
               "patches": [],
               "patch_args": [],
-              "sum": "h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=",
+              "sum": "h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=",
               "replace": "",
-              "version": "v0.0.0-20230905200255-921286631fa9"
+              "version": "v0.0.0-20240119083558-1b970713d09a"
             }
           },
           "org_golang_x_net": {
@@ -2467,7 +2467,13 @@
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO"
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "gazelle~0.35.0",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@gazelle~0.35.0//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
@@ -2665,6 +2671,203 @@
               "sdk_repos": [
                 "go_default_sdk",
                 "rules_go__download_0_darwin_arm64",
+                "rules_go__download_0_linux_amd64",
+                "rules_go__download_0_linux_arm64",
+                "rules_go__download_0_windows_amd64",
+                "rules_go__download_0_windows_arm64"
+              ],
+              "sdk_types": [
+                "remote",
+                "remote",
+                "remote",
+                "remote",
+                "remote",
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.21.1",
+                "1.21.1",
+                "1.21.1",
+                "1.21.1",
+                "1.21.1",
+                "1.21.1"
+              ]
+            }
+          },
+          "rules_go__download_0_windows_amd64": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~rules_go__download_0_windows_amd64",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~1.3.0",
+            "bazel_features_globals",
+            "bazel_features~1.3.0~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~1.3.0",
+            "bazel_features_version",
+            "bazel_features~1.3.0~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~0.44.0",
+            "bazel_features",
+            "bazel_features~1.3.0"
+          ],
+          [
+            "rules_go~0.44.0",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go~0.44.0",
+            "io_bazel_rules_go",
+            "rules_go~0.44.0"
+          ]
+        ]
+      },
+      "os:osx,arch:aarch64": {
+        "bzlTransitiveDigest": "GI6yMOM2hDU7hVAHmfnV90TgIqJguaDlemn2az5C07E=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "io_bazel_rules_nogo": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:nogo.bzl",
+            "ruleClassName": "go_register_nogo",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~io_bazel_rules_nogo",
+              "nogo": "@io_bazel_rules_go//:default_nogo",
+              "includes": [
+                "'@@//:__subpackages__'"
+              ],
+              "excludes": []
+            }
+          },
+          "rules_go__download_0_windows_arm64": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~rules_go__download_0_windows_arm64",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1"
+            }
+          },
+          "rules_go__download_0_linux_arm64": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~rules_go__download_0_linux_arm64",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1"
+            }
+          },
+          "go_default_sdk": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~go_default_sdk",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "experiments": [],
+              "patches": [],
+              "patch_strip": 0,
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1",
+              "strip_prefix": "go"
+            }
+          },
+          "go_host_compatible_sdk_label": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:extensions.bzl",
+            "ruleClassName": "host_compatible_toolchain",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~go_host_compatible_sdk_label",
+              "toolchain": "@go_default_sdk//:ROOT"
+            }
+          },
+          "rules_go__download_0_linux_amd64": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~rules_go__download_0_linux_amd64",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1"
+            }
+          },
+          "rules_go__download_0_darwin_amd64": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~rules_go__download_0_darwin_amd64",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1"
+            }
+          },
+          "go_toolchains": {
+            "bzlFile": "@@rules_go~0.44.0//go/private:sdk.bzl",
+            "ruleClassName": "go_multiple_toolchains",
+            "attributes": {
+              "name": "rules_go~0.44.0~go_sdk~go_toolchains",
+              "prefixes": [
+                "_0000_go_default_sdk_",
+                "_0001_rules_go__download_0_darwin_amd64_",
+                "_0002_rules_go__download_0_linux_amd64_",
+                "_0003_rules_go__download_0_linux_arm64_",
+                "_0004_rules_go__download_0_windows_amd64_",
+                "_0005_rules_go__download_0_windows_arm64_"
+              ],
+              "geese": [
+                "",
+                "darwin",
+                "linux",
+                "linux",
+                "windows",
+                "windows"
+              ],
+              "goarchs": [
+                "",
+                "amd64",
+                "amd64",
+                "arm64",
+                "amd64",
+                "arm64"
+              ],
+              "sdk_repos": [
+                "go_default_sdk",
+                "rules_go__download_0_darwin_amd64",
                 "rules_go__download_0_linux_amd64",
                 "rules_go__download_0_linux_arm64",
                 "rules_go__download_0_windows_amd64",
@@ -3286,9 +3489,9 @@
     },
     "@@rules_swift_package_manager~override//:extensions.bzl%swift_deps": {
       "general": {
-        "bzlTransitiveDigest": "RAXmIOdYeEgAIU2uKKJFxO3Uqo7xvnGxHmOD276y14c=",
+        "bzlTransitiveDigest": "as4eezfsKxYRPI/SCDwyVkNTkS1/5QeaOQDknddac6Q=",
         "accumulatedFileDigests": {
-          "@@//:swift_deps_index.json": "3be7742c44abf40672933dc1220e8ada77e4cf88cd3117e01fa449d128cec021"
+          "@@//:swift_deps_index.json": "e4d9172b140ed339681c9778ef026e7eb354db69e4b2d5abceb39cf44b0ab6ec"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3462,7 +3665,7 @@
         ]
       }
     },
-    "@@rules_swift~1.15.1//swift:extensions.bzl%non_module_deps": {
+    "@@rules_swift~1.16.0//swift:extensions.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "JXT9csgB0VHkXU94H+OROIY4q5dpOW0Di+C2YoFqVTM=",
         "accumulatedFileDigests": {},
@@ -3472,99 +3675,99 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_grpc_grpc_swift",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_grpc_grpc_swift",
               "urls": [
                 "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
               ],
               "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
               "strip_prefix": "grpc-swift-1.16.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
             }
           },
           "com_github_apple_swift_nio_extras": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_extras",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_extras",
               "urls": [
                 "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
               ],
               "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
               "strip_prefix": "swift-nio-extras-1.4.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
             }
           },
           "com_github_apple_swift_protobuf": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_protobuf",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_protobuf",
               "urls": [
                 "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
               ],
               "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
               "strip_prefix": "swift-protobuf-1.20.2/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
             }
           },
           "com_github_apple_swift_nio_ssl": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_ssl",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_ssl",
               "urls": [
                 "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
               ],
               "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
               "strip_prefix": "swift-nio-ssl-2.23.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
             }
           },
           "com_github_apple_swift_atomics": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_atomics",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_atomics",
               "urls": [
                 "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
               ],
               "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
               "strip_prefix": "swift-atomics-1.1.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_atomics/BUILD.overlay"
             }
           },
           "com_github_apple_swift_nio_http2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_http2",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_http2",
               "urls": [
                 "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
               ],
               "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
               "strip_prefix": "swift-nio-http2-1.26.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
             }
           },
           "com_github_apple_swift_nio_transport_services": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio_transport_services",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_transport_services",
               "urls": [
                 "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
               ],
               "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
               "strip_prefix": "swift-nio-transport-services-1.15.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
             }
           },
           "build_bazel_rules_swift_index_import": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~build_bazel_rules_swift_index_import",
-              "build_file": "@@rules_swift~1.15.1//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "name": "rules_swift~1.16.0~non_module_deps~build_bazel_rules_swift_index_import",
+              "build_file": "@@rules_swift~1.16.0//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
               "canonical_id": "index-import-5.8",
               "urls": [
                 "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
@@ -3576,59 +3779,59 @@
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_nio",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio",
               "urls": [
                 "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
               ],
               "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
               "strip_prefix": "swift-nio-2.42.0/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_nio/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio/BUILD.overlay"
             }
           },
           "com_github_apple_swift_log": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_log",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_log",
               "urls": [
                 "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
               ],
               "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
               "strip_prefix": "swift-log-1.4.4/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_log/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_log/BUILD.overlay"
             }
           },
           "com_github_apple_swift_collections": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~com_github_apple_swift_collections",
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_collections",
               "urls": [
                 "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
               ],
               "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
               "strip_prefix": "swift-collections-1.0.4/",
-              "build_file": "@@rules_swift~1.15.1//third_party:com_github_apple_swift_collections/BUILD.overlay"
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_collections/BUILD.overlay"
             }
           },
           "build_bazel_rules_swift_local_config": {
-            "bzlFile": "@@rules_swift~1.15.1//swift/internal:swift_autoconfiguration.bzl",
+            "bzlFile": "@@rules_swift~1.16.0//swift/internal:swift_autoconfiguration.bzl",
             "ruleClassName": "swift_autoconfiguration",
             "attributes": {
-              "name": "rules_swift~1.15.1~non_module_deps~build_bazel_rules_swift_local_config"
+              "name": "rules_swift~1.16.0~non_module_deps~build_bazel_rules_swift_local_config"
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_swift~1.15.1",
+            "rules_swift~1.16.0",
             "bazel_tools",
             "bazel_tools"
           ],
           [
-            "rules_swift~1.15.1",
+            "rules_swift~1.16.0",
             "build_bazel_rules_swift",
-            "rules_swift~1.15.1"
+            "rules_swift~1.16.0"
           ]
         ]
       }

--- a/examples/resources_example/Sources/MyApp/BUILD.bazel
+++ b/examples/resources_example/Sources/MyApp/BUILD.bazel
@@ -12,9 +12,9 @@ swift_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "@swiftpkg_another_package_with_resources//:MoreCoolUI",
-        "@swiftpkg_googlesignin_ios//:GoogleSignInSwift_Sources_GoogleSignInSwift",
-        "@swiftpkg_package_with_resources//:Sources_CoolUI",
-        "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI_Classes_SDWebImageSwiftUI",
+        "@swiftpkg_googlesignin_ios//:GoogleSignInSwift",
+        "@swiftpkg_package_with_resources//:CoolUI",
+        "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI",
     ],
 )
 

--- a/examples/resources_example/Tests/MyAppTests/BUILD.bazel
+++ b/examples/resources_example/Tests/MyAppTests/BUILD.bazel
@@ -10,8 +10,8 @@ swift_library(
     module_name = "MyAppTests",
     tags = ["manual"],
     deps = [
-        "@swiftpkg_app_lovin_sdk//:Sources_AppLovinSDKResources",
-        "@swiftpkg_package_with_resources//:Sources_CoolUI",
+        "@swiftpkg_app_lovin_sdk//:AppLovinSDK",
+        "@swiftpkg_package_with_resources//:CoolUI",
     ],
 )
 

--- a/examples/resources_example/swift_deps_index.json
+++ b/examples/resources_example/swift_deps_index.json
@@ -11,27 +11,27 @@
       "name": "MoreCoolUI",
       "c99name": "MoreCoolUI",
       "src_type": "swift",
-      "label": "@swiftpkg_another_package_with_resources//:MoreCoolUI",
+      "label": "@swiftpkg_another_package_with_resources//:MoreCoolUI.rspm",
       "package_identity": "another_package_with_resources",
       "product_memberships": [
         "MoreCoolUI"
       ]
     },
     {
-      "name": "AppLovinSDKResources",
-      "c99name": "AppLovinSDKResources",
-      "src_type": "objc",
-      "label": "@swiftpkg_app_lovin_sdk//:Sources_AppLovinSDKResources",
+      "name": "AppLovinSDK",
+      "c99name": "AppLovinSDK",
+      "src_type": "binary",
+      "label": "@swiftpkg_app_lovin_sdk//:AppLovinSDK.rspm",
       "package_identity": "app_lovin_sdk",
       "product_memberships": [
         "AppLovinSDK"
       ]
     },
     {
-      "name": "AppLovinSDK",
-      "c99name": "AppLovinSDK",
-      "src_type": "binary",
-      "label": "@swiftpkg_app_lovin_sdk//:remote_archive_AppLovinSDK-12.0.0.xcframework.zip_AppLovinSDK",
+      "name": "AppLovinSDKResources",
+      "c99name": "AppLovinSDKResources",
+      "src_type": "objc",
+      "label": "@swiftpkg_app_lovin_sdk//:AppLovinSDKResources.rspm",
       "package_identity": "app_lovin_sdk",
       "product_memberships": [
         "AppLovinSDK"
@@ -41,7 +41,7 @@
       "name": "AppAuth",
       "c99name": "AppAuth",
       "src_type": "objc",
-      "label": "@swiftpkg_appauth_ios//:Source_AppAuth",
+      "label": "@swiftpkg_appauth_ios//:AppAuth.rspm",
       "package_identity": "appauth-ios",
       "product_memberships": [
         "AppAuth"
@@ -51,7 +51,7 @@
       "name": "AppAuthCore",
       "c99name": "AppAuthCore",
       "src_type": "objc",
-      "label": "@swiftpkg_appauth_ios//:Source_AppAuthCore",
+      "label": "@swiftpkg_appauth_ios//:AppAuthCore.rspm",
       "package_identity": "appauth-ios",
       "product_memberships": [
         "AppAuthCore",
@@ -63,27 +63,17 @@
       "name": "AppAuthTV",
       "c99name": "AppAuthTV",
       "src_type": "objc",
-      "label": "@swiftpkg_appauth_ios//:Source_AppAuthTV",
+      "label": "@swiftpkg_appauth_ios//:AppAuthTV.rspm",
       "package_identity": "appauth-ios",
       "product_memberships": [
         "AppAuthTV"
       ]
     },
     {
-      "name": "GoogleSignInSwift",
-      "c99name": "GoogleSignInSwift",
-      "src_type": "swift",
-      "label": "@swiftpkg_googlesignin_ios//:GoogleSignInSwift_Sources_GoogleSignInSwift",
-      "package_identity": "googlesignin-ios",
-      "product_memberships": [
-        "GoogleSignInSwift"
-      ]
-    },
-    {
       "name": "GoogleSignIn",
       "c99name": "GoogleSignIn",
       "src_type": "objc",
-      "label": "@swiftpkg_googlesignin_ios//:GoogleSignIn_Sources_GoogleSignIn",
+      "label": "@swiftpkg_googlesignin_ios//:GoogleSignIn.rspm",
       "package_identity": "googlesignin-ios",
       "product_memberships": [
         "GoogleSignIn",
@@ -91,10 +81,20 @@
       ]
     },
     {
+      "name": "GoogleSignInSwift",
+      "c99name": "GoogleSignInSwift",
+      "src_type": "swift",
+      "label": "@swiftpkg_googlesignin_ios//:GoogleSignInSwift.rspm",
+      "package_identity": "googlesignin-ios",
+      "product_memberships": [
+        "GoogleSignInSwift"
+      ]
+    },
+    {
       "name": "GTMSessionFetcherCore",
       "c99name": "GTMSessionFetcherCore",
       "src_type": "objc",
-      "label": "@swiftpkg_gtm_session_fetcher//:Sources_Core_GTMSessionFetcherCore",
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherCore.rspm",
       "package_identity": "gtm-session-fetcher",
       "product_memberships": [
         "GTMSessionFetcher",
@@ -107,7 +107,7 @@
       "name": "GTMSessionFetcherFull",
       "c99name": "GTMSessionFetcherFull",
       "src_type": "objc",
-      "label": "@swiftpkg_gtm_session_fetcher//:Sources_Full_GTMSessionFetcherFull",
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherFull.rspm",
       "package_identity": "gtm-session-fetcher",
       "product_memberships": [
         "GTMSessionFetcher",
@@ -118,7 +118,7 @@
       "name": "GTMSessionFetcherLogView",
       "c99name": "GTMSessionFetcherLogView",
       "src_type": "objc",
-      "label": "@swiftpkg_gtm_session_fetcher//:Sources_LogView_GTMSessionFetcherLogView",
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherLogView.rspm",
       "package_identity": "gtm-session-fetcher",
       "product_memberships": [
         "GTMSessionFetcherLogView"
@@ -128,7 +128,7 @@
       "name": "GTMAppAuth",
       "c99name": "GTMAppAuth",
       "src_type": "objc",
-      "label": "@swiftpkg_gtmappauth//:GTMAppAuth_Sources_GTMAppAuth",
+      "label": "@swiftpkg_gtmappauth//:GTMAppAuth.rspm",
       "package_identity": "gtmappauth",
       "product_memberships": [
         "GTMAppAuth"
@@ -138,27 +138,17 @@
       "name": "CoolUI",
       "c99name": "CoolUI",
       "src_type": "swift",
-      "label": "@swiftpkg_package_with_resources//:Sources_CoolUI",
+      "label": "@swiftpkg_package_with_resources//:CoolUI.rspm",
       "package_identity": "package_with_resources",
       "product_memberships": [
         "CoolUI"
       ]
     },
     {
-      "name": "SDWebImageMapKit",
-      "c99name": "SDWebImageMapKit",
-      "src_type": "objc",
-      "label": "@swiftpkg_sdwebimage//:SDWebImageMapKit_SDWebImageMapKit",
-      "package_identity": "sdwebimage",
-      "product_memberships": [
-        "SDWebImageMapKit"
-      ]
-    },
-    {
       "name": "SDWebImage",
       "c99name": "SDWebImage",
       "src_type": "objc",
-      "label": "@swiftpkg_sdwebimage//:SDWebImage_SDWebImage",
+      "label": "@swiftpkg_sdwebimage//:SDWebImage.rspm",
       "package_identity": "sdwebimage",
       "product_memberships": [
         "SDWebImage",
@@ -166,10 +156,20 @@
       ]
     },
     {
+      "name": "SDWebImageMapKit",
+      "c99name": "SDWebImageMapKit",
+      "src_type": "objc",
+      "label": "@swiftpkg_sdwebimage//:SDWebImageMapKit.rspm",
+      "package_identity": "sdwebimage",
+      "product_memberships": [
+        "SDWebImageMapKit"
+      ]
+    },
+    {
       "name": "SDWebImageSwiftUI",
       "c99name": "SDWebImageSwiftUI",
       "src_type": "swift",
-      "label": "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI_Classes_SDWebImageSwiftUI",
+      "label": "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI.rspm",
       "package_identity": "sdwebimageswiftui",
       "product_memberships": [
         "SDWebImageSwiftUI"
@@ -181,130 +181,97 @@
       "identity": "another_package_with_resources",
       "name": "MoreCoolUI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_another_package_with_resources//:MoreCoolUI"
-      ]
+      "label": "@swiftpkg_another_package_with_resources//:MoreCoolUI"
     },
     {
       "identity": "app_lovin_sdk",
       "name": "AppLovinSDK",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_app_lovin_sdk//:Sources_AppLovinSDKResources"
-      ]
+      "label": "@swiftpkg_app_lovin_sdk//:AppLovinSDK"
     },
     {
       "identity": "appauth-ios",
       "name": "AppAuth",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_appauth_ios//:Source_AppAuth"
-      ]
+      "label": "@swiftpkg_appauth_ios//:AppAuth"
     },
     {
       "identity": "appauth-ios",
       "name": "AppAuthCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_appauth_ios//:Source_AppAuthCore"
-      ]
+      "label": "@swiftpkg_appauth_ios//:AppAuthCore"
     },
     {
       "identity": "appauth-ios",
       "name": "AppAuthTV",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_appauth_ios//:Source_AppAuthTV"
-      ]
+      "label": "@swiftpkg_appauth_ios//:AppAuthTV"
     },
     {
       "identity": "googlesignin-ios",
       "name": "GoogleSignIn",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googlesignin_ios//:GoogleSignIn_Sources_GoogleSignIn"
-      ]
+      "label": "@swiftpkg_googlesignin_ios//:GoogleSignIn"
     },
     {
       "identity": "googlesignin-ios",
       "name": "GoogleSignInSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_googlesignin_ios//:GoogleSignInSwift_Sources_GoogleSignInSwift"
-      ]
+      "label": "@swiftpkg_googlesignin_ios//:GoogleSignInSwift"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcher",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_Core_GTMSessionFetcherCore",
-        "@swiftpkg_gtm_session_fetcher//:Sources_Full_GTMSessionFetcherFull"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcher"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcherCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_Core_GTMSessionFetcherCore"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherCore"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcherFull",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_Full_GTMSessionFetcherFull"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherFull"
     },
     {
       "identity": "gtm-session-fetcher",
       "name": "GTMSessionFetcherLogView",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtm_session_fetcher//:Sources_LogView_GTMSessionFetcherLogView"
-      ]
+      "label": "@swiftpkg_gtm_session_fetcher//:GTMSessionFetcherLogView"
     },
     {
       "identity": "gtmappauth",
       "name": "GTMAppAuth",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gtmappauth//:GTMAppAuth_Sources_GTMAppAuth"
-      ]
+      "label": "@swiftpkg_gtmappauth//:GTMAppAuth"
     },
     {
       "identity": "package_with_resources",
       "name": "CoolUI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_package_with_resources//:Sources_CoolUI"
-      ]
+      "label": "@swiftpkg_package_with_resources//:CoolUI"
     },
     {
       "identity": "sdwebimageswiftui",
       "name": "SDWebImageSwiftUI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI_Classes_SDWebImageSwiftUI"
-      ]
+      "label": "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI"
     },
     {
       "identity": "sdwebimage",
       "name": "SDWebImage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sdwebimage//:SDWebImage_SDWebImage"
-      ]
+      "label": "@swiftpkg_sdwebimage//:SDWebImage"
     },
     {
       "identity": "sdwebimage",
       "name": "SDWebImageMapKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sdwebimage//:SDWebImageMapKit_SDWebImageMapKit"
-      ]
+      "label": "@swiftpkg_sdwebimage//:SDWebImageMapKit"
     }
   ],
   "packages": [

--- a/examples/shake_ios_example/ShakeIOSExample/BUILD.bazel
+++ b/examples/shake_ios_example/ShakeIOSExample/BUILD.bazel
@@ -10,7 +10,7 @@ swift_library(
     module_name = "ShakeIOSExample",
     tags = ["manual"],
     visibility = ["//:__subpackages__"],
-    deps = ["@swiftpkg_shake_ios//:Sources_Shake.xcframework_Shake"],
+    deps = ["@swiftpkg_shake_ios//:Shake"],
 )
 
 ios_application(

--- a/examples/shake_ios_example/swift_deps_index.json
+++ b/examples/shake_ios_example/swift_deps_index.json
@@ -7,7 +7,7 @@
       "name": "Shake",
       "c99name": "Shake",
       "src_type": "binary",
-      "label": "@swiftpkg_shake_ios//:Sources_Shake.xcframework_Shake",
+      "label": "@swiftpkg_shake_ios//:Shake.rspm",
       "package_identity": "shake-ios",
       "product_memberships": [
         "Shake"
@@ -19,9 +19,7 @@
       "identity": "shake-ios",
       "name": "Shake",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_shake_ios//:Sources_Shake.xcframework_Shake"
-      ]
+      "label": "@swiftpkg_shake_ios//:Shake"
     }
   ],
   "packages": [

--- a/examples/snapkit_example/BUILD.bazel
+++ b/examples/snapkit_example/BUILD.bazel
@@ -51,7 +51,7 @@ swift_library(
     module_name = "SnapkitExample",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = ["@swiftpkg_snapkit//:Sources_SnapKit"],
+    deps = ["@swiftpkg_snapkit//:SnapKit-Dynamic"],
 )
 
 ios_application(

--- a/examples/snapkit_example/swift_deps_index.json
+++ b/examples/snapkit_example/swift_deps_index.json
@@ -7,7 +7,7 @@
       "name": "SnapKit",
       "c99name": "SnapKit",
       "src_type": "swift",
-      "label": "@swiftpkg_snapkit//:Sources_SnapKit",
+      "label": "@swiftpkg_snapkit//:SnapKit.rspm",
       "package_identity": "snapkit",
       "product_memberships": [
         "SnapKit",
@@ -20,17 +20,13 @@
       "identity": "snapkit",
       "name": "SnapKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_snapkit//:Sources_SnapKit"
-      ]
+      "label": "@swiftpkg_snapkit//:SnapKit"
     },
     {
       "identity": "snapkit",
       "name": "SnapKit-Dynamic",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_snapkit//:Sources_SnapKit"
-      ]
+      "label": "@swiftpkg_snapkit//:SnapKit-Dynamic"
     }
   ],
   "packages": [

--- a/examples/soto_example/Tests/SotoTests/BUILD.bazel
+++ b/examples/soto_example/Tests/SotoTests/BUILD.bazel
@@ -7,5 +7,5 @@ swift_test(
         "main.swift",
     ],
     module_name = "SotoTests",
-    deps = ["@swiftpkg_soto//:Sources_Soto_SotoS3"],
+    deps = ["@swiftpkg_soto//:SotoS3"],
 )

--- a/examples/soto_example/swift_deps_index.json
+++ b/examples/soto_example/swift_deps_index.json
@@ -7,7 +7,7 @@
       "name": "AsyncHTTPClient",
       "c99name": "AsyncHTTPClient",
       "src_type": "swift",
-      "label": "@swiftpkg_async_http_client//:Sources_AsyncHTTPClient",
+      "label": "@swiftpkg_async_http_client//:AsyncHTTPClient.rspm",
       "package_identity": "async-http-client",
       "product_memberships": [
         "AsyncHTTPClient"
@@ -17,7 +17,7 @@
       "name": "CAsyncHTTPClient",
       "c99name": "CAsyncHTTPClient",
       "src_type": "clang",
-      "label": "@swiftpkg_async_http_client//:Sources_CAsyncHTTPClient",
+      "label": "@swiftpkg_async_http_client//:CAsyncHTTPClient.rspm",
       "package_identity": "async-http-client",
       "product_memberships": [
         "AsyncHTTPClient"
@@ -27,37 +27,37 @@
       "name": "JMESPath",
       "c99name": "JMESPath",
       "src_type": "swift",
-      "label": "@swiftpkg_jmespath.swift//:Sources_JMESPath",
+      "label": "@swiftpkg_jmespath.swift//:JMESPath.rspm",
       "package_identity": "jmespath.swift",
       "product_memberships": [
         "JMESPath"
       ]
     },
     {
-      "name": "SotoACMPCA",
-      "c99name": "SotoACMPCA",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ACMPCA_SotoACMPCA",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoACMPCA"
-      ]
-    },
-    {
       "name": "SotoACM",
       "c99name": "SotoACM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ACM_SotoACM",
+      "label": "@swiftpkg_soto//:SotoACM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoACM"
       ]
     },
     {
+      "name": "SotoACMPCA",
+      "c99name": "SotoACMPCA",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoACMPCA.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoACMPCA"
+      ]
+    },
+    {
       "name": "SotoAPIGateway",
       "c99name": "SotoAPIGateway",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_APIGateway_SotoAPIGateway",
+      "label": "@swiftpkg_soto//:SotoAPIGateway.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAPIGateway"
@@ -67,7 +67,7 @@
       "name": "SotoARCZonalShift",
       "c99name": "SotoARCZonalShift",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ARCZonalShift_SotoARCZonalShift",
+      "label": "@swiftpkg_soto//:SotoARCZonalShift.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoARCZonalShift"
@@ -77,7 +77,7 @@
       "name": "SotoAccessAnalyzer",
       "c99name": "SotoAccessAnalyzer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AccessAnalyzer_SotoAccessAnalyzer",
+      "label": "@swiftpkg_soto//:SotoAccessAnalyzer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAccessAnalyzer"
@@ -87,7 +87,7 @@
       "name": "SotoAccount",
       "c99name": "SotoAccount",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Account_SotoAccount",
+      "label": "@swiftpkg_soto//:SotoAccount.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAccount"
@@ -97,7 +97,7 @@
       "name": "SotoAlexaForBusiness",
       "c99name": "SotoAlexaForBusiness",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AlexaForBusiness_SotoAlexaForBusiness",
+      "label": "@swiftpkg_soto//:SotoAlexaForBusiness.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAlexaForBusiness"
@@ -107,17 +107,27 @@
       "name": "SotoAmp",
       "c99name": "SotoAmp",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Amp_SotoAmp",
+      "label": "@swiftpkg_soto//:SotoAmp.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAmp"
       ]
     },
     {
+      "name": "SotoAmplify",
+      "c99name": "SotoAmplify",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoAmplify.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoAmplify"
+      ]
+    },
+    {
       "name": "SotoAmplifyBackend",
       "c99name": "SotoAmplifyBackend",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AmplifyBackend_SotoAmplifyBackend",
+      "label": "@swiftpkg_soto//:SotoAmplifyBackend.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAmplifyBackend"
@@ -127,27 +137,17 @@
       "name": "SotoAmplifyUIBuilder",
       "c99name": "SotoAmplifyUIBuilder",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AmplifyUIBuilder_SotoAmplifyUIBuilder",
+      "label": "@swiftpkg_soto//:SotoAmplifyUIBuilder.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAmplifyUIBuilder"
       ]
     },
     {
-      "name": "SotoAmplify",
-      "c99name": "SotoAmplify",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Amplify_SotoAmplify",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoAmplify"
-      ]
-    },
-    {
       "name": "SotoApiGatewayManagementApi",
       "c99name": "SotoApiGatewayManagementApi",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ApiGatewayManagementApi_SotoApiGatewayManagementApi",
+      "label": "@swiftpkg_soto//:SotoApiGatewayManagementApi.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoApiGatewayManagementApi"
@@ -157,37 +157,37 @@
       "name": "SotoApiGatewayV2",
       "c99name": "SotoApiGatewayV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ApiGatewayV2_SotoApiGatewayV2",
+      "label": "@swiftpkg_soto//:SotoApiGatewayV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoApiGatewayV2"
       ]
     },
     {
-      "name": "SotoAppConfigData",
-      "c99name": "SotoAppConfigData",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppConfigData_SotoAppConfigData",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoAppConfigData"
-      ]
-    },
-    {
       "name": "SotoAppConfig",
       "c99name": "SotoAppConfig",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppConfig_SotoAppConfig",
+      "label": "@swiftpkg_soto//:SotoAppConfig.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppConfig"
       ]
     },
     {
+      "name": "SotoAppConfigData",
+      "c99name": "SotoAppConfigData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoAppConfigData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoAppConfigData"
+      ]
+    },
+    {
       "name": "SotoAppIntegrations",
       "c99name": "SotoAppIntegrations",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppIntegrations_SotoAppIntegrations",
+      "label": "@swiftpkg_soto//:SotoAppIntegrations.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppIntegrations"
@@ -197,7 +197,7 @@
       "name": "SotoAppMesh",
       "c99name": "SotoAppMesh",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppMesh_SotoAppMesh",
+      "label": "@swiftpkg_soto//:SotoAppMesh.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppMesh"
@@ -207,7 +207,7 @@
       "name": "SotoAppRunner",
       "c99name": "SotoAppRunner",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppRunner_SotoAppRunner",
+      "label": "@swiftpkg_soto//:SotoAppRunner.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppRunner"
@@ -217,7 +217,7 @@
       "name": "SotoAppStream",
       "c99name": "SotoAppStream",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppStream_SotoAppStream",
+      "label": "@swiftpkg_soto//:SotoAppStream.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppStream"
@@ -227,7 +227,7 @@
       "name": "SotoAppSync",
       "c99name": "SotoAppSync",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AppSync_SotoAppSync",
+      "label": "@swiftpkg_soto//:SotoAppSync.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppSync"
@@ -237,7 +237,7 @@
       "name": "SotoAppflow",
       "c99name": "SotoAppflow",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Appflow_SotoAppflow",
+      "label": "@swiftpkg_soto//:SotoAppflow.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAppflow"
@@ -247,7 +247,7 @@
       "name": "SotoApplicationAutoScaling",
       "c99name": "SotoApplicationAutoScaling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ApplicationAutoScaling_SotoApplicationAutoScaling",
+      "label": "@swiftpkg_soto//:SotoApplicationAutoScaling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoApplicationAutoScaling"
@@ -257,7 +257,7 @@
       "name": "SotoApplicationCostProfiler",
       "c99name": "SotoApplicationCostProfiler",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ApplicationCostProfiler_SotoApplicationCostProfiler",
+      "label": "@swiftpkg_soto//:SotoApplicationCostProfiler.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoApplicationCostProfiler"
@@ -267,7 +267,7 @@
       "name": "SotoApplicationDiscoveryService",
       "c99name": "SotoApplicationDiscoveryService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ApplicationDiscoveryService_SotoApplicationDiscoveryService",
+      "label": "@swiftpkg_soto//:SotoApplicationDiscoveryService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoApplicationDiscoveryService"
@@ -277,7 +277,7 @@
       "name": "SotoApplicationInsights",
       "c99name": "SotoApplicationInsights",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ApplicationInsights_SotoApplicationInsights",
+      "label": "@swiftpkg_soto//:SotoApplicationInsights.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoApplicationInsights"
@@ -287,7 +287,7 @@
       "name": "SotoAthena",
       "c99name": "SotoAthena",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Athena_SotoAthena",
+      "label": "@swiftpkg_soto//:SotoAthena.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAthena"
@@ -297,37 +297,47 @@
       "name": "SotoAuditManager",
       "c99name": "SotoAuditManager",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AuditManager_SotoAuditManager",
+      "label": "@swiftpkg_soto//:SotoAuditManager.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAuditManager"
       ]
     },
     {
-      "name": "SotoAutoScalingPlans",
-      "c99name": "SotoAutoScalingPlans",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AutoScalingPlans_SotoAutoScalingPlans",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoAutoScalingPlans"
-      ]
-    },
-    {
       "name": "SotoAutoScaling",
       "c99name": "SotoAutoScaling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_AutoScaling_SotoAutoScaling",
+      "label": "@swiftpkg_soto//:SotoAutoScaling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoAutoScaling"
       ]
     },
     {
+      "name": "SotoAutoScalingPlans",
+      "c99name": "SotoAutoScalingPlans",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoAutoScalingPlans.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoAutoScalingPlans"
+      ]
+    },
+    {
+      "name": "SotoBackup",
+      "c99name": "SotoBackup",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoBackup.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoBackup"
+      ]
+    },
+    {
       "name": "SotoBackupGateway",
       "c99name": "SotoBackupGateway",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_BackupGateway_SotoBackupGateway",
+      "label": "@swiftpkg_soto//:SotoBackupGateway.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoBackupGateway"
@@ -337,27 +347,17 @@
       "name": "SotoBackupStorage",
       "c99name": "SotoBackupStorage",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_BackupStorage_SotoBackupStorage",
+      "label": "@swiftpkg_soto//:SotoBackupStorage.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoBackupStorage"
       ]
     },
     {
-      "name": "SotoBackup",
-      "c99name": "SotoBackup",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Backup_SotoBackup",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoBackup"
-      ]
-    },
-    {
       "name": "SotoBatch",
       "c99name": "SotoBatch",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Batch_SotoBatch",
+      "label": "@swiftpkg_soto//:SotoBatch.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoBatch"
@@ -367,7 +367,7 @@
       "name": "SotoBillingconductor",
       "c99name": "SotoBillingconductor",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Billingconductor_SotoBillingconductor",
+      "label": "@swiftpkg_soto//:SotoBillingconductor.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoBillingconductor"
@@ -377,7 +377,7 @@
       "name": "SotoBraket",
       "c99name": "SotoBraket",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Braket_SotoBraket",
+      "label": "@swiftpkg_soto//:SotoBraket.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoBraket"
@@ -387,17 +387,27 @@
       "name": "SotoBudgets",
       "c99name": "SotoBudgets",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Budgets_SotoBudgets",
+      "label": "@swiftpkg_soto//:SotoBudgets.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoBudgets"
       ]
     },
     {
+      "name": "SotoChime",
+      "c99name": "SotoChime",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoChime.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoChime"
+      ]
+    },
+    {
       "name": "SotoChimeSDKIdentity",
       "c99name": "SotoChimeSDKIdentity",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKIdentity_SotoChimeSDKIdentity",
+      "label": "@swiftpkg_soto//:SotoChimeSDKIdentity.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoChimeSDKIdentity"
@@ -407,7 +417,7 @@
       "name": "SotoChimeSDKMediaPipelines",
       "c99name": "SotoChimeSDKMediaPipelines",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKMediaPipelines_SotoChimeSDKMediaPipelines",
+      "label": "@swiftpkg_soto//:SotoChimeSDKMediaPipelines.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoChimeSDKMediaPipelines"
@@ -417,7 +427,7 @@
       "name": "SotoChimeSDKMeetings",
       "c99name": "SotoChimeSDKMeetings",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKMeetings_SotoChimeSDKMeetings",
+      "label": "@swiftpkg_soto//:SotoChimeSDKMeetings.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoChimeSDKMeetings"
@@ -427,7 +437,7 @@
       "name": "SotoChimeSDKMessaging",
       "c99name": "SotoChimeSDKMessaging",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKMessaging_SotoChimeSDKMessaging",
+      "label": "@swiftpkg_soto//:SotoChimeSDKMessaging.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoChimeSDKMessaging"
@@ -437,27 +447,17 @@
       "name": "SotoChimeSDKVoice",
       "c99name": "SotoChimeSDKVoice",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKVoice_SotoChimeSDKVoice",
+      "label": "@swiftpkg_soto//:SotoChimeSDKVoice.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoChimeSDKVoice"
       ]
     },
     {
-      "name": "SotoChime",
-      "c99name": "SotoChime",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Chime_SotoChime",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoChime"
-      ]
-    },
-    {
       "name": "SotoCleanRooms",
       "c99name": "SotoCleanRooms",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CleanRooms_SotoCleanRooms",
+      "label": "@swiftpkg_soto//:SotoCleanRooms.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCleanRooms"
@@ -467,7 +467,7 @@
       "name": "SotoCloud9",
       "c99name": "SotoCloud9",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Cloud9_SotoCloud9",
+      "label": "@swiftpkg_soto//:SotoCloud9.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloud9"
@@ -477,7 +477,7 @@
       "name": "SotoCloudControl",
       "c99name": "SotoCloudControl",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudControl_SotoCloudControl",
+      "label": "@swiftpkg_soto//:SotoCloudControl.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudControl"
@@ -487,7 +487,7 @@
       "name": "SotoCloudDirectory",
       "c99name": "SotoCloudDirectory",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudDirectory_SotoCloudDirectory",
+      "label": "@swiftpkg_soto//:SotoCloudDirectory.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudDirectory"
@@ -497,7 +497,7 @@
       "name": "SotoCloudFormation",
       "c99name": "SotoCloudFormation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudFormation_SotoCloudFormation",
+      "label": "@swiftpkg_soto//:SotoCloudFormation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudFormation"
@@ -507,77 +507,87 @@
       "name": "SotoCloudFront",
       "c99name": "SotoCloudFront",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudFront_SotoCloudFront",
+      "label": "@swiftpkg_soto//:SotoCloudFront.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudFront"
       ]
     },
     {
-      "name": "SotoCloudHSMV2",
-      "c99name": "SotoCloudHSMV2",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudHSMV2_SotoCloudHSMV2",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoCloudHSMV2"
-      ]
-    },
-    {
       "name": "SotoCloudHSM",
       "c99name": "SotoCloudHSM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudHSM_SotoCloudHSM",
+      "label": "@swiftpkg_soto//:SotoCloudHSM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudHSM"
       ]
     },
     {
-      "name": "SotoCloudSearchDomain",
-      "c99name": "SotoCloudSearchDomain",
+      "name": "SotoCloudHSMV2",
+      "c99name": "SotoCloudHSMV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudSearchDomain_SotoCloudSearchDomain",
+      "label": "@swiftpkg_soto//:SotoCloudHSMV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoCloudSearchDomain"
+        "SotoCloudHSMV2"
       ]
     },
     {
       "name": "SotoCloudSearch",
       "c99name": "SotoCloudSearch",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudSearch_SotoCloudSearch",
+      "label": "@swiftpkg_soto//:SotoCloudSearch.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudSearch"
       ]
     },
     {
-      "name": "SotoCloudTrailData",
-      "c99name": "SotoCloudTrailData",
+      "name": "SotoCloudSearchDomain",
+      "c99name": "SotoCloudSearchDomain",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudTrailData_SotoCloudTrailData",
+      "label": "@swiftpkg_soto//:SotoCloudSearchDomain.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoCloudTrailData"
+        "SotoCloudSearchDomain"
       ]
     },
     {
       "name": "SotoCloudTrail",
       "c99name": "SotoCloudTrail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudTrail_SotoCloudTrail",
+      "label": "@swiftpkg_soto//:SotoCloudTrail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudTrail"
       ]
     },
     {
+      "name": "SotoCloudTrailData",
+      "c99name": "SotoCloudTrailData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoCloudTrailData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoCloudTrailData"
+      ]
+    },
+    {
+      "name": "SotoCloudWatch",
+      "c99name": "SotoCloudWatch",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoCloudWatch.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoCloudWatch"
+      ]
+    },
+    {
       "name": "SotoCloudWatchEvents",
       "c99name": "SotoCloudWatchEvents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudWatchEvents_SotoCloudWatchEvents",
+      "label": "@swiftpkg_soto//:SotoCloudWatchEvents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudWatchEvents"
@@ -587,27 +597,17 @@
       "name": "SotoCloudWatchLogs",
       "c99name": "SotoCloudWatchLogs",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudWatchLogs_SotoCloudWatchLogs",
+      "label": "@swiftpkg_soto//:SotoCloudWatchLogs.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCloudWatchLogs"
       ]
     },
     {
-      "name": "SotoCloudWatch",
-      "c99name": "SotoCloudWatch",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CloudWatch_SotoCloudWatch",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoCloudWatch"
-      ]
-    },
-    {
       "name": "SotoCodeArtifact",
       "c99name": "SotoCodeArtifact",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeArtifact_SotoCodeArtifact",
+      "label": "@swiftpkg_soto//:SotoCodeArtifact.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeArtifact"
@@ -617,7 +617,7 @@
       "name": "SotoCodeBuild",
       "c99name": "SotoCodeBuild",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeBuild_SotoCodeBuild",
+      "label": "@swiftpkg_soto//:SotoCodeBuild.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeBuild"
@@ -627,7 +627,7 @@
       "name": "SotoCodeCatalyst",
       "c99name": "SotoCodeCatalyst",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeCatalyst_SotoCodeCatalyst",
+      "label": "@swiftpkg_soto//:SotoCodeCatalyst.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeCatalyst"
@@ -637,7 +637,7 @@
       "name": "SotoCodeCommit",
       "c99name": "SotoCodeCommit",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeCommit_SotoCodeCommit",
+      "label": "@swiftpkg_soto//:SotoCodeCommit.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeCommit"
@@ -647,7 +647,7 @@
       "name": "SotoCodeDeploy",
       "c99name": "SotoCodeDeploy",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeDeploy_SotoCodeDeploy",
+      "label": "@swiftpkg_soto//:SotoCodeDeploy.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeDeploy"
@@ -657,7 +657,7 @@
       "name": "SotoCodeGuruProfiler",
       "c99name": "SotoCodeGuruProfiler",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeGuruProfiler_SotoCodeGuruProfiler",
+      "label": "@swiftpkg_soto//:SotoCodeGuruProfiler.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeGuruProfiler"
@@ -667,7 +667,7 @@
       "name": "SotoCodeGuruReviewer",
       "c99name": "SotoCodeGuruReviewer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeGuruReviewer_SotoCodeGuruReviewer",
+      "label": "@swiftpkg_soto//:SotoCodeGuruReviewer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeGuruReviewer"
@@ -677,7 +677,7 @@
       "name": "SotoCodeGuruSecurity",
       "c99name": "SotoCodeGuruSecurity",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeGuruSecurity_SotoCodeGuruSecurity",
+      "label": "@swiftpkg_soto//:SotoCodeGuruSecurity.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeGuruSecurity"
@@ -687,17 +687,27 @@
       "name": "SotoCodePipeline",
       "c99name": "SotoCodePipeline",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodePipeline_SotoCodePipeline",
+      "label": "@swiftpkg_soto//:SotoCodePipeline.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodePipeline"
       ]
     },
     {
+      "name": "SotoCodeStar",
+      "c99name": "SotoCodeStar",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoCodeStar.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoCodeStar"
+      ]
+    },
+    {
       "name": "SotoCodeStarConnections",
       "c99name": "SotoCodeStarConnections",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeStarConnections_SotoCodeStarConnections",
+      "label": "@swiftpkg_soto//:SotoCodeStarConnections.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeStarConnections"
@@ -707,27 +717,27 @@
       "name": "SotoCodeStarNotifications",
       "c99name": "SotoCodeStarNotifications",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeStarNotifications_SotoCodeStarNotifications",
+      "label": "@swiftpkg_soto//:SotoCodeStarNotifications.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCodeStarNotifications"
       ]
     },
     {
-      "name": "SotoCodeStar",
-      "c99name": "SotoCodeStar",
+      "name": "SotoCognitoIdentity",
+      "c99name": "SotoCognitoIdentity",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CodeStar_SotoCodeStar",
+      "label": "@swiftpkg_soto//:SotoCognitoIdentity.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoCodeStar"
+        "SotoCognitoIdentity"
       ]
     },
     {
       "name": "SotoCognitoIdentityProvider",
       "c99name": "SotoCognitoIdentityProvider",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CognitoIdentityProvider_SotoCognitoIdentityProvider",
+      "label": "@swiftpkg_soto//:SotoCognitoIdentityProvider.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCognitoIdentityProvider"
@@ -737,37 +747,37 @@
       "name": "SotoCognitoSync",
       "c99name": "SotoCognitoSync",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CognitoSync_SotoCognitoSync",
+      "label": "@swiftpkg_soto//:SotoCognitoSync.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCognitoSync"
       ]
     },
     {
-      "name": "SotoComprehendMedical",
-      "c99name": "SotoComprehendMedical",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ComprehendMedical_SotoComprehendMedical",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoComprehendMedical"
-      ]
-    },
-    {
       "name": "SotoComprehend",
       "c99name": "SotoComprehend",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Comprehend_SotoComprehend",
+      "label": "@swiftpkg_soto//:SotoComprehend.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoComprehend"
       ]
     },
     {
+      "name": "SotoComprehendMedical",
+      "c99name": "SotoComprehendMedical",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoComprehendMedical.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoComprehendMedical"
+      ]
+    },
+    {
       "name": "SotoComputeOptimizer",
       "c99name": "SotoComputeOptimizer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ComputeOptimizer_SotoComputeOptimizer",
+      "label": "@swiftpkg_soto//:SotoComputeOptimizer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoComputeOptimizer"
@@ -777,17 +787,27 @@
       "name": "SotoConfigService",
       "c99name": "SotoConfigService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ConfigService_SotoConfigService",
+      "label": "@swiftpkg_soto//:SotoConfigService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoConfigService"
       ]
     },
     {
+      "name": "SotoConnect",
+      "c99name": "SotoConnect",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoConnect.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoConnect"
+      ]
+    },
+    {
       "name": "SotoConnectCampaigns",
       "c99name": "SotoConnectCampaigns",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ConnectCampaigns_SotoConnectCampaigns",
+      "label": "@swiftpkg_soto//:SotoConnectCampaigns.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoConnectCampaigns"
@@ -797,7 +817,7 @@
       "name": "SotoConnectCases",
       "c99name": "SotoConnectCases",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ConnectCases_SotoConnectCases",
+      "label": "@swiftpkg_soto//:SotoConnectCases.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoConnectCases"
@@ -807,7 +827,7 @@
       "name": "SotoConnectContactLens",
       "c99name": "SotoConnectContactLens",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ConnectContactLens_SotoConnectContactLens",
+      "label": "@swiftpkg_soto//:SotoConnectContactLens.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoConnectContactLens"
@@ -817,27 +837,17 @@
       "name": "SotoConnectParticipant",
       "c99name": "SotoConnectParticipant",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ConnectParticipant_SotoConnectParticipant",
+      "label": "@swiftpkg_soto//:SotoConnectParticipant.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoConnectParticipant"
       ]
     },
     {
-      "name": "SotoConnect",
-      "c99name": "SotoConnect",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Connect_SotoConnect",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoConnect"
-      ]
-    },
-    {
       "name": "SotoControlTower",
       "c99name": "SotoControlTower",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ControlTower_SotoControlTower",
+      "label": "@swiftpkg_soto//:SotoControlTower.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoControlTower"
@@ -847,7 +857,7 @@
       "name": "SotoCostAndUsageReportService",
       "c99name": "SotoCostAndUsageReportService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CostAndUsageReportService_SotoCostAndUsageReportService",
+      "label": "@swiftpkg_soto//:SotoCostAndUsageReportService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCostAndUsageReportService"
@@ -857,7 +867,7 @@
       "name": "SotoCostExplorer",
       "c99name": "SotoCostExplorer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CostExplorer_SotoCostExplorer",
+      "label": "@swiftpkg_soto//:SotoCostExplorer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCostExplorer"
@@ -867,7 +877,7 @@
       "name": "SotoCustomerProfiles",
       "c99name": "SotoCustomerProfiles",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_CustomerProfiles_SotoCustomerProfiles",
+      "label": "@swiftpkg_soto//:SotoCustomerProfiles.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoCustomerProfiles"
@@ -877,7 +887,7 @@
       "name": "SotoDAX",
       "c99name": "SotoDAX",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DAX_SotoDAX",
+      "label": "@swiftpkg_soto//:SotoDAX.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDAX"
@@ -887,7 +897,7 @@
       "name": "SotoDLM",
       "c99name": "SotoDLM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DLM_SotoDLM",
+      "label": "@swiftpkg_soto//:SotoDLM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDLM"
@@ -897,7 +907,7 @@
       "name": "SotoDataBrew",
       "c99name": "SotoDataBrew",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DataBrew_SotoDataBrew",
+      "label": "@swiftpkg_soto//:SotoDataBrew.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDataBrew"
@@ -907,7 +917,7 @@
       "name": "SotoDataExchange",
       "c99name": "SotoDataExchange",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DataExchange_SotoDataExchange",
+      "label": "@swiftpkg_soto//:SotoDataExchange.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDataExchange"
@@ -917,7 +927,7 @@
       "name": "SotoDataPipeline",
       "c99name": "SotoDataPipeline",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DataPipeline_SotoDataPipeline",
+      "label": "@swiftpkg_soto//:SotoDataPipeline.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDataPipeline"
@@ -927,7 +937,7 @@
       "name": "SotoDataSync",
       "c99name": "SotoDataSync",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DataSync_SotoDataSync",
+      "label": "@swiftpkg_soto//:SotoDataSync.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDataSync"
@@ -937,7 +947,7 @@
       "name": "SotoDatabaseMigrationService",
       "c99name": "SotoDatabaseMigrationService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DatabaseMigrationService_SotoDatabaseMigrationService",
+      "label": "@swiftpkg_soto//:SotoDatabaseMigrationService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDatabaseMigrationService"
@@ -947,7 +957,7 @@
       "name": "SotoDetective",
       "c99name": "SotoDetective",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Detective_SotoDetective",
+      "label": "@swiftpkg_soto//:SotoDetective.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDetective"
@@ -957,7 +967,7 @@
       "name": "SotoDevOpsGuru",
       "c99name": "SotoDevOpsGuru",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DevOpsGuru_SotoDevOpsGuru",
+      "label": "@swiftpkg_soto//:SotoDevOpsGuru.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDevOpsGuru"
@@ -967,7 +977,7 @@
       "name": "SotoDeviceFarm",
       "c99name": "SotoDeviceFarm",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DeviceFarm_SotoDeviceFarm",
+      "label": "@swiftpkg_soto//:SotoDeviceFarm.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDeviceFarm"
@@ -977,7 +987,7 @@
       "name": "SotoDirectConnect",
       "c99name": "SotoDirectConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DirectConnect_SotoDirectConnect",
+      "label": "@swiftpkg_soto//:SotoDirectConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDirectConnect"
@@ -987,47 +997,57 @@
       "name": "SotoDirectoryService",
       "c99name": "SotoDirectoryService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DirectoryService_SotoDirectoryService",
+      "label": "@swiftpkg_soto//:SotoDirectoryService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDirectoryService"
       ]
     },
     {
-      "name": "SotoDocDBElastic",
-      "c99name": "SotoDocDBElastic",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DocDBElastic_SotoDocDBElastic",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoDocDBElastic"
-      ]
-    },
-    {
       "name": "SotoDocDB",
       "c99name": "SotoDocDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DocDB_SotoDocDB",
+      "label": "@swiftpkg_soto//:SotoDocDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDocDB"
       ]
     },
     {
+      "name": "SotoDocDBElastic",
+      "c99name": "SotoDocDBElastic",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoDocDBElastic.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoDocDBElastic"
+      ]
+    },
+    {
       "name": "SotoDrs",
       "c99name": "SotoDrs",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Drs_SotoDrs",
+      "label": "@swiftpkg_soto//:SotoDrs.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDrs"
       ]
     },
     {
+      "name": "SotoDynamoDB",
+      "c99name": "SotoDynamoDB",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoDynamoDB.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoDynamoDB"
+      ]
+    },
+    {
       "name": "SotoDynamoDBStreams",
       "c99name": "SotoDynamoDBStreams",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_DynamoDBStreams_SotoDynamoDBStreams",
+      "label": "@swiftpkg_soto//:SotoDynamoDBStreams.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoDynamoDBStreams"
@@ -1037,57 +1057,57 @@
       "name": "SotoEBS",
       "c99name": "SotoEBS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EBS_SotoEBS",
+      "label": "@swiftpkg_soto//:SotoEBS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEBS"
       ]
     },
     {
-      "name": "SotoEC2InstanceConnect",
-      "c99name": "SotoEC2InstanceConnect",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EC2InstanceConnect_SotoEC2InstanceConnect",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoEC2InstanceConnect"
-      ]
-    },
-    {
       "name": "SotoEC2",
       "c99name": "SotoEC2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EC2_SotoEC2",
+      "label": "@swiftpkg_soto//:SotoEC2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEC2"
       ]
     },
     {
-      "name": "SotoECRPublic",
-      "c99name": "SotoECRPublic",
+      "name": "SotoEC2InstanceConnect",
+      "c99name": "SotoEC2InstanceConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ECRPublic_SotoECRPublic",
+      "label": "@swiftpkg_soto//:SotoEC2InstanceConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoECRPublic"
+        "SotoEC2InstanceConnect"
       ]
     },
     {
       "name": "SotoECR",
       "c99name": "SotoECR",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ECR_SotoECR",
+      "label": "@swiftpkg_soto//:SotoECR.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoECR"
       ]
     },
     {
+      "name": "SotoECRPublic",
+      "c99name": "SotoECRPublic",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoECRPublic.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoECRPublic"
+      ]
+    },
+    {
       "name": "SotoECS",
       "c99name": "SotoECS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ECS_SotoECS",
+      "label": "@swiftpkg_soto//:SotoECS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoECS"
@@ -1097,7 +1117,7 @@
       "name": "SotoEFS",
       "c99name": "SotoEFS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EFS_SotoEFS",
+      "label": "@swiftpkg_soto//:SotoEFS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEFS"
@@ -1107,17 +1127,27 @@
       "name": "SotoEKS",
       "c99name": "SotoEKS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EKS_SotoEKS",
+      "label": "@swiftpkg_soto//:SotoEKS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEKS"
       ]
     },
     {
+      "name": "SotoEMR",
+      "c99name": "SotoEMR",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoEMR.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoEMR"
+      ]
+    },
+    {
       "name": "SotoEMRContainers",
       "c99name": "SotoEMRContainers",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EMRContainers_SotoEMRContainers",
+      "label": "@swiftpkg_soto//:SotoEMRContainers.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEMRContainers"
@@ -1127,27 +1157,17 @@
       "name": "SotoEMRServerless",
       "c99name": "SotoEMRServerless",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EMRServerless_SotoEMRServerless",
+      "label": "@swiftpkg_soto//:SotoEMRServerless.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEMRServerless"
       ]
     },
     {
-      "name": "SotoEMR",
-      "c99name": "SotoEMR",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EMR_SotoEMR",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoEMR"
-      ]
-    },
-    {
       "name": "SotoElastiCache",
       "c99name": "SotoElastiCache",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElastiCache_SotoElastiCache",
+      "label": "@swiftpkg_soto//:SotoElastiCache.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoElastiCache"
@@ -1157,7 +1177,7 @@
       "name": "SotoElasticBeanstalk",
       "c99name": "SotoElasticBeanstalk",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElasticBeanstalk_SotoElasticBeanstalk",
+      "label": "@swiftpkg_soto//:SotoElasticBeanstalk.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoElasticBeanstalk"
@@ -1167,37 +1187,37 @@
       "name": "SotoElasticInference",
       "c99name": "SotoElasticInference",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElasticInference_SotoElasticInference",
+      "label": "@swiftpkg_soto//:SotoElasticInference.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoElasticInference"
       ]
     },
     {
-      "name": "SotoElasticLoadBalancingV2",
-      "c99name": "SotoElasticLoadBalancingV2",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElasticLoadBalancingV2_SotoElasticLoadBalancingV2",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoElasticLoadBalancingV2"
-      ]
-    },
-    {
       "name": "SotoElasticLoadBalancing",
       "c99name": "SotoElasticLoadBalancing",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElasticLoadBalancing_SotoElasticLoadBalancing",
+      "label": "@swiftpkg_soto//:SotoElasticLoadBalancing.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoElasticLoadBalancing"
       ]
     },
     {
+      "name": "SotoElasticLoadBalancingV2",
+      "c99name": "SotoElasticLoadBalancingV2",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoElasticLoadBalancingV2.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoElasticLoadBalancingV2"
+      ]
+    },
+    {
       "name": "SotoElasticTranscoder",
       "c99name": "SotoElasticTranscoder",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElasticTranscoder_SotoElasticTranscoder",
+      "label": "@swiftpkg_soto//:SotoElasticTranscoder.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoElasticTranscoder"
@@ -1207,7 +1227,7 @@
       "name": "SotoElasticsearchService",
       "c99name": "SotoElasticsearchService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ElasticsearchService_SotoElasticsearchService",
+      "label": "@swiftpkg_soto//:SotoElasticsearchService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoElasticsearchService"
@@ -1217,7 +1237,7 @@
       "name": "SotoEventBridge",
       "c99name": "SotoEventBridge",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_EventBridge_SotoEventBridge",
+      "label": "@swiftpkg_soto//:SotoEventBridge.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEventBridge"
@@ -1227,7 +1247,7 @@
       "name": "SotoEvidently",
       "c99name": "SotoEvidently",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Evidently_SotoEvidently",
+      "label": "@swiftpkg_soto//:SotoEvidently.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoEvidently"
@@ -1237,7 +1257,7 @@
       "name": "SotoFIS",
       "c99name": "SotoFIS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_FIS_SotoFIS",
+      "label": "@swiftpkg_soto//:SotoFIS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoFIS"
@@ -1247,7 +1267,7 @@
       "name": "SotoFMS",
       "c99name": "SotoFMS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_FMS_SotoFMS",
+      "label": "@swiftpkg_soto//:SotoFMS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoFMS"
@@ -1257,37 +1277,37 @@
       "name": "SotoFSx",
       "c99name": "SotoFSx",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_FSx_SotoFSx",
+      "label": "@swiftpkg_soto//:SotoFSx.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoFSx"
       ]
     },
     {
-      "name": "SotoFinspaceData",
-      "c99name": "SotoFinspaceData",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_FinspaceData_SotoFinspaceData",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoFinspaceData"
-      ]
-    },
-    {
       "name": "SotoFinspace",
       "c99name": "SotoFinspace",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Finspace_SotoFinspace",
+      "label": "@swiftpkg_soto//:SotoFinspace.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoFinspace"
       ]
     },
     {
+      "name": "SotoFinspaceData",
+      "c99name": "SotoFinspaceData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoFinspaceData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoFinspaceData"
+      ]
+    },
+    {
       "name": "SotoFirehose",
       "c99name": "SotoFirehose",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Firehose_SotoFirehose",
+      "label": "@swiftpkg_soto//:SotoFirehose.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoFirehose"
@@ -1297,7 +1317,7 @@
       "name": "SotoForecast",
       "c99name": "SotoForecast",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Forecast_SotoForecast",
+      "label": "@swiftpkg_soto//:SotoForecast.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoForecast"
@@ -1307,7 +1327,7 @@
       "name": "SotoForecastquery",
       "c99name": "SotoForecastquery",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Forecastquery_SotoForecastquery",
+      "label": "@swiftpkg_soto//:SotoForecastquery.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoForecastquery"
@@ -1317,7 +1337,7 @@
       "name": "SotoFraudDetector",
       "c99name": "SotoFraudDetector",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_FraudDetector_SotoFraudDetector",
+      "label": "@swiftpkg_soto//:SotoFraudDetector.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoFraudDetector"
@@ -1327,7 +1347,7 @@
       "name": "SotoGameLift",
       "c99name": "SotoGameLift",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_GameLift_SotoGameLift",
+      "label": "@swiftpkg_soto//:SotoGameLift.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGameLift"
@@ -1337,7 +1357,7 @@
       "name": "SotoGameSparks",
       "c99name": "SotoGameSparks",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_GameSparks_SotoGameSparks",
+      "label": "@swiftpkg_soto//:SotoGameSparks.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGameSparks"
@@ -1347,7 +1367,7 @@
       "name": "SotoGlacier",
       "c99name": "SotoGlacier",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Glacier_SotoGlacier",
+      "label": "@swiftpkg_soto//:SotoGlacier.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGlacier"
@@ -1357,7 +1377,7 @@
       "name": "SotoGlobalAccelerator",
       "c99name": "SotoGlobalAccelerator",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_GlobalAccelerator_SotoGlobalAccelerator",
+      "label": "@swiftpkg_soto//:SotoGlobalAccelerator.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGlobalAccelerator"
@@ -1367,7 +1387,7 @@
       "name": "SotoGlue",
       "c99name": "SotoGlue",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Glue_SotoGlue",
+      "label": "@swiftpkg_soto//:SotoGlue.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGlue"
@@ -1377,37 +1397,37 @@
       "name": "SotoGrafana",
       "c99name": "SotoGrafana",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Grafana_SotoGrafana",
+      "label": "@swiftpkg_soto//:SotoGrafana.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGrafana"
       ]
     },
     {
-      "name": "SotoGreengrassV2",
-      "c99name": "SotoGreengrassV2",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_GreengrassV2_SotoGreengrassV2",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoGreengrassV2"
-      ]
-    },
-    {
       "name": "SotoGreengrass",
       "c99name": "SotoGreengrass",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Greengrass_SotoGreengrass",
+      "label": "@swiftpkg_soto//:SotoGreengrass.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGreengrass"
       ]
     },
     {
+      "name": "SotoGreengrassV2",
+      "c99name": "SotoGreengrassV2",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoGreengrassV2.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoGreengrassV2"
+      ]
+    },
+    {
       "name": "SotoGroundStation",
       "c99name": "SotoGroundStation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_GroundStation_SotoGroundStation",
+      "label": "@swiftpkg_soto//:SotoGroundStation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGroundStation"
@@ -1417,37 +1437,37 @@
       "name": "SotoGuardDuty",
       "c99name": "SotoGuardDuty",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_GuardDuty_SotoGuardDuty",
+      "label": "@swiftpkg_soto//:SotoGuardDuty.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoGuardDuty"
       ]
     },
     {
-      "name": "SotoHealthLake",
-      "c99name": "SotoHealthLake",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_HealthLake_SotoHealthLake",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoHealthLake"
-      ]
-    },
-    {
       "name": "SotoHealth",
       "c99name": "SotoHealth",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Health_SotoHealth",
+      "label": "@swiftpkg_soto//:SotoHealth.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoHealth"
       ]
     },
     {
+      "name": "SotoHealthLake",
+      "c99name": "SotoHealthLake",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoHealthLake.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoHealthLake"
+      ]
+    },
+    {
       "name": "SotoHoneycode",
       "c99name": "SotoHoneycode",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Honeycode_SotoHoneycode",
+      "label": "@swiftpkg_soto//:SotoHoneycode.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoHoneycode"
@@ -1457,37 +1477,37 @@
       "name": "SotoIAM",
       "c99name": "SotoIAM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IAM_SotoIAM",
+      "label": "@swiftpkg_soto//:SotoIAM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIAM"
       ]
     },
     {
-      "name": "SotoIVSRealTime",
-      "c99name": "SotoIVSRealTime",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IVSRealTime_SotoIVSRealTime",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoIVSRealTime"
-      ]
-    },
-    {
       "name": "SotoIVS",
       "c99name": "SotoIVS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IVS_SotoIVS",
+      "label": "@swiftpkg_soto//:SotoIVS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIVS"
       ]
     },
     {
+      "name": "SotoIVSRealTime",
+      "c99name": "SotoIVSRealTime",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoIVSRealTime.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoIVSRealTime"
+      ]
+    },
+    {
       "name": "SotoIdentityStore",
       "c99name": "SotoIdentityStore",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IdentityStore_SotoIdentityStore",
+      "label": "@swiftpkg_soto//:SotoIdentityStore.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIdentityStore"
@@ -1497,47 +1517,57 @@
       "name": "SotoImagebuilder",
       "c99name": "SotoImagebuilder",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Imagebuilder_SotoImagebuilder",
+      "label": "@swiftpkg_soto//:SotoImagebuilder.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoImagebuilder"
       ]
     },
     {
-      "name": "SotoInspector2",
-      "c99name": "SotoInspector2",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Inspector2_SotoInspector2",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoInspector2"
-      ]
-    },
-    {
       "name": "SotoInspector",
       "c99name": "SotoInspector",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Inspector_SotoInspector",
+      "label": "@swiftpkg_soto//:SotoInspector.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoInspector"
       ]
     },
     {
+      "name": "SotoInspector2",
+      "c99name": "SotoInspector2",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoInspector2.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoInspector2"
+      ]
+    },
+    {
       "name": "SotoInternetMonitor",
       "c99name": "SotoInternetMonitor",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_InternetMonitor_SotoInternetMonitor",
+      "label": "@swiftpkg_soto//:SotoInternetMonitor.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoInternetMonitor"
       ]
     },
     {
+      "name": "SotoIoT",
+      "c99name": "SotoIoT",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoIoT.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoIoT"
+      ]
+    },
+    {
       "name": "SotoIoT1ClickDevicesService",
       "c99name": "SotoIoT1ClickDevicesService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoT1ClickDevicesService_SotoIoT1ClickDevicesService",
+      "label": "@swiftpkg_soto//:SotoIoT1ClickDevicesService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoT1ClickDevicesService"
@@ -1547,7 +1577,7 @@
       "name": "SotoIoT1ClickProjects",
       "c99name": "SotoIoT1ClickProjects",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoT1ClickProjects_SotoIoT1ClickProjects",
+      "label": "@swiftpkg_soto//:SotoIoT1ClickProjects.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoT1ClickProjects"
@@ -1557,7 +1587,7 @@
       "name": "SotoIoTAnalytics",
       "c99name": "SotoIoTAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTAnalytics_SotoIoTAnalytics",
+      "label": "@swiftpkg_soto//:SotoIoTAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTAnalytics"
@@ -1567,7 +1597,7 @@
       "name": "SotoIoTDataPlane",
       "c99name": "SotoIoTDataPlane",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTDataPlane_SotoIoTDataPlane",
+      "label": "@swiftpkg_soto//:SotoIoTDataPlane.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTDataPlane"
@@ -1577,37 +1607,37 @@
       "name": "SotoIoTDeviceAdvisor",
       "c99name": "SotoIoTDeviceAdvisor",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTDeviceAdvisor_SotoIoTDeviceAdvisor",
+      "label": "@swiftpkg_soto//:SotoIoTDeviceAdvisor.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTDeviceAdvisor"
       ]
     },
     {
-      "name": "SotoIoTEventsData",
-      "c99name": "SotoIoTEventsData",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTEventsData_SotoIoTEventsData",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoIoTEventsData"
-      ]
-    },
-    {
       "name": "SotoIoTEvents",
       "c99name": "SotoIoTEvents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTEvents_SotoIoTEvents",
+      "label": "@swiftpkg_soto//:SotoIoTEvents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTEvents"
       ]
     },
     {
+      "name": "SotoIoTEventsData",
+      "c99name": "SotoIoTEventsData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoIoTEventsData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoIoTEventsData"
+      ]
+    },
+    {
       "name": "SotoIoTFleetHub",
       "c99name": "SotoIoTFleetHub",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTFleetHub_SotoIoTFleetHub",
+      "label": "@swiftpkg_soto//:SotoIoTFleetHub.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTFleetHub"
@@ -1617,7 +1647,7 @@
       "name": "SotoIoTFleetWise",
       "c99name": "SotoIoTFleetWise",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTFleetWise_SotoIoTFleetWise",
+      "label": "@swiftpkg_soto//:SotoIoTFleetWise.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTFleetWise"
@@ -1627,7 +1657,7 @@
       "name": "SotoIoTJobsDataPlane",
       "c99name": "SotoIoTJobsDataPlane",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTJobsDataPlane_SotoIoTJobsDataPlane",
+      "label": "@swiftpkg_soto//:SotoIoTJobsDataPlane.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTJobsDataPlane"
@@ -1637,7 +1667,7 @@
       "name": "SotoIoTRoboRunner",
       "c99name": "SotoIoTRoboRunner",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTRoboRunner_SotoIoTRoboRunner",
+      "label": "@swiftpkg_soto//:SotoIoTRoboRunner.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTRoboRunner"
@@ -1647,7 +1677,7 @@
       "name": "SotoIoTSecureTunneling",
       "c99name": "SotoIoTSecureTunneling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTSecureTunneling_SotoIoTSecureTunneling",
+      "label": "@swiftpkg_soto//:SotoIoTSecureTunneling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTSecureTunneling"
@@ -1657,7 +1687,7 @@
       "name": "SotoIoTSiteWise",
       "c99name": "SotoIoTSiteWise",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTSiteWise_SotoIoTSiteWise",
+      "label": "@swiftpkg_soto//:SotoIoTSiteWise.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTSiteWise"
@@ -1667,7 +1697,7 @@
       "name": "SotoIoTThingsGraph",
       "c99name": "SotoIoTThingsGraph",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTThingsGraph_SotoIoTThingsGraph",
+      "label": "@swiftpkg_soto//:SotoIoTThingsGraph.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTThingsGraph"
@@ -1677,7 +1707,7 @@
       "name": "SotoIoTTwinMaker",
       "c99name": "SotoIoTTwinMaker",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTTwinMaker_SotoIoTTwinMaker",
+      "label": "@swiftpkg_soto//:SotoIoTTwinMaker.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTTwinMaker"
@@ -1687,27 +1717,17 @@
       "name": "SotoIoTWireless",
       "c99name": "SotoIoTWireless",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoTWireless_SotoIoTWireless",
+      "label": "@swiftpkg_soto//:SotoIoTWireless.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIoTWireless"
       ]
     },
     {
-      "name": "SotoIoT",
-      "c99name": "SotoIoT",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_IoT_SotoIoT",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoIoT"
-      ]
-    },
-    {
       "name": "SotoIvschat",
       "c99name": "SotoIvschat",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Ivschat_SotoIvschat",
+      "label": "@swiftpkg_soto//:SotoIvschat.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoIvschat"
@@ -1717,87 +1737,107 @@
       "name": "SotoKMS",
       "c99name": "SotoKMS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KMS_SotoKMS",
+      "label": "@swiftpkg_soto//:SotoKMS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKMS"
       ]
     },
     {
-      "name": "SotoKafkaConnect",
-      "c99name": "SotoKafkaConnect",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KafkaConnect_SotoKafkaConnect",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoKafkaConnect"
-      ]
-    },
-    {
       "name": "SotoKafka",
       "c99name": "SotoKafka",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Kafka_SotoKafka",
+      "label": "@swiftpkg_soto//:SotoKafka.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKafka"
       ]
     },
     {
-      "name": "SotoKendraRanking",
-      "c99name": "SotoKendraRanking",
+      "name": "SotoKafkaConnect",
+      "c99name": "SotoKafkaConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KendraRanking_SotoKendraRanking",
+      "label": "@swiftpkg_soto//:SotoKafkaConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoKendraRanking"
+        "SotoKafkaConnect"
       ]
     },
     {
       "name": "SotoKendra",
       "c99name": "SotoKendra",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Kendra_SotoKendra",
+      "label": "@swiftpkg_soto//:SotoKendra.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKendra"
       ]
     },
     {
+      "name": "SotoKendraRanking",
+      "c99name": "SotoKendraRanking",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoKendraRanking.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoKendraRanking"
+      ]
+    },
+    {
       "name": "SotoKeyspaces",
       "c99name": "SotoKeyspaces",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Keyspaces_SotoKeyspaces",
+      "label": "@swiftpkg_soto//:SotoKeyspaces.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKeyspaces"
       ]
     },
     {
-      "name": "SotoKinesisAnalyticsV2",
-      "c99name": "SotoKinesisAnalyticsV2",
+      "name": "SotoKinesis",
+      "c99name": "SotoKinesis",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisAnalyticsV2_SotoKinesisAnalyticsV2",
+      "label": "@swiftpkg_soto//:SotoKinesis.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoKinesisAnalyticsV2"
+        "SotoKinesis"
       ]
     },
     {
       "name": "SotoKinesisAnalytics",
       "c99name": "SotoKinesisAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisAnalytics_SotoKinesisAnalytics",
+      "label": "@swiftpkg_soto//:SotoKinesisAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKinesisAnalytics"
       ]
     },
     {
+      "name": "SotoKinesisAnalyticsV2",
+      "c99name": "SotoKinesisAnalyticsV2",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoKinesisAnalyticsV2.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoKinesisAnalyticsV2"
+      ]
+    },
+    {
+      "name": "SotoKinesisVideo",
+      "c99name": "SotoKinesisVideo",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoKinesisVideo.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoKinesisVideo"
+      ]
+    },
+    {
       "name": "SotoKinesisVideoArchivedMedia",
       "c99name": "SotoKinesisVideoArchivedMedia",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoArchivedMedia_SotoKinesisVideoArchivedMedia",
+      "label": "@swiftpkg_soto//:SotoKinesisVideoArchivedMedia.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKinesisVideoArchivedMedia"
@@ -1807,7 +1847,7 @@
       "name": "SotoKinesisVideoMedia",
       "c99name": "SotoKinesisVideoMedia",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoMedia_SotoKinesisVideoMedia",
+      "label": "@swiftpkg_soto//:SotoKinesisVideoMedia.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKinesisVideoMedia"
@@ -1817,7 +1857,7 @@
       "name": "SotoKinesisVideoSignaling",
       "c99name": "SotoKinesisVideoSignaling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoSignaling_SotoKinesisVideoSignaling",
+      "label": "@swiftpkg_soto//:SotoKinesisVideoSignaling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKinesisVideoSignaling"
@@ -1827,37 +1867,17 @@
       "name": "SotoKinesisVideoWebRTCStorage",
       "c99name": "SotoKinesisVideoWebRTCStorage",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoWebRTCStorage_SotoKinesisVideoWebRTCStorage",
+      "label": "@swiftpkg_soto//:SotoKinesisVideoWebRTCStorage.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoKinesisVideoWebRTCStorage"
       ]
     },
     {
-      "name": "SotoKinesisVideo",
-      "c99name": "SotoKinesisVideo",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideo_SotoKinesisVideo",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoKinesisVideo"
-      ]
-    },
-    {
-      "name": "SotoKinesis",
-      "c99name": "SotoKinesis",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Kinesis_SotoKinesis",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoKinesis"
-      ]
-    },
-    {
       "name": "SotoLakeFormation",
       "c99name": "SotoLakeFormation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LakeFormation_SotoLakeFormation",
+      "label": "@swiftpkg_soto//:SotoLakeFormation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLakeFormation"
@@ -1867,7 +1887,7 @@
       "name": "SotoLambda",
       "c99name": "SotoLambda",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Lambda_SotoLambda",
+      "label": "@swiftpkg_soto//:SotoLambda.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLambda"
@@ -1877,7 +1897,7 @@
       "name": "SotoLexModelBuildingService",
       "c99name": "SotoLexModelBuildingService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LexModelBuildingService_SotoLexModelBuildingService",
+      "label": "@swiftpkg_soto//:SotoLexModelBuildingService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLexModelBuildingService"
@@ -1887,7 +1907,7 @@
       "name": "SotoLexModelsV2",
       "c99name": "SotoLexModelsV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LexModelsV2_SotoLexModelsV2",
+      "label": "@swiftpkg_soto//:SotoLexModelsV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLexModelsV2"
@@ -1897,7 +1917,7 @@
       "name": "SotoLexRuntimeService",
       "c99name": "SotoLexRuntimeService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LexRuntimeService_SotoLexRuntimeService",
+      "label": "@swiftpkg_soto//:SotoLexRuntimeService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLexRuntimeService"
@@ -1907,17 +1927,27 @@
       "name": "SotoLexRuntimeV2",
       "c99name": "SotoLexRuntimeV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LexRuntimeV2_SotoLexRuntimeV2",
+      "label": "@swiftpkg_soto//:SotoLexRuntimeV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLexRuntimeV2"
       ]
     },
     {
+      "name": "SotoLicenseManager",
+      "c99name": "SotoLicenseManager",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoLicenseManager.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoLicenseManager"
+      ]
+    },
+    {
       "name": "SotoLicenseManagerLinuxSubscriptions",
       "c99name": "SotoLicenseManagerLinuxSubscriptions",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LicenseManagerLinuxSubscriptions_SotoLicenseManagerLinuxSubscriptions",
+      "label": "@swiftpkg_soto//:SotoLicenseManagerLinuxSubscriptions.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLicenseManagerLinuxSubscriptions"
@@ -1927,27 +1957,17 @@
       "name": "SotoLicenseManagerUserSubscriptions",
       "c99name": "SotoLicenseManagerUserSubscriptions",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LicenseManagerUserSubscriptions_SotoLicenseManagerUserSubscriptions",
+      "label": "@swiftpkg_soto//:SotoLicenseManagerUserSubscriptions.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLicenseManagerUserSubscriptions"
       ]
     },
     {
-      "name": "SotoLicenseManager",
-      "c99name": "SotoLicenseManager",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LicenseManager_SotoLicenseManager",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoLicenseManager"
-      ]
-    },
-    {
       "name": "SotoLightsail",
       "c99name": "SotoLightsail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Lightsail_SotoLightsail",
+      "label": "@swiftpkg_soto//:SotoLightsail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLightsail"
@@ -1957,7 +1977,7 @@
       "name": "SotoLocation",
       "c99name": "SotoLocation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Location_SotoLocation",
+      "label": "@swiftpkg_soto//:SotoLocation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLocation"
@@ -1967,7 +1987,7 @@
       "name": "SotoLookoutEquipment",
       "c99name": "SotoLookoutEquipment",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LookoutEquipment_SotoLookoutEquipment",
+      "label": "@swiftpkg_soto//:SotoLookoutEquipment.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLookoutEquipment"
@@ -1977,7 +1997,7 @@
       "name": "SotoLookoutMetrics",
       "c99name": "SotoLookoutMetrics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LookoutMetrics_SotoLookoutMetrics",
+      "label": "@swiftpkg_soto//:SotoLookoutMetrics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLookoutMetrics"
@@ -1987,7 +2007,7 @@
       "name": "SotoLookoutVision",
       "c99name": "SotoLookoutVision",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_LookoutVision_SotoLookoutVision",
+      "label": "@swiftpkg_soto//:SotoLookoutVision.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoLookoutVision"
@@ -1997,7 +2017,7 @@
       "name": "SotoM2",
       "c99name": "SotoM2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_M2_SotoM2",
+      "label": "@swiftpkg_soto//:SotoM2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoM2"
@@ -2007,7 +2027,7 @@
       "name": "SotoMQ",
       "c99name": "SotoMQ",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MQ_SotoMQ",
+      "label": "@swiftpkg_soto//:SotoMQ.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMQ"
@@ -2017,7 +2037,7 @@
       "name": "SotoMTurk",
       "c99name": "SotoMTurk",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MTurk_SotoMTurk",
+      "label": "@swiftpkg_soto//:SotoMTurk.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMTurk"
@@ -2027,7 +2047,7 @@
       "name": "SotoMWAA",
       "c99name": "SotoMWAA",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MWAA_SotoMWAA",
+      "label": "@swiftpkg_soto//:SotoMWAA.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMWAA"
@@ -2037,37 +2057,37 @@
       "name": "SotoMachineLearning",
       "c99name": "SotoMachineLearning",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MachineLearning_SotoMachineLearning",
+      "label": "@swiftpkg_soto//:SotoMachineLearning.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMachineLearning"
       ]
     },
     {
-      "name": "SotoMacie2",
-      "c99name": "SotoMacie2",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Macie2_SotoMacie2",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoMacie2"
-      ]
-    },
-    {
       "name": "SotoMacie",
       "c99name": "SotoMacie",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Macie_SotoMacie",
+      "label": "@swiftpkg_soto//:SotoMacie.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMacie"
       ]
     },
     {
+      "name": "SotoMacie2",
+      "c99name": "SotoMacie2",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoMacie2.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoMacie2"
+      ]
+    },
+    {
       "name": "SotoManagedBlockchain",
       "c99name": "SotoManagedBlockchain",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ManagedBlockchain_SotoManagedBlockchain",
+      "label": "@swiftpkg_soto//:SotoManagedBlockchain.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoManagedBlockchain"
@@ -2077,7 +2097,7 @@
       "name": "SotoMarketplaceCatalog",
       "c99name": "SotoMarketplaceCatalog",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceCatalog_SotoMarketplaceCatalog",
+      "label": "@swiftpkg_soto//:SotoMarketplaceCatalog.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMarketplaceCatalog"
@@ -2087,7 +2107,7 @@
       "name": "SotoMarketplaceCommerceAnalytics",
       "c99name": "SotoMarketplaceCommerceAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceCommerceAnalytics_SotoMarketplaceCommerceAnalytics",
+      "label": "@swiftpkg_soto//:SotoMarketplaceCommerceAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMarketplaceCommerceAnalytics"
@@ -2097,7 +2117,7 @@
       "name": "SotoMarketplaceEntitlementService",
       "c99name": "SotoMarketplaceEntitlementService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceEntitlementService_SotoMarketplaceEntitlementService",
+      "label": "@swiftpkg_soto//:SotoMarketplaceEntitlementService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMarketplaceEntitlementService"
@@ -2107,7 +2127,7 @@
       "name": "SotoMarketplaceMetering",
       "c99name": "SotoMarketplaceMetering",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceMetering_SotoMarketplaceMetering",
+      "label": "@swiftpkg_soto//:SotoMarketplaceMetering.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMarketplaceMetering"
@@ -2117,7 +2137,7 @@
       "name": "SotoMediaConnect",
       "c99name": "SotoMediaConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaConnect_SotoMediaConnect",
+      "label": "@swiftpkg_soto//:SotoMediaConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaConnect"
@@ -2127,7 +2147,7 @@
       "name": "SotoMediaConvert",
       "c99name": "SotoMediaConvert",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaConvert_SotoMediaConvert",
+      "label": "@swiftpkg_soto//:SotoMediaConvert.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaConvert"
@@ -2137,17 +2157,27 @@
       "name": "SotoMediaLive",
       "c99name": "SotoMediaLive",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaLive_SotoMediaLive",
+      "label": "@swiftpkg_soto//:SotoMediaLive.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaLive"
       ]
     },
     {
+      "name": "SotoMediaPackage",
+      "c99name": "SotoMediaPackage",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoMediaPackage.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoMediaPackage"
+      ]
+    },
+    {
       "name": "SotoMediaPackageV2",
       "c99name": "SotoMediaPackageV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaPackageV2_SotoMediaPackageV2",
+      "label": "@swiftpkg_soto//:SotoMediaPackageV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaPackageV2"
@@ -2157,47 +2187,37 @@
       "name": "SotoMediaPackageVod",
       "c99name": "SotoMediaPackageVod",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaPackageVod_SotoMediaPackageVod",
+      "label": "@swiftpkg_soto//:SotoMediaPackageVod.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaPackageVod"
       ]
     },
     {
-      "name": "SotoMediaPackage",
-      "c99name": "SotoMediaPackage",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaPackage_SotoMediaPackage",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoMediaPackage"
-      ]
-    },
-    {
-      "name": "SotoMediaStoreData",
-      "c99name": "SotoMediaStoreData",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaStoreData_SotoMediaStoreData",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoMediaStoreData"
-      ]
-    },
-    {
       "name": "SotoMediaStore",
       "c99name": "SotoMediaStore",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaStore_SotoMediaStore",
+      "label": "@swiftpkg_soto//:SotoMediaStore.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaStore"
       ]
     },
     {
+      "name": "SotoMediaStoreData",
+      "c99name": "SotoMediaStoreData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoMediaStoreData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoMediaStoreData"
+      ]
+    },
+    {
       "name": "SotoMediaTailor",
       "c99name": "SotoMediaTailor",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MediaTailor_SotoMediaTailor",
+      "label": "@swiftpkg_soto//:SotoMediaTailor.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMediaTailor"
@@ -2207,7 +2227,7 @@
       "name": "SotoMemoryDB",
       "c99name": "SotoMemoryDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MemoryDB_SotoMemoryDB",
+      "label": "@swiftpkg_soto//:SotoMemoryDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMemoryDB"
@@ -2217,17 +2237,27 @@
       "name": "SotoMgn",
       "c99name": "SotoMgn",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Mgn_SotoMgn",
+      "label": "@swiftpkg_soto//:SotoMgn.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMgn"
       ]
     },
     {
+      "name": "SotoMigrationHub",
+      "c99name": "SotoMigrationHub",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoMigrationHub.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoMigrationHub"
+      ]
+    },
+    {
       "name": "SotoMigrationHubConfig",
       "c99name": "SotoMigrationHubConfig",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubConfig_SotoMigrationHubConfig",
+      "label": "@swiftpkg_soto//:SotoMigrationHubConfig.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMigrationHubConfig"
@@ -2237,7 +2267,7 @@
       "name": "SotoMigrationHubOrchestrator",
       "c99name": "SotoMigrationHubOrchestrator",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubOrchestrator_SotoMigrationHubOrchestrator",
+      "label": "@swiftpkg_soto//:SotoMigrationHubOrchestrator.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMigrationHubOrchestrator"
@@ -2247,7 +2277,7 @@
       "name": "SotoMigrationHubRefactorSpaces",
       "c99name": "SotoMigrationHubRefactorSpaces",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubRefactorSpaces_SotoMigrationHubRefactorSpaces",
+      "label": "@swiftpkg_soto//:SotoMigrationHubRefactorSpaces.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMigrationHubRefactorSpaces"
@@ -2257,27 +2287,17 @@
       "name": "SotoMigrationHubStrategy",
       "c99name": "SotoMigrationHubStrategy",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubStrategy_SotoMigrationHubStrategy",
+      "label": "@swiftpkg_soto//:SotoMigrationHubStrategy.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMigrationHubStrategy"
       ]
     },
     {
-      "name": "SotoMigrationHub",
-      "c99name": "SotoMigrationHub",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_MigrationHub_SotoMigrationHub",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoMigrationHub"
-      ]
-    },
-    {
       "name": "SotoMobile",
       "c99name": "SotoMobile",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Mobile_SotoMobile",
+      "label": "@swiftpkg_soto//:SotoMobile.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoMobile"
@@ -2287,7 +2307,7 @@
       "name": "SotoNeptune",
       "c99name": "SotoNeptune",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Neptune_SotoNeptune",
+      "label": "@swiftpkg_soto//:SotoNeptune.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoNeptune"
@@ -2297,7 +2317,7 @@
       "name": "SotoNetworkFirewall",
       "c99name": "SotoNetworkFirewall",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_NetworkFirewall_SotoNetworkFirewall",
+      "label": "@swiftpkg_soto//:SotoNetworkFirewall.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoNetworkFirewall"
@@ -2307,7 +2327,7 @@
       "name": "SotoNetworkManager",
       "c99name": "SotoNetworkManager",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_NetworkManager_SotoNetworkManager",
+      "label": "@swiftpkg_soto//:SotoNetworkManager.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoNetworkManager"
@@ -2317,7 +2337,7 @@
       "name": "SotoNimble",
       "c99name": "SotoNimble",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Nimble_SotoNimble",
+      "label": "@swiftpkg_soto//:SotoNimble.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoNimble"
@@ -2327,7 +2347,7 @@
       "name": "SotoOAM",
       "c99name": "SotoOAM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_OAM_SotoOAM",
+      "label": "@swiftpkg_soto//:SotoOAM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOAM"
@@ -2337,7 +2357,7 @@
       "name": "SotoOSIS",
       "c99name": "SotoOSIS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_OSIS_SotoOSIS",
+      "label": "@swiftpkg_soto//:SotoOSIS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOSIS"
@@ -2347,57 +2367,57 @@
       "name": "SotoOmics",
       "c99name": "SotoOmics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Omics_SotoOmics",
+      "label": "@swiftpkg_soto//:SotoOmics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOmics"
       ]
     },
     {
-      "name": "SotoOpenSearchServerless",
-      "c99name": "SotoOpenSearchServerless",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_OpenSearchServerless_SotoOpenSearchServerless",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoOpenSearchServerless"
-      ]
-    },
-    {
       "name": "SotoOpenSearch",
       "c99name": "SotoOpenSearch",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_OpenSearch_SotoOpenSearch",
+      "label": "@swiftpkg_soto//:SotoOpenSearch.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOpenSearch"
       ]
     },
     {
-      "name": "SotoOpsWorksCM",
-      "c99name": "SotoOpsWorksCM",
+      "name": "SotoOpenSearchServerless",
+      "c99name": "SotoOpenSearchServerless",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_OpsWorksCM_SotoOpsWorksCM",
+      "label": "@swiftpkg_soto//:SotoOpenSearchServerless.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoOpsWorksCM"
+        "SotoOpenSearchServerless"
       ]
     },
     {
       "name": "SotoOpsWorks",
       "c99name": "SotoOpsWorks",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_OpsWorks_SotoOpsWorks",
+      "label": "@swiftpkg_soto//:SotoOpsWorks.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOpsWorks"
       ]
     },
     {
+      "name": "SotoOpsWorksCM",
+      "c99name": "SotoOpsWorksCM",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoOpsWorksCM.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoOpsWorksCM"
+      ]
+    },
+    {
       "name": "SotoOrganizations",
       "c99name": "SotoOrganizations",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Organizations_SotoOrganizations",
+      "label": "@swiftpkg_soto//:SotoOrganizations.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOrganizations"
@@ -2407,7 +2427,7 @@
       "name": "SotoOutposts",
       "c99name": "SotoOutposts",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Outposts_SotoOutposts",
+      "label": "@swiftpkg_soto//:SotoOutposts.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoOutposts"
@@ -2417,7 +2437,7 @@
       "name": "SotoPI",
       "c99name": "SotoPI",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PI_SotoPI",
+      "label": "@swiftpkg_soto//:SotoPI.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPI"
@@ -2427,37 +2447,47 @@
       "name": "SotoPanorama",
       "c99name": "SotoPanorama",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Panorama_SotoPanorama",
+      "label": "@swiftpkg_soto//:SotoPanorama.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPanorama"
       ]
     },
     {
-      "name": "SotoPaymentCryptographyData",
-      "c99name": "SotoPaymentCryptographyData",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PaymentCryptographyData_SotoPaymentCryptographyData",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoPaymentCryptographyData"
-      ]
-    },
-    {
       "name": "SotoPaymentCryptography",
       "c99name": "SotoPaymentCryptography",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PaymentCryptography_SotoPaymentCryptography",
+      "label": "@swiftpkg_soto//:SotoPaymentCryptography.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPaymentCryptography"
       ]
     },
     {
+      "name": "SotoPaymentCryptographyData",
+      "c99name": "SotoPaymentCryptographyData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoPaymentCryptographyData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoPaymentCryptographyData"
+      ]
+    },
+    {
+      "name": "SotoPersonalize",
+      "c99name": "SotoPersonalize",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoPersonalize.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoPersonalize"
+      ]
+    },
+    {
       "name": "SotoPersonalizeEvents",
       "c99name": "SotoPersonalizeEvents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PersonalizeEvents_SotoPersonalizeEvents",
+      "label": "@swiftpkg_soto//:SotoPersonalizeEvents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPersonalizeEvents"
@@ -2467,67 +2497,57 @@
       "name": "SotoPersonalizeRuntime",
       "c99name": "SotoPersonalizeRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PersonalizeRuntime_SotoPersonalizeRuntime",
+      "label": "@swiftpkg_soto//:SotoPersonalizeRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPersonalizeRuntime"
       ]
     },
     {
-      "name": "SotoPersonalize",
-      "c99name": "SotoPersonalize",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Personalize_SotoPersonalize",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoPersonalize"
-      ]
-    },
-    {
-      "name": "SotoPinpointEmail",
-      "c99name": "SotoPinpointEmail",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PinpointEmail_SotoPinpointEmail",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoPinpointEmail"
-      ]
-    },
-    {
-      "name": "SotoPinpointSMSVoiceV2",
-      "c99name": "SotoPinpointSMSVoiceV2",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PinpointSMSVoiceV2_SotoPinpointSMSVoiceV2",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoPinpointSMSVoiceV2"
-      ]
-    },
-    {
-      "name": "SotoPinpointSMSVoice",
-      "c99name": "SotoPinpointSMSVoice",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PinpointSMSVoice_SotoPinpointSMSVoice",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoPinpointSMSVoice"
-      ]
-    },
-    {
       "name": "SotoPinpoint",
       "c99name": "SotoPinpoint",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Pinpoint_SotoPinpoint",
+      "label": "@swiftpkg_soto//:SotoPinpoint.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPinpoint"
       ]
     },
     {
+      "name": "SotoPinpointEmail",
+      "c99name": "SotoPinpointEmail",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoPinpointEmail.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoPinpointEmail"
+      ]
+    },
+    {
+      "name": "SotoPinpointSMSVoice",
+      "c99name": "SotoPinpointSMSVoice",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoPinpointSMSVoice.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoPinpointSMSVoice"
+      ]
+    },
+    {
+      "name": "SotoPinpointSMSVoiceV2",
+      "c99name": "SotoPinpointSMSVoiceV2",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoPinpointSMSVoiceV2.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoPinpointSMSVoiceV2"
+      ]
+    },
+    {
       "name": "SotoPipes",
       "c99name": "SotoPipes",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Pipes_SotoPipes",
+      "label": "@swiftpkg_soto//:SotoPipes.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPipes"
@@ -2537,7 +2557,7 @@
       "name": "SotoPolly",
       "c99name": "SotoPolly",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Polly_SotoPolly",
+      "label": "@swiftpkg_soto//:SotoPolly.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPolly"
@@ -2547,7 +2567,7 @@
       "name": "SotoPricing",
       "c99name": "SotoPricing",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Pricing_SotoPricing",
+      "label": "@swiftpkg_soto//:SotoPricing.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPricing"
@@ -2557,7 +2577,7 @@
       "name": "SotoPrivateNetworks",
       "c99name": "SotoPrivateNetworks",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_PrivateNetworks_SotoPrivateNetworks",
+      "label": "@swiftpkg_soto//:SotoPrivateNetworks.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoPrivateNetworks"
@@ -2567,37 +2587,37 @@
       "name": "SotoProton",
       "c99name": "SotoProton",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Proton_SotoProton",
+      "label": "@swiftpkg_soto//:SotoProton.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoProton"
       ]
     },
     {
-      "name": "SotoQLDBSession",
-      "c99name": "SotoQLDBSession",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_QLDBSession_SotoQLDBSession",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoQLDBSession"
-      ]
-    },
-    {
       "name": "SotoQLDB",
       "c99name": "SotoQLDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_QLDB_SotoQLDB",
+      "label": "@swiftpkg_soto//:SotoQLDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoQLDB"
       ]
     },
     {
+      "name": "SotoQLDBSession",
+      "c99name": "SotoQLDBSession",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoQLDBSession.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoQLDBSession"
+      ]
+    },
+    {
       "name": "SotoQuickSight",
       "c99name": "SotoQuickSight",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_QuickSight_SotoQuickSight",
+      "label": "@swiftpkg_soto//:SotoQuickSight.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoQuickSight"
@@ -2607,37 +2627,37 @@
       "name": "SotoRAM",
       "c99name": "SotoRAM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RAM_SotoRAM",
+      "label": "@swiftpkg_soto//:SotoRAM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRAM"
       ]
     },
     {
-      "name": "SotoRDSData",
-      "c99name": "SotoRDSData",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RDSData_SotoRDSData",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoRDSData"
-      ]
-    },
-    {
       "name": "SotoRDS",
       "c99name": "SotoRDS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RDS_SotoRDS",
+      "label": "@swiftpkg_soto//:SotoRDS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRDS"
       ]
     },
     {
+      "name": "SotoRDSData",
+      "c99name": "SotoRDSData",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoRDSData.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoRDSData"
+      ]
+    },
+    {
       "name": "SotoRUM",
       "c99name": "SotoRUM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RUM_SotoRUM",
+      "label": "@swiftpkg_soto//:SotoRUM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRUM"
@@ -2647,17 +2667,27 @@
       "name": "SotoRbin",
       "c99name": "SotoRbin",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Rbin_SotoRbin",
+      "label": "@swiftpkg_soto//:SotoRbin.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRbin"
       ]
     },
     {
+      "name": "SotoRedshift",
+      "c99name": "SotoRedshift",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoRedshift.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoRedshift"
+      ]
+    },
+    {
       "name": "SotoRedshiftData",
       "c99name": "SotoRedshiftData",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RedshiftData_SotoRedshiftData",
+      "label": "@swiftpkg_soto//:SotoRedshiftData.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRedshiftData"
@@ -2667,27 +2697,17 @@
       "name": "SotoRedshiftServerless",
       "c99name": "SotoRedshiftServerless",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RedshiftServerless_SotoRedshiftServerless",
+      "label": "@swiftpkg_soto//:SotoRedshiftServerless.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRedshiftServerless"
       ]
     },
     {
-      "name": "SotoRedshift",
-      "c99name": "SotoRedshift",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Redshift_SotoRedshift",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoRedshift"
-      ]
-    },
-    {
       "name": "SotoRekognition",
       "c99name": "SotoRekognition",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Rekognition_SotoRekognition",
+      "label": "@swiftpkg_soto//:SotoRekognition.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRekognition"
@@ -2697,7 +2717,7 @@
       "name": "SotoResiliencehub",
       "c99name": "SotoResiliencehub",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Resiliencehub_SotoResiliencehub",
+      "label": "@swiftpkg_soto//:SotoResiliencehub.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoResiliencehub"
@@ -2707,37 +2727,37 @@
       "name": "SotoResourceExplorer2",
       "c99name": "SotoResourceExplorer2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ResourceExplorer2_SotoResourceExplorer2",
+      "label": "@swiftpkg_soto//:SotoResourceExplorer2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoResourceExplorer2"
       ]
     },
     {
-      "name": "SotoResourceGroupsTaggingAPI",
-      "c99name": "SotoResourceGroupsTaggingAPI",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ResourceGroupsTaggingAPI_SotoResourceGroupsTaggingAPI",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoResourceGroupsTaggingAPI"
-      ]
-    },
-    {
       "name": "SotoResourceGroups",
       "c99name": "SotoResourceGroups",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ResourceGroups_SotoResourceGroups",
+      "label": "@swiftpkg_soto//:SotoResourceGroups.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoResourceGroups"
       ]
     },
     {
+      "name": "SotoResourceGroupsTaggingAPI",
+      "c99name": "SotoResourceGroupsTaggingAPI",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoResourceGroupsTaggingAPI.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoResourceGroupsTaggingAPI"
+      ]
+    },
+    {
       "name": "SotoRoboMaker",
       "c99name": "SotoRoboMaker",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RoboMaker_SotoRoboMaker",
+      "label": "@swiftpkg_soto//:SotoRoboMaker.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRoboMaker"
@@ -2747,17 +2767,27 @@
       "name": "SotoRolesAnywhere",
       "c99name": "SotoRolesAnywhere",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_RolesAnywhere_SotoRolesAnywhere",
+      "label": "@swiftpkg_soto//:SotoRolesAnywhere.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRolesAnywhere"
       ]
     },
     {
+      "name": "SotoRoute53",
+      "c99name": "SotoRoute53",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoRoute53.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoRoute53"
+      ]
+    },
+    {
       "name": "SotoRoute53Domains",
       "c99name": "SotoRoute53Domains",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Route53Domains_SotoRoute53Domains",
+      "label": "@swiftpkg_soto//:SotoRoute53Domains.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRoute53Domains"
@@ -2767,7 +2797,7 @@
       "name": "SotoRoute53RecoveryCluster",
       "c99name": "SotoRoute53RecoveryCluster",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Route53RecoveryCluster_SotoRoute53RecoveryCluster",
+      "label": "@swiftpkg_soto//:SotoRoute53RecoveryCluster.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRoute53RecoveryCluster"
@@ -2777,7 +2807,7 @@
       "name": "SotoRoute53RecoveryControlConfig",
       "c99name": "SotoRoute53RecoveryControlConfig",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Route53RecoveryControlConfig_SotoRoute53RecoveryControlConfig",
+      "label": "@swiftpkg_soto//:SotoRoute53RecoveryControlConfig.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRoute53RecoveryControlConfig"
@@ -2787,7 +2817,7 @@
       "name": "SotoRoute53RecoveryReadiness",
       "c99name": "SotoRoute53RecoveryReadiness",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Route53RecoveryReadiness_SotoRoute53RecoveryReadiness",
+      "label": "@swiftpkg_soto//:SotoRoute53RecoveryReadiness.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRoute53RecoveryReadiness"
@@ -2797,27 +2827,27 @@
       "name": "SotoRoute53Resolver",
       "c99name": "SotoRoute53Resolver",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Route53Resolver_SotoRoute53Resolver",
+      "label": "@swiftpkg_soto//:SotoRoute53Resolver.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoRoute53Resolver"
       ]
     },
     {
-      "name": "SotoRoute53",
-      "c99name": "SotoRoute53",
+      "name": "SotoS3",
+      "c99name": "SotoS3",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Route53_SotoRoute53",
+      "label": "@swiftpkg_soto//:SotoS3.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoRoute53"
+        "SotoS3"
       ]
     },
     {
       "name": "SotoS3Control",
       "c99name": "SotoS3Control",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_S3Control_SotoS3Control",
+      "label": "@swiftpkg_soto//:SotoS3Control.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoS3Control"
@@ -2827,7 +2857,7 @@
       "name": "SotoS3Outposts",
       "c99name": "SotoS3Outposts",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_S3Outposts_SotoS3Outposts",
+      "label": "@swiftpkg_soto//:SotoS3Outposts.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoS3Outposts"
@@ -2837,7 +2867,7 @@
       "name": "SotoSES",
       "c99name": "SotoSES",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SES_SotoSES",
+      "label": "@swiftpkg_soto//:SotoSES.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSES"
@@ -2847,7 +2877,7 @@
       "name": "SotoSESv2",
       "c99name": "SotoSESv2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SESv2_SotoSESv2",
+      "label": "@swiftpkg_soto//:SotoSESv2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSESv2"
@@ -2857,7 +2887,7 @@
       "name": "SotoSFN",
       "c99name": "SotoSFN",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SFN_SotoSFN",
+      "label": "@swiftpkg_soto//:SotoSFN.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSFN"
@@ -2867,7 +2897,7 @@
       "name": "SotoSMS",
       "c99name": "SotoSMS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SMS_SotoSMS",
+      "label": "@swiftpkg_soto//:SotoSMS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSMS"
@@ -2877,7 +2907,7 @@
       "name": "SotoSNS",
       "c99name": "SotoSNS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SNS_SotoSNS",
+      "label": "@swiftpkg_soto//:SotoSNS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSNS"
@@ -2887,17 +2917,27 @@
       "name": "SotoSQS",
       "c99name": "SotoSQS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SQS_SotoSQS",
+      "label": "@swiftpkg_soto//:SotoSQS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSQS"
       ]
     },
     {
+      "name": "SotoSSM",
+      "c99name": "SotoSSM",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoSSM.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoSSM"
+      ]
+    },
+    {
       "name": "SotoSSMContacts",
       "c99name": "SotoSSMContacts",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SSMContacts_SotoSSMContacts",
+      "label": "@swiftpkg_soto//:SotoSSMContacts.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSSMContacts"
@@ -2907,27 +2947,27 @@
       "name": "SotoSSMIncidents",
       "c99name": "SotoSSMIncidents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SSMIncidents_SotoSSMIncidents",
+      "label": "@swiftpkg_soto//:SotoSSMIncidents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSSMIncidents"
       ]
     },
     {
-      "name": "SotoSSM",
-      "c99name": "SotoSSM",
+      "name": "SotoSSO",
+      "c99name": "SotoSSO",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SSM_SotoSSM",
+      "label": "@swiftpkg_soto//:SotoSSO.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoSSM"
+        "SotoSSO"
       ]
     },
     {
       "name": "SotoSSOAdmin",
       "c99name": "SotoSSOAdmin",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SSOAdmin_SotoSSOAdmin",
+      "label": "@swiftpkg_soto//:SotoSSOAdmin.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSSOAdmin"
@@ -2937,37 +2977,47 @@
       "name": "SotoSSOOIDC",
       "c99name": "SotoSSOOIDC",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SSOOIDC_SotoSSOOIDC",
+      "label": "@swiftpkg_soto//:SotoSSOOIDC.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSSOOIDC"
       ]
     },
     {
-      "name": "SotoSSO",
-      "c99name": "SotoSSO",
+      "name": "SotoSTS",
+      "c99name": "SotoSTS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SSO_SotoSSO",
+      "label": "@swiftpkg_soto//:SotoSTS.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoSSO"
+        "SotoSTS"
       ]
     },
     {
       "name": "SotoSWF",
       "c99name": "SotoSWF",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SWF_SotoSWF",
+      "label": "@swiftpkg_soto//:SotoSWF.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSWF"
       ]
     },
     {
+      "name": "SotoSageMaker",
+      "c99name": "SotoSageMaker",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoSageMaker.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoSageMaker"
+      ]
+    },
+    {
       "name": "SotoSageMakerA2IRuntime",
       "c99name": "SotoSageMakerA2IRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SageMakerA2IRuntime_SotoSageMakerA2IRuntime",
+      "label": "@swiftpkg_soto//:SotoSageMakerA2IRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSageMakerA2IRuntime"
@@ -2977,7 +3027,7 @@
       "name": "SotoSageMakerFeatureStoreRuntime",
       "c99name": "SotoSageMakerFeatureStoreRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SageMakerFeatureStoreRuntime_SotoSageMakerFeatureStoreRuntime",
+      "label": "@swiftpkg_soto//:SotoSageMakerFeatureStoreRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSageMakerFeatureStoreRuntime"
@@ -2987,7 +3037,7 @@
       "name": "SotoSageMakerGeospatial",
       "c99name": "SotoSageMakerGeospatial",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SageMakerGeospatial_SotoSageMakerGeospatial",
+      "label": "@swiftpkg_soto//:SotoSageMakerGeospatial.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSageMakerGeospatial"
@@ -2997,7 +3047,7 @@
       "name": "SotoSageMakerMetrics",
       "c99name": "SotoSageMakerMetrics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SageMakerMetrics_SotoSageMakerMetrics",
+      "label": "@swiftpkg_soto//:SotoSageMakerMetrics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSageMakerMetrics"
@@ -3007,27 +3057,17 @@
       "name": "SotoSageMakerRuntime",
       "c99name": "SotoSageMakerRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SageMakerRuntime_SotoSageMakerRuntime",
+      "label": "@swiftpkg_soto//:SotoSageMakerRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSageMakerRuntime"
       ]
     },
     {
-      "name": "SotoSageMaker",
-      "c99name": "SotoSageMaker",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SageMaker_SotoSageMaker",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoSageMaker"
-      ]
-    },
-    {
       "name": "SotoSagemakerEdge",
       "c99name": "SotoSagemakerEdge",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SagemakerEdge_SotoSagemakerEdge",
+      "label": "@swiftpkg_soto//:SotoSagemakerEdge.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSagemakerEdge"
@@ -3037,7 +3077,7 @@
       "name": "SotoSavingsPlans",
       "c99name": "SotoSavingsPlans",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SavingsPlans_SotoSavingsPlans",
+      "label": "@swiftpkg_soto//:SotoSavingsPlans.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSavingsPlans"
@@ -3047,7 +3087,7 @@
       "name": "SotoScheduler",
       "c99name": "SotoScheduler",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Scheduler_SotoScheduler",
+      "label": "@swiftpkg_soto//:SotoScheduler.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoScheduler"
@@ -3057,7 +3097,7 @@
       "name": "SotoSchemas",
       "c99name": "SotoSchemas",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Schemas_SotoSchemas",
+      "label": "@swiftpkg_soto//:SotoSchemas.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSchemas"
@@ -3067,7 +3107,7 @@
       "name": "SotoSecretsManager",
       "c99name": "SotoSecretsManager",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SecretsManager_SotoSecretsManager",
+      "label": "@swiftpkg_soto//:SotoSecretsManager.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSecretsManager"
@@ -3077,7 +3117,7 @@
       "name": "SotoSecurityHub",
       "c99name": "SotoSecurityHub",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SecurityHub_SotoSecurityHub",
+      "label": "@swiftpkg_soto//:SotoSecurityHub.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSecurityHub"
@@ -3087,7 +3127,7 @@
       "name": "SotoSecurityLake",
       "c99name": "SotoSecurityLake",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SecurityLake_SotoSecurityLake",
+      "label": "@swiftpkg_soto//:SotoSecurityLake.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSecurityLake"
@@ -3097,37 +3137,37 @@
       "name": "SotoServerlessApplicationRepository",
       "c99name": "SotoServerlessApplicationRepository",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ServerlessApplicationRepository_SotoServerlessApplicationRepository",
+      "label": "@swiftpkg_soto//:SotoServerlessApplicationRepository.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoServerlessApplicationRepository"
       ]
     },
     {
-      "name": "SotoServiceCatalogAppRegistry",
-      "c99name": "SotoServiceCatalogAppRegistry",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ServiceCatalogAppRegistry_SotoServiceCatalogAppRegistry",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoServiceCatalogAppRegistry"
-      ]
-    },
-    {
       "name": "SotoServiceCatalog",
       "c99name": "SotoServiceCatalog",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ServiceCatalog_SotoServiceCatalog",
+      "label": "@swiftpkg_soto//:SotoServiceCatalog.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoServiceCatalog"
       ]
     },
     {
+      "name": "SotoServiceCatalogAppRegistry",
+      "c99name": "SotoServiceCatalogAppRegistry",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoServiceCatalogAppRegistry.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoServiceCatalogAppRegistry"
+      ]
+    },
+    {
       "name": "SotoServiceDiscovery",
       "c99name": "SotoServiceDiscovery",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ServiceDiscovery_SotoServiceDiscovery",
+      "label": "@swiftpkg_soto//:SotoServiceDiscovery.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoServiceDiscovery"
@@ -3137,7 +3177,7 @@
       "name": "SotoServiceQuotas",
       "c99name": "SotoServiceQuotas",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_ServiceQuotas_SotoServiceQuotas",
+      "label": "@swiftpkg_soto//:SotoServiceQuotas.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoServiceQuotas"
@@ -3147,7 +3187,7 @@
       "name": "SotoShield",
       "c99name": "SotoShield",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Shield_SotoShield",
+      "label": "@swiftpkg_soto//:SotoShield.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoShield"
@@ -3157,7 +3197,7 @@
       "name": "SotoSigner",
       "c99name": "SotoSigner",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Signer_SotoSigner",
+      "label": "@swiftpkg_soto//:SotoSigner.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSigner"
@@ -3167,7 +3207,7 @@
       "name": "SotoSimSpaceWeaver",
       "c99name": "SotoSimSpaceWeaver",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SimSpaceWeaver_SotoSimSpaceWeaver",
+      "label": "@swiftpkg_soto//:SotoSimSpaceWeaver.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSimSpaceWeaver"
@@ -3177,7 +3217,7 @@
       "name": "SotoSnowDeviceManagement",
       "c99name": "SotoSnowDeviceManagement",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SnowDeviceManagement_SotoSnowDeviceManagement",
+      "label": "@swiftpkg_soto//:SotoSnowDeviceManagement.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSnowDeviceManagement"
@@ -3187,7 +3227,7 @@
       "name": "SotoSnowball",
       "c99name": "SotoSnowball",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Snowball_SotoSnowball",
+      "label": "@swiftpkg_soto//:SotoSnowball.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSnowball"
@@ -3197,7 +3237,7 @@
       "name": "SotoSsmSap",
       "c99name": "SotoSsmSap",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SsmSap_SotoSsmSap",
+      "label": "@swiftpkg_soto//:SotoSsmSap.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSsmSap"
@@ -3207,37 +3247,37 @@
       "name": "SotoStorageGateway",
       "c99name": "SotoStorageGateway",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_StorageGateway_SotoStorageGateway",
+      "label": "@swiftpkg_soto//:SotoStorageGateway.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoStorageGateway"
       ]
     },
     {
-      "name": "SotoSupportApp",
-      "c99name": "SotoSupportApp",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_SupportApp_SotoSupportApp",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoSupportApp"
-      ]
-    },
-    {
       "name": "SotoSupport",
       "c99name": "SotoSupport",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Support_SotoSupport",
+      "label": "@swiftpkg_soto//:SotoSupport.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSupport"
       ]
     },
     {
+      "name": "SotoSupportApp",
+      "c99name": "SotoSupportApp",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoSupportApp.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoSupportApp"
+      ]
+    },
+    {
       "name": "SotoSynthetics",
       "c99name": "SotoSynthetics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Synthetics_SotoSynthetics",
+      "label": "@swiftpkg_soto//:SotoSynthetics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoSynthetics"
@@ -3247,7 +3287,7 @@
       "name": "SotoTextract",
       "c99name": "SotoTextract",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Textract_SotoTextract",
+      "label": "@swiftpkg_soto//:SotoTextract.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTextract"
@@ -3257,7 +3297,7 @@
       "name": "SotoTimestreamQuery",
       "c99name": "SotoTimestreamQuery",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_TimestreamQuery_SotoTimestreamQuery",
+      "label": "@swiftpkg_soto//:SotoTimestreamQuery.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTimestreamQuery"
@@ -3267,7 +3307,7 @@
       "name": "SotoTimestreamWrite",
       "c99name": "SotoTimestreamWrite",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_TimestreamWrite_SotoTimestreamWrite",
+      "label": "@swiftpkg_soto//:SotoTimestreamWrite.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTimestreamWrite"
@@ -3277,37 +3317,37 @@
       "name": "SotoTnb",
       "c99name": "SotoTnb",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Tnb_SotoTnb",
+      "label": "@swiftpkg_soto//:SotoTnb.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTnb"
       ]
     },
     {
-      "name": "SotoTranscribeStreaming",
-      "c99name": "SotoTranscribeStreaming",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_TranscribeStreaming_SotoTranscribeStreaming",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoTranscribeStreaming"
-      ]
-    },
-    {
       "name": "SotoTranscribe",
       "c99name": "SotoTranscribe",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Transcribe_SotoTranscribe",
+      "label": "@swiftpkg_soto//:SotoTranscribe.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTranscribe"
       ]
     },
     {
+      "name": "SotoTranscribeStreaming",
+      "c99name": "SotoTranscribeStreaming",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoTranscribeStreaming.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoTranscribeStreaming"
+      ]
+    },
+    {
       "name": "SotoTransfer",
       "c99name": "SotoTransfer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Transfer_SotoTransfer",
+      "label": "@swiftpkg_soto//:SotoTransfer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTransfer"
@@ -3317,7 +3357,7 @@
       "name": "SotoTranslate",
       "c99name": "SotoTranslate",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Translate_SotoTranslate",
+      "label": "@swiftpkg_soto//:SotoTranslate.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoTranslate"
@@ -3327,7 +3367,7 @@
       "name": "SotoVPCLattice",
       "c99name": "SotoVPCLattice",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_VPCLattice_SotoVPCLattice",
+      "label": "@swiftpkg_soto//:SotoVPCLattice.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoVPCLattice"
@@ -3337,7 +3377,7 @@
       "name": "SotoVerifiedPermissions",
       "c99name": "SotoVerifiedPermissions",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_VerifiedPermissions_SotoVerifiedPermissions",
+      "label": "@swiftpkg_soto//:SotoVerifiedPermissions.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoVerifiedPermissions"
@@ -3347,17 +3387,27 @@
       "name": "SotoVoiceID",
       "c99name": "SotoVoiceID",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_VoiceID_SotoVoiceID",
+      "label": "@swiftpkg_soto//:SotoVoiceID.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoVoiceID"
       ]
     },
     {
+      "name": "SotoWAF",
+      "c99name": "SotoWAF",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoWAF.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoWAF"
+      ]
+    },
+    {
       "name": "SotoWAFRegional",
       "c99name": "SotoWAFRegional",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WAFRegional_SotoWAFRegional",
+      "label": "@swiftpkg_soto//:SotoWAFRegional.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWAFRegional"
@@ -3367,27 +3417,17 @@
       "name": "SotoWAFV2",
       "c99name": "SotoWAFV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WAFV2_SotoWAFV2",
+      "label": "@swiftpkg_soto//:SotoWAFV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWAFV2"
       ]
     },
     {
-      "name": "SotoWAF",
-      "c99name": "SotoWAF",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WAF_SotoWAF",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoWAF"
-      ]
-    },
-    {
       "name": "SotoWellArchitected",
       "c99name": "SotoWellArchitected",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WellArchitected_SotoWellArchitected",
+      "label": "@swiftpkg_soto//:SotoWellArchitected.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWellArchitected"
@@ -3397,7 +3437,7 @@
       "name": "SotoWisdom",
       "c99name": "SotoWisdom",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_Wisdom_SotoWisdom",
+      "label": "@swiftpkg_soto//:SotoWisdom.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWisdom"
@@ -3407,7 +3447,7 @@
       "name": "SotoWorkDocs",
       "c99name": "SotoWorkDocs",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WorkDocs_SotoWorkDocs",
+      "label": "@swiftpkg_soto//:SotoWorkDocs.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWorkDocs"
@@ -3417,107 +3457,67 @@
       "name": "SotoWorkLink",
       "c99name": "SotoWorkLink",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WorkLink_SotoWorkLink",
+      "label": "@swiftpkg_soto//:SotoWorkLink.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWorkLink"
       ]
     },
     {
-      "name": "SotoWorkMailMessageFlow",
-      "c99name": "SotoWorkMailMessageFlow",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WorkMailMessageFlow_SotoWorkMailMessageFlow",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoWorkMailMessageFlow"
-      ]
-    },
-    {
       "name": "SotoWorkMail",
       "c99name": "SotoWorkMail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WorkMail_SotoWorkMail",
+      "label": "@swiftpkg_soto//:SotoWorkMail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWorkMail"
       ]
     },
     {
-      "name": "SotoWorkSpacesWeb",
-      "c99name": "SotoWorkSpacesWeb",
+      "name": "SotoWorkMailMessageFlow",
+      "c99name": "SotoWorkMailMessageFlow",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WorkSpacesWeb_SotoWorkSpacesWeb",
+      "label": "@swiftpkg_soto//:SotoWorkMailMessageFlow.rspm",
       "package_identity": "soto",
       "product_memberships": [
-        "SotoWorkSpacesWeb"
+        "SotoWorkMailMessageFlow"
       ]
     },
     {
       "name": "SotoWorkSpaces",
       "c99name": "SotoWorkSpaces",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_WorkSpaces_SotoWorkSpaces",
+      "label": "@swiftpkg_soto//:SotoWorkSpaces.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoWorkSpaces"
       ]
     },
     {
+      "name": "SotoWorkSpacesWeb",
+      "c99name": "SotoWorkSpacesWeb",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:SotoWorkSpacesWeb.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "SotoWorkSpacesWeb"
+      ]
+    },
+    {
       "name": "SotoXRay",
       "c99name": "SotoXRay",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_Services_XRay_SotoXRay",
+      "label": "@swiftpkg_soto//:SotoXRay.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "SotoXRay"
       ]
     },
     {
-      "name": "SotoCognitoIdentity",
-      "c99name": "SotoCognitoIdentity",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_SotoCognitoIdentity",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoCognitoIdentity"
-      ]
-    },
-    {
-      "name": "SotoDynamoDB",
-      "c99name": "SotoDynamoDB",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_SotoDynamoDB",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoDynamoDB"
-      ]
-    },
-    {
-      "name": "SotoS3",
-      "c99name": "SotoS3",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_SotoS3",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoS3"
-      ]
-    },
-    {
-      "name": "SotoSTS",
-      "c99name": "SotoSTS",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_Soto_SotoSTS",
-      "package_identity": "soto",
-      "product_memberships": [
-        "SotoSTS"
-      ]
-    },
-    {
       "name": "CSotoExpat",
       "c99name": "CSotoExpat",
       "src_type": "clang",
-      "label": "@swiftpkg_soto_core//:Sources_CSotoExpat",
+      "label": "@swiftpkg_soto_core//:CSotoExpat.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoCore",
@@ -3528,7 +3528,7 @@
       "name": "INIParser",
       "c99name": "INIParser",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_INIParser",
+      "label": "@swiftpkg_soto_core//:INIParser.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoCore",
@@ -3539,7 +3539,7 @@
       "name": "SotoCore",
       "c99name": "SotoCore",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_SotoCore",
+      "label": "@swiftpkg_soto_core//:SotoCore.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoCore",
@@ -3550,7 +3550,7 @@
       "name": "SotoCrypto",
       "c99name": "SotoCrypto",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_SotoCrypto",
+      "label": "@swiftpkg_soto_core//:SotoCrypto.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoCore",
@@ -3562,7 +3562,7 @@
       "name": "SotoSignerV4",
       "c99name": "SotoSignerV4",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_SotoSignerV4",
+      "label": "@swiftpkg_soto_core//:SotoSignerV4.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoCore",
@@ -3574,7 +3574,7 @@
       "name": "SotoTestUtils",
       "c99name": "SotoTestUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_SotoTestUtils",
+      "label": "@swiftpkg_soto_core//:SotoTestUtils.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoTestUtils"
@@ -3584,7 +3584,7 @@
       "name": "SotoXML",
       "c99name": "SotoXML",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_SotoXML",
+      "label": "@swiftpkg_soto_core//:SotoXML.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "SotoCore",
@@ -3595,7 +3595,7 @@
       "name": "Atomics",
       "c99name": "Atomics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_atomics//:Sources_Atomics",
+      "label": "@swiftpkg_swift_atomics//:Atomics.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -3605,7 +3605,7 @@
       "name": "_AtomicsShims",
       "c99name": "_AtomicsShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_atomics//:Sources__AtomicsShims",
+      "label": "@swiftpkg_swift_atomics//:_AtomicsShims.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -3615,7 +3615,7 @@
       "name": "Collections",
       "c99name": "Collections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_Collections",
+      "label": "@swiftpkg_swift_collections//:Collections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections"
@@ -3625,7 +3625,7 @@
       "name": "DequeModule",
       "c99name": "DequeModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_DequeModule",
+      "label": "@swiftpkg_swift_collections//:DequeModule.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -3636,7 +3636,7 @@
       "name": "OrderedCollections",
       "c99name": "OrderedCollections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_OrderedCollections",
+      "label": "@swiftpkg_swift_collections//:OrderedCollections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -3647,7 +3647,7 @@
       "name": "Logging",
       "c99name": "Logging",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_log//:Sources_Logging",
+      "label": "@swiftpkg_swift_log//:Logging.rspm",
       "package_identity": "swift-log",
       "product_memberships": [
         "Logging"
@@ -3657,7 +3657,7 @@
       "name": "CoreMetrics",
       "c99name": "CoreMetrics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_CoreMetrics",
+      "label": "@swiftpkg_swift_metrics//:CoreMetrics.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "CoreMetrics",
@@ -3669,7 +3669,7 @@
       "name": "Metrics",
       "c99name": "Metrics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_Metrics",
+      "label": "@swiftpkg_swift_metrics//:Metrics.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "Metrics",
@@ -3680,7 +3680,7 @@
       "name": "MetricsTestKit",
       "c99name": "MetricsTestKit",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_MetricsTestKit",
+      "label": "@swiftpkg_swift_metrics//:MetricsTestKit.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "MetricsTestKit"
@@ -3690,7 +3690,7 @@
       "name": "CNIOAtomics",
       "c99name": "CNIOAtomics",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOAtomics",
+      "label": "@swiftpkg_swift_nio//:CNIOAtomics.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3710,7 +3710,7 @@
       "name": "CNIODarwin",
       "c99name": "CNIODarwin",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIODarwin",
+      "label": "@swiftpkg_swift_nio//:CNIODarwin.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3727,7 +3727,7 @@
       "name": "CNIOLLHTTP",
       "c99name": "CNIOLLHTTP",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLLHTTP",
+      "label": "@swiftpkg_swift_nio//:CNIOLLHTTP.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -3739,7 +3739,7 @@
       "name": "CNIOLinux",
       "c99name": "CNIOLinux",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLinux",
+      "label": "@swiftpkg_swift_nio//:CNIOLinux.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3758,7 +3758,7 @@
       "name": "CNIOSHA1",
       "c99name": "CNIOSHA1",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOSHA1",
+      "label": "@swiftpkg_swift_nio//:CNIOSHA1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -3768,7 +3768,7 @@
       "name": "CNIOWindows",
       "c99name": "CNIOWindows",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOWindows",
+      "label": "@swiftpkg_swift_nio//:CNIOWindows.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3787,7 +3787,7 @@
       "name": "NIO",
       "c99name": "NIO",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIO",
+      "label": "@swiftpkg_swift_nio//:NIO.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3803,7 +3803,7 @@
       "name": "NIOConcurrencyHelpers",
       "c99name": "NIOConcurrencyHelpers",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers",
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3823,7 +3823,7 @@
       "name": "NIOCore",
       "c99name": "NIOCore",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOCore",
+      "label": "@swiftpkg_swift_nio//:NIOCore.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3842,7 +3842,7 @@
       "name": "NIOEmbedded",
       "c99name": "NIOEmbedded",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOEmbedded",
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3859,7 +3859,7 @@
       "name": "NIOFoundationCompat",
       "c99name": "NIOFoundationCompat",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat",
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOFoundationCompat"
@@ -3869,7 +3869,7 @@
       "name": "NIOHTTP1",
       "c99name": "NIOHTTP1",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOHTTP1",
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -3881,7 +3881,7 @@
       "name": "NIOPosix",
       "c99name": "NIOPosix",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOPosix",
+      "label": "@swiftpkg_swift_nio//:NIOPosix.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3898,7 +3898,7 @@
       "name": "NIOTLS",
       "c99name": "NIOTLS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTLS",
+      "label": "@swiftpkg_swift_nio//:NIOTLS.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTLS"
@@ -3908,7 +3908,7 @@
       "name": "NIOTestUtils",
       "c99name": "NIOTestUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTestUtils",
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTestUtils"
@@ -3918,7 +3918,7 @@
       "name": "NIOWebSocket",
       "c99name": "NIOWebSocket",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOWebSocket",
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -3928,7 +3928,7 @@
       "name": "_NIOConcurrency",
       "c99name": "_NIOConcurrency",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIOConcurrency",
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "_NIOConcurrency"
@@ -3938,7 +3938,7 @@
       "name": "_NIODataStructures",
       "c99name": "_NIODataStructures",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIODataStructures",
+      "label": "@swiftpkg_swift_nio//:_NIODataStructures.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3956,7 +3956,7 @@
       "name": "CNIOExtrasZlib",
       "c99name": "CNIOExtrasZlib",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_CNIOExtrasZlib",
+      "label": "@swiftpkg_swift_nio_extras//:CNIOExtrasZlib.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOHTTPCompression"
@@ -3966,7 +3966,7 @@
       "name": "NIOExtras",
       "c99name": "NIOExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOExtras",
+      "label": "@swiftpkg_swift_nio_extras//:NIOExtras.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOExtras"
@@ -3976,7 +3976,7 @@
       "name": "NIOHTTPCompression",
       "c99name": "NIOHTTPCompression",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOHTTPCompression",
+      "label": "@swiftpkg_swift_nio_extras//:NIOHTTPCompression.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOHTTPCompression"
@@ -3986,7 +3986,7 @@
       "name": "NIOSOCKS",
       "c99name": "NIOSOCKS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOSOCKS",
+      "label": "@swiftpkg_swift_nio_extras//:NIOSOCKS.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOSOCKS"
@@ -3996,7 +3996,7 @@
       "name": "NIOHPACK",
       "c99name": "NIOHPACK",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_http2//:Sources_NIOHPACK",
+      "label": "@swiftpkg_swift_nio_http2//:NIOHPACK.rspm",
       "package_identity": "swift-nio-http2",
       "product_memberships": [
         "NIOHTTP2"
@@ -4006,7 +4006,7 @@
       "name": "NIOHTTP2",
       "c99name": "NIOHTTP2",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_http2//:Sources_NIOHTTP2",
+      "label": "@swiftpkg_swift_nio_http2//:NIOHTTP2.rspm",
       "package_identity": "swift-nio-http2",
       "product_memberships": [
         "NIOHTTP2"
@@ -4016,7 +4016,7 @@
       "name": "CNIOBoringSSL",
       "c99name": "CNIOBoringSSL",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_CNIOBoringSSL",
+      "label": "@swiftpkg_swift_nio_ssl//:CNIOBoringSSL.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -4028,7 +4028,7 @@
       "name": "CNIOBoringSSLShims",
       "c99name": "CNIOBoringSSLShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_CNIOBoringSSLShims",
+      "label": "@swiftpkg_swift_nio_ssl//:CNIOBoringSSLShims.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -4040,7 +4040,7 @@
       "name": "NIOSSL",
       "c99name": "NIOSSL",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOSSL",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSL.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -4052,7 +4052,7 @@
       "name": "NIOSSLHTTP1Client",
       "c99name": "NIOSSLHTTP1Client",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOSSLHTTP1Client",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSLHTTP1Client.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSLHTTP1Client"
@@ -4062,7 +4062,7 @@
       "name": "NIOTLSServer",
       "c99name": "NIOTLSServer",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOTLSServer",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOTLSServer.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOTLSServer"
@@ -4072,7 +4072,7 @@
       "name": "NIOTransportServices",
       "c99name": "NIOTransportServices",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_transport_services//:Sources_NIOTransportServices",
+      "label": "@swiftpkg_swift_nio_transport_services//:NIOTransportServices.rspm",
       "package_identity": "swift-nio-transport-services",
       "product_memberships": [
         "NIOTransportServices"
@@ -4084,3041 +4084,2281 @@
       "identity": "async-http-client",
       "name": "AsyncHTTPClient",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_async_http_client//:Sources_AsyncHTTPClient"
-      ]
+      "label": "@swiftpkg_async_http_client//:AsyncHTTPClient"
     },
     {
       "identity": "jmespath.swift",
       "name": "JMESPath",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_jmespath.swift//:Sources_JMESPath"
-      ]
+      "label": "@swiftpkg_jmespath.swift//:JMESPath"
     },
     {
       "identity": "soto-core",
       "name": "SotoCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto_core//:Sources_SotoCore"
-      ]
+      "label": "@swiftpkg_soto_core//:SotoCore"
     },
     {
       "identity": "soto-core",
       "name": "SotoSignerV4",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto_core//:Sources_SotoSignerV4"
-      ]
+      "label": "@swiftpkg_soto_core//:SotoSignerV4"
     },
     {
       "identity": "soto-core",
       "name": "SotoTestUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto_core//:Sources_SotoTestUtils"
-      ]
+      "label": "@swiftpkg_soto_core//:SotoTestUtils"
     },
     {
       "identity": "soto",
       "name": "SotoACM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ACM_SotoACM"
-      ]
+      "label": "@swiftpkg_soto//:SotoACM"
     },
     {
       "identity": "soto",
       "name": "SotoACMPCA",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ACMPCA_SotoACMPCA"
-      ]
+      "label": "@swiftpkg_soto//:SotoACMPCA"
     },
     {
       "identity": "soto",
       "name": "SotoAPIGateway",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_APIGateway_SotoAPIGateway"
-      ]
+      "label": "@swiftpkg_soto//:SotoAPIGateway"
     },
     {
       "identity": "soto",
       "name": "SotoARCZonalShift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ARCZonalShift_SotoARCZonalShift"
-      ]
+      "label": "@swiftpkg_soto//:SotoARCZonalShift"
     },
     {
       "identity": "soto",
       "name": "SotoAccessAnalyzer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AccessAnalyzer_SotoAccessAnalyzer"
-      ]
+      "label": "@swiftpkg_soto//:SotoAccessAnalyzer"
     },
     {
       "identity": "soto",
       "name": "SotoAccount",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Account_SotoAccount"
-      ]
+      "label": "@swiftpkg_soto//:SotoAccount"
     },
     {
       "identity": "soto",
       "name": "SotoAlexaForBusiness",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AlexaForBusiness_SotoAlexaForBusiness"
-      ]
+      "label": "@swiftpkg_soto//:SotoAlexaForBusiness"
     },
     {
       "identity": "soto",
       "name": "SotoAmp",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Amp_SotoAmp"
-      ]
+      "label": "@swiftpkg_soto//:SotoAmp"
     },
     {
       "identity": "soto",
       "name": "SotoAmplify",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Amplify_SotoAmplify"
-      ]
+      "label": "@swiftpkg_soto//:SotoAmplify"
     },
     {
       "identity": "soto",
       "name": "SotoAmplifyBackend",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AmplifyBackend_SotoAmplifyBackend"
-      ]
+      "label": "@swiftpkg_soto//:SotoAmplifyBackend"
     },
     {
       "identity": "soto",
       "name": "SotoAmplifyUIBuilder",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AmplifyUIBuilder_SotoAmplifyUIBuilder"
-      ]
+      "label": "@swiftpkg_soto//:SotoAmplifyUIBuilder"
     },
     {
       "identity": "soto",
       "name": "SotoApiGatewayManagementApi",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ApiGatewayManagementApi_SotoApiGatewayManagementApi"
-      ]
+      "label": "@swiftpkg_soto//:SotoApiGatewayManagementApi"
     },
     {
       "identity": "soto",
       "name": "SotoApiGatewayV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ApiGatewayV2_SotoApiGatewayV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoApiGatewayV2"
     },
     {
       "identity": "soto",
       "name": "SotoAppConfig",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppConfig_SotoAppConfig"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppConfig"
     },
     {
       "identity": "soto",
       "name": "SotoAppConfigData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppConfigData_SotoAppConfigData"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppConfigData"
     },
     {
       "identity": "soto",
       "name": "SotoAppIntegrations",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppIntegrations_SotoAppIntegrations"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppIntegrations"
     },
     {
       "identity": "soto",
       "name": "SotoAppMesh",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppMesh_SotoAppMesh"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppMesh"
     },
     {
       "identity": "soto",
       "name": "SotoAppRunner",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppRunner_SotoAppRunner"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppRunner"
     },
     {
       "identity": "soto",
       "name": "SotoAppStream",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppStream_SotoAppStream"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppStream"
     },
     {
       "identity": "soto",
       "name": "SotoAppSync",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AppSync_SotoAppSync"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppSync"
     },
     {
       "identity": "soto",
       "name": "SotoAppflow",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Appflow_SotoAppflow"
-      ]
+      "label": "@swiftpkg_soto//:SotoAppflow"
     },
     {
       "identity": "soto",
       "name": "SotoApplicationAutoScaling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ApplicationAutoScaling_SotoApplicationAutoScaling"
-      ]
+      "label": "@swiftpkg_soto//:SotoApplicationAutoScaling"
     },
     {
       "identity": "soto",
       "name": "SotoApplicationCostProfiler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ApplicationCostProfiler_SotoApplicationCostProfiler"
-      ]
+      "label": "@swiftpkg_soto//:SotoApplicationCostProfiler"
     },
     {
       "identity": "soto",
       "name": "SotoApplicationDiscoveryService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ApplicationDiscoveryService_SotoApplicationDiscoveryService"
-      ]
+      "label": "@swiftpkg_soto//:SotoApplicationDiscoveryService"
     },
     {
       "identity": "soto",
       "name": "SotoApplicationInsights",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ApplicationInsights_SotoApplicationInsights"
-      ]
+      "label": "@swiftpkg_soto//:SotoApplicationInsights"
     },
     {
       "identity": "soto",
       "name": "SotoAthena",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Athena_SotoAthena"
-      ]
+      "label": "@swiftpkg_soto//:SotoAthena"
     },
     {
       "identity": "soto",
       "name": "SotoAuditManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AuditManager_SotoAuditManager"
-      ]
+      "label": "@swiftpkg_soto//:SotoAuditManager"
     },
     {
       "identity": "soto",
       "name": "SotoAutoScaling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AutoScaling_SotoAutoScaling"
-      ]
+      "label": "@swiftpkg_soto//:SotoAutoScaling"
     },
     {
       "identity": "soto",
       "name": "SotoAutoScalingPlans",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_AutoScalingPlans_SotoAutoScalingPlans"
-      ]
+      "label": "@swiftpkg_soto//:SotoAutoScalingPlans"
     },
     {
       "identity": "soto",
       "name": "SotoBackup",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Backup_SotoBackup"
-      ]
+      "label": "@swiftpkg_soto//:SotoBackup"
     },
     {
       "identity": "soto",
       "name": "SotoBackupGateway",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_BackupGateway_SotoBackupGateway"
-      ]
+      "label": "@swiftpkg_soto//:SotoBackupGateway"
     },
     {
       "identity": "soto",
       "name": "SotoBackupStorage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_BackupStorage_SotoBackupStorage"
-      ]
+      "label": "@swiftpkg_soto//:SotoBackupStorage"
     },
     {
       "identity": "soto",
       "name": "SotoBatch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Batch_SotoBatch"
-      ]
+      "label": "@swiftpkg_soto//:SotoBatch"
     },
     {
       "identity": "soto",
       "name": "SotoBillingconductor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Billingconductor_SotoBillingconductor"
-      ]
+      "label": "@swiftpkg_soto//:SotoBillingconductor"
     },
     {
       "identity": "soto",
       "name": "SotoBraket",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Braket_SotoBraket"
-      ]
+      "label": "@swiftpkg_soto//:SotoBraket"
     },
     {
       "identity": "soto",
       "name": "SotoBudgets",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Budgets_SotoBudgets"
-      ]
+      "label": "@swiftpkg_soto//:SotoBudgets"
     },
     {
       "identity": "soto",
       "name": "SotoChime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Chime_SotoChime"
-      ]
+      "label": "@swiftpkg_soto//:SotoChime"
     },
     {
       "identity": "soto",
       "name": "SotoChimeSDKIdentity",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKIdentity_SotoChimeSDKIdentity"
-      ]
+      "label": "@swiftpkg_soto//:SotoChimeSDKIdentity"
     },
     {
       "identity": "soto",
       "name": "SotoChimeSDKMediaPipelines",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKMediaPipelines_SotoChimeSDKMediaPipelines"
-      ]
+      "label": "@swiftpkg_soto//:SotoChimeSDKMediaPipelines"
     },
     {
       "identity": "soto",
       "name": "SotoChimeSDKMeetings",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKMeetings_SotoChimeSDKMeetings"
-      ]
+      "label": "@swiftpkg_soto//:SotoChimeSDKMeetings"
     },
     {
       "identity": "soto",
       "name": "SotoChimeSDKMessaging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKMessaging_SotoChimeSDKMessaging"
-      ]
+      "label": "@swiftpkg_soto//:SotoChimeSDKMessaging"
     },
     {
       "identity": "soto",
       "name": "SotoChimeSDKVoice",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ChimeSDKVoice_SotoChimeSDKVoice"
-      ]
+      "label": "@swiftpkg_soto//:SotoChimeSDKVoice"
     },
     {
       "identity": "soto",
       "name": "SotoCleanRooms",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CleanRooms_SotoCleanRooms"
-      ]
+      "label": "@swiftpkg_soto//:SotoCleanRooms"
     },
     {
       "identity": "soto",
       "name": "SotoCloud9",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Cloud9_SotoCloud9"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloud9"
     },
     {
       "identity": "soto",
       "name": "SotoCloudControl",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudControl_SotoCloudControl"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudControl"
     },
     {
       "identity": "soto",
       "name": "SotoCloudDirectory",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudDirectory_SotoCloudDirectory"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudDirectory"
     },
     {
       "identity": "soto",
       "name": "SotoCloudFormation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudFormation_SotoCloudFormation"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudFormation"
     },
     {
       "identity": "soto",
       "name": "SotoCloudFront",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudFront_SotoCloudFront"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudFront"
     },
     {
       "identity": "soto",
       "name": "SotoCloudHSM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudHSM_SotoCloudHSM"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudHSM"
     },
     {
       "identity": "soto",
       "name": "SotoCloudHSMV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudHSMV2_SotoCloudHSMV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudHSMV2"
     },
     {
       "identity": "soto",
       "name": "SotoCloudSearch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudSearch_SotoCloudSearch"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudSearch"
     },
     {
       "identity": "soto",
       "name": "SotoCloudSearchDomain",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudSearchDomain_SotoCloudSearchDomain"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudSearchDomain"
     },
     {
       "identity": "soto",
       "name": "SotoCloudTrail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudTrail_SotoCloudTrail"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudTrail"
     },
     {
       "identity": "soto",
       "name": "SotoCloudTrailData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudTrailData_SotoCloudTrailData"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudTrailData"
     },
     {
       "identity": "soto",
       "name": "SotoCloudWatch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudWatch_SotoCloudWatch"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudWatch"
     },
     {
       "identity": "soto",
       "name": "SotoCloudWatchEvents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudWatchEvents_SotoCloudWatchEvents"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudWatchEvents"
     },
     {
       "identity": "soto",
       "name": "SotoCloudWatchLogs",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CloudWatchLogs_SotoCloudWatchLogs"
-      ]
+      "label": "@swiftpkg_soto//:SotoCloudWatchLogs"
     },
     {
       "identity": "soto",
       "name": "SotoCodeArtifact",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeArtifact_SotoCodeArtifact"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeArtifact"
     },
     {
       "identity": "soto",
       "name": "SotoCodeBuild",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeBuild_SotoCodeBuild"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeBuild"
     },
     {
       "identity": "soto",
       "name": "SotoCodeCatalyst",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeCatalyst_SotoCodeCatalyst"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeCatalyst"
     },
     {
       "identity": "soto",
       "name": "SotoCodeCommit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeCommit_SotoCodeCommit"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeCommit"
     },
     {
       "identity": "soto",
       "name": "SotoCodeDeploy",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeDeploy_SotoCodeDeploy"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeDeploy"
     },
     {
       "identity": "soto",
       "name": "SotoCodeGuruProfiler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeGuruProfiler_SotoCodeGuruProfiler"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeGuruProfiler"
     },
     {
       "identity": "soto",
       "name": "SotoCodeGuruReviewer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeGuruReviewer_SotoCodeGuruReviewer"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeGuruReviewer"
     },
     {
       "identity": "soto",
       "name": "SotoCodeGuruSecurity",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeGuruSecurity_SotoCodeGuruSecurity"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeGuruSecurity"
     },
     {
       "identity": "soto",
       "name": "SotoCodePipeline",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodePipeline_SotoCodePipeline"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodePipeline"
     },
     {
       "identity": "soto",
       "name": "SotoCodeStar",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeStar_SotoCodeStar"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeStar"
     },
     {
       "identity": "soto",
       "name": "SotoCodeStarConnections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeStarConnections_SotoCodeStarConnections"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeStarConnections"
     },
     {
       "identity": "soto",
       "name": "SotoCodeStarNotifications",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CodeStarNotifications_SotoCodeStarNotifications"
-      ]
+      "label": "@swiftpkg_soto//:SotoCodeStarNotifications"
     },
     {
       "identity": "soto",
       "name": "SotoCognitoIdentity",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_SotoCognitoIdentity"
-      ]
+      "label": "@swiftpkg_soto//:SotoCognitoIdentity"
     },
     {
       "identity": "soto",
       "name": "SotoCognitoIdentityProvider",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CognitoIdentityProvider_SotoCognitoIdentityProvider"
-      ]
+      "label": "@swiftpkg_soto//:SotoCognitoIdentityProvider"
     },
     {
       "identity": "soto",
       "name": "SotoCognitoSync",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CognitoSync_SotoCognitoSync"
-      ]
+      "label": "@swiftpkg_soto//:SotoCognitoSync"
     },
     {
       "identity": "soto",
       "name": "SotoComprehend",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Comprehend_SotoComprehend"
-      ]
+      "label": "@swiftpkg_soto//:SotoComprehend"
     },
     {
       "identity": "soto",
       "name": "SotoComprehendMedical",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ComprehendMedical_SotoComprehendMedical"
-      ]
+      "label": "@swiftpkg_soto//:SotoComprehendMedical"
     },
     {
       "identity": "soto",
       "name": "SotoComputeOptimizer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ComputeOptimizer_SotoComputeOptimizer"
-      ]
+      "label": "@swiftpkg_soto//:SotoComputeOptimizer"
     },
     {
       "identity": "soto",
       "name": "SotoConfigService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ConfigService_SotoConfigService"
-      ]
+      "label": "@swiftpkg_soto//:SotoConfigService"
     },
     {
       "identity": "soto",
       "name": "SotoConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Connect_SotoConnect"
-      ]
+      "label": "@swiftpkg_soto//:SotoConnect"
     },
     {
       "identity": "soto",
       "name": "SotoConnectCampaigns",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ConnectCampaigns_SotoConnectCampaigns"
-      ]
+      "label": "@swiftpkg_soto//:SotoConnectCampaigns"
     },
     {
       "identity": "soto",
       "name": "SotoConnectCases",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ConnectCases_SotoConnectCases"
-      ]
+      "label": "@swiftpkg_soto//:SotoConnectCases"
     },
     {
       "identity": "soto",
       "name": "SotoConnectContactLens",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ConnectContactLens_SotoConnectContactLens"
-      ]
+      "label": "@swiftpkg_soto//:SotoConnectContactLens"
     },
     {
       "identity": "soto",
       "name": "SotoConnectParticipant",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ConnectParticipant_SotoConnectParticipant"
-      ]
+      "label": "@swiftpkg_soto//:SotoConnectParticipant"
     },
     {
       "identity": "soto",
       "name": "SotoControlTower",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ControlTower_SotoControlTower"
-      ]
+      "label": "@swiftpkg_soto//:SotoControlTower"
     },
     {
       "identity": "soto",
       "name": "SotoCostAndUsageReportService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CostAndUsageReportService_SotoCostAndUsageReportService"
-      ]
+      "label": "@swiftpkg_soto//:SotoCostAndUsageReportService"
     },
     {
       "identity": "soto",
       "name": "SotoCostExplorer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CostExplorer_SotoCostExplorer"
-      ]
+      "label": "@swiftpkg_soto//:SotoCostExplorer"
     },
     {
       "identity": "soto",
       "name": "SotoCustomerProfiles",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_CustomerProfiles_SotoCustomerProfiles"
-      ]
+      "label": "@swiftpkg_soto//:SotoCustomerProfiles"
     },
     {
       "identity": "soto",
       "name": "SotoDAX",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DAX_SotoDAX"
-      ]
+      "label": "@swiftpkg_soto//:SotoDAX"
     },
     {
       "identity": "soto",
       "name": "SotoDLM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DLM_SotoDLM"
-      ]
+      "label": "@swiftpkg_soto//:SotoDLM"
     },
     {
       "identity": "soto",
       "name": "SotoDataBrew",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DataBrew_SotoDataBrew"
-      ]
+      "label": "@swiftpkg_soto//:SotoDataBrew"
     },
     {
       "identity": "soto",
       "name": "SotoDataExchange",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DataExchange_SotoDataExchange"
-      ]
+      "label": "@swiftpkg_soto//:SotoDataExchange"
     },
     {
       "identity": "soto",
       "name": "SotoDataPipeline",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DataPipeline_SotoDataPipeline"
-      ]
+      "label": "@swiftpkg_soto//:SotoDataPipeline"
     },
     {
       "identity": "soto",
       "name": "SotoDataSync",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DataSync_SotoDataSync"
-      ]
+      "label": "@swiftpkg_soto//:SotoDataSync"
     },
     {
       "identity": "soto",
       "name": "SotoDatabaseMigrationService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DatabaseMigrationService_SotoDatabaseMigrationService"
-      ]
+      "label": "@swiftpkg_soto//:SotoDatabaseMigrationService"
     },
     {
       "identity": "soto",
       "name": "SotoDetective",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Detective_SotoDetective"
-      ]
+      "label": "@swiftpkg_soto//:SotoDetective"
     },
     {
       "identity": "soto",
       "name": "SotoDevOpsGuru",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DevOpsGuru_SotoDevOpsGuru"
-      ]
+      "label": "@swiftpkg_soto//:SotoDevOpsGuru"
     },
     {
       "identity": "soto",
       "name": "SotoDeviceFarm",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DeviceFarm_SotoDeviceFarm"
-      ]
+      "label": "@swiftpkg_soto//:SotoDeviceFarm"
     },
     {
       "identity": "soto",
       "name": "SotoDirectConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DirectConnect_SotoDirectConnect"
-      ]
+      "label": "@swiftpkg_soto//:SotoDirectConnect"
     },
     {
       "identity": "soto",
       "name": "SotoDirectoryService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DirectoryService_SotoDirectoryService"
-      ]
+      "label": "@swiftpkg_soto//:SotoDirectoryService"
     },
     {
       "identity": "soto",
       "name": "SotoDocDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DocDB_SotoDocDB"
-      ]
+      "label": "@swiftpkg_soto//:SotoDocDB"
     },
     {
       "identity": "soto",
       "name": "SotoDocDBElastic",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DocDBElastic_SotoDocDBElastic"
-      ]
+      "label": "@swiftpkg_soto//:SotoDocDBElastic"
     },
     {
       "identity": "soto",
       "name": "SotoDrs",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Drs_SotoDrs"
-      ]
+      "label": "@swiftpkg_soto//:SotoDrs"
     },
     {
       "identity": "soto",
       "name": "SotoDynamoDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_SotoDynamoDB"
-      ]
+      "label": "@swiftpkg_soto//:SotoDynamoDB"
     },
     {
       "identity": "soto",
       "name": "SotoDynamoDBStreams",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_DynamoDBStreams_SotoDynamoDBStreams"
-      ]
+      "label": "@swiftpkg_soto//:SotoDynamoDBStreams"
     },
     {
       "identity": "soto",
       "name": "SotoEBS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EBS_SotoEBS"
-      ]
+      "label": "@swiftpkg_soto//:SotoEBS"
     },
     {
       "identity": "soto",
       "name": "SotoEC2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EC2_SotoEC2"
-      ]
+      "label": "@swiftpkg_soto//:SotoEC2"
     },
     {
       "identity": "soto",
       "name": "SotoEC2InstanceConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EC2InstanceConnect_SotoEC2InstanceConnect"
-      ]
+      "label": "@swiftpkg_soto//:SotoEC2InstanceConnect"
     },
     {
       "identity": "soto",
       "name": "SotoECR",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ECR_SotoECR"
-      ]
+      "label": "@swiftpkg_soto//:SotoECR"
     },
     {
       "identity": "soto",
       "name": "SotoECRPublic",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ECRPublic_SotoECRPublic"
-      ]
+      "label": "@swiftpkg_soto//:SotoECRPublic"
     },
     {
       "identity": "soto",
       "name": "SotoECS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ECS_SotoECS"
-      ]
+      "label": "@swiftpkg_soto//:SotoECS"
     },
     {
       "identity": "soto",
       "name": "SotoEFS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EFS_SotoEFS"
-      ]
+      "label": "@swiftpkg_soto//:SotoEFS"
     },
     {
       "identity": "soto",
       "name": "SotoEKS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EKS_SotoEKS"
-      ]
+      "label": "@swiftpkg_soto//:SotoEKS"
     },
     {
       "identity": "soto",
       "name": "SotoEMR",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EMR_SotoEMR"
-      ]
+      "label": "@swiftpkg_soto//:SotoEMR"
     },
     {
       "identity": "soto",
       "name": "SotoEMRContainers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EMRContainers_SotoEMRContainers"
-      ]
+      "label": "@swiftpkg_soto//:SotoEMRContainers"
     },
     {
       "identity": "soto",
       "name": "SotoEMRServerless",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EMRServerless_SotoEMRServerless"
-      ]
+      "label": "@swiftpkg_soto//:SotoEMRServerless"
     },
     {
       "identity": "soto",
       "name": "SotoElastiCache",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElastiCache_SotoElastiCache"
-      ]
+      "label": "@swiftpkg_soto//:SotoElastiCache"
     },
     {
       "identity": "soto",
       "name": "SotoElasticBeanstalk",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElasticBeanstalk_SotoElasticBeanstalk"
-      ]
+      "label": "@swiftpkg_soto//:SotoElasticBeanstalk"
     },
     {
       "identity": "soto",
       "name": "SotoElasticInference",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElasticInference_SotoElasticInference"
-      ]
+      "label": "@swiftpkg_soto//:SotoElasticInference"
     },
     {
       "identity": "soto",
       "name": "SotoElasticLoadBalancing",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElasticLoadBalancing_SotoElasticLoadBalancing"
-      ]
+      "label": "@swiftpkg_soto//:SotoElasticLoadBalancing"
     },
     {
       "identity": "soto",
       "name": "SotoElasticLoadBalancingV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElasticLoadBalancingV2_SotoElasticLoadBalancingV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoElasticLoadBalancingV2"
     },
     {
       "identity": "soto",
       "name": "SotoElasticTranscoder",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElasticTranscoder_SotoElasticTranscoder"
-      ]
+      "label": "@swiftpkg_soto//:SotoElasticTranscoder"
     },
     {
       "identity": "soto",
       "name": "SotoElasticsearchService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ElasticsearchService_SotoElasticsearchService"
-      ]
+      "label": "@swiftpkg_soto//:SotoElasticsearchService"
     },
     {
       "identity": "soto",
       "name": "SotoEventBridge",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_EventBridge_SotoEventBridge"
-      ]
+      "label": "@swiftpkg_soto//:SotoEventBridge"
     },
     {
       "identity": "soto",
       "name": "SotoEvidently",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Evidently_SotoEvidently"
-      ]
+      "label": "@swiftpkg_soto//:SotoEvidently"
     },
     {
       "identity": "soto",
       "name": "SotoFIS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_FIS_SotoFIS"
-      ]
+      "label": "@swiftpkg_soto//:SotoFIS"
     },
     {
       "identity": "soto",
       "name": "SotoFMS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_FMS_SotoFMS"
-      ]
+      "label": "@swiftpkg_soto//:SotoFMS"
     },
     {
       "identity": "soto",
       "name": "SotoFSx",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_FSx_SotoFSx"
-      ]
+      "label": "@swiftpkg_soto//:SotoFSx"
     },
     {
       "identity": "soto",
       "name": "SotoFinspace",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Finspace_SotoFinspace"
-      ]
+      "label": "@swiftpkg_soto//:SotoFinspace"
     },
     {
       "identity": "soto",
       "name": "SotoFinspaceData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_FinspaceData_SotoFinspaceData"
-      ]
+      "label": "@swiftpkg_soto//:SotoFinspaceData"
     },
     {
       "identity": "soto",
       "name": "SotoFirehose",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Firehose_SotoFirehose"
-      ]
+      "label": "@swiftpkg_soto//:SotoFirehose"
     },
     {
       "identity": "soto",
       "name": "SotoForecast",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Forecast_SotoForecast"
-      ]
+      "label": "@swiftpkg_soto//:SotoForecast"
     },
     {
       "identity": "soto",
       "name": "SotoForecastquery",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Forecastquery_SotoForecastquery"
-      ]
+      "label": "@swiftpkg_soto//:SotoForecastquery"
     },
     {
       "identity": "soto",
       "name": "SotoFraudDetector",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_FraudDetector_SotoFraudDetector"
-      ]
+      "label": "@swiftpkg_soto//:SotoFraudDetector"
     },
     {
       "identity": "soto",
       "name": "SotoGameLift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_GameLift_SotoGameLift"
-      ]
+      "label": "@swiftpkg_soto//:SotoGameLift"
     },
     {
       "identity": "soto",
       "name": "SotoGameSparks",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_GameSparks_SotoGameSparks"
-      ]
+      "label": "@swiftpkg_soto//:SotoGameSparks"
     },
     {
       "identity": "soto",
       "name": "SotoGlacier",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Glacier_SotoGlacier"
-      ]
+      "label": "@swiftpkg_soto//:SotoGlacier"
     },
     {
       "identity": "soto",
       "name": "SotoGlobalAccelerator",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_GlobalAccelerator_SotoGlobalAccelerator"
-      ]
+      "label": "@swiftpkg_soto//:SotoGlobalAccelerator"
     },
     {
       "identity": "soto",
       "name": "SotoGlue",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Glue_SotoGlue"
-      ]
+      "label": "@swiftpkg_soto//:SotoGlue"
     },
     {
       "identity": "soto",
       "name": "SotoGrafana",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Grafana_SotoGrafana"
-      ]
+      "label": "@swiftpkg_soto//:SotoGrafana"
     },
     {
       "identity": "soto",
       "name": "SotoGreengrass",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Greengrass_SotoGreengrass"
-      ]
+      "label": "@swiftpkg_soto//:SotoGreengrass"
     },
     {
       "identity": "soto",
       "name": "SotoGreengrassV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_GreengrassV2_SotoGreengrassV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoGreengrassV2"
     },
     {
       "identity": "soto",
       "name": "SotoGroundStation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_GroundStation_SotoGroundStation"
-      ]
+      "label": "@swiftpkg_soto//:SotoGroundStation"
     },
     {
       "identity": "soto",
       "name": "SotoGuardDuty",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_GuardDuty_SotoGuardDuty"
-      ]
+      "label": "@swiftpkg_soto//:SotoGuardDuty"
     },
     {
       "identity": "soto",
       "name": "SotoHealth",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Health_SotoHealth"
-      ]
+      "label": "@swiftpkg_soto//:SotoHealth"
     },
     {
       "identity": "soto",
       "name": "SotoHealthLake",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_HealthLake_SotoHealthLake"
-      ]
+      "label": "@swiftpkg_soto//:SotoHealthLake"
     },
     {
       "identity": "soto",
       "name": "SotoHoneycode",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Honeycode_SotoHoneycode"
-      ]
+      "label": "@swiftpkg_soto//:SotoHoneycode"
     },
     {
       "identity": "soto",
       "name": "SotoIAM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IAM_SotoIAM"
-      ]
+      "label": "@swiftpkg_soto//:SotoIAM"
     },
     {
       "identity": "soto",
       "name": "SotoIVS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IVS_SotoIVS"
-      ]
+      "label": "@swiftpkg_soto//:SotoIVS"
     },
     {
       "identity": "soto",
       "name": "SotoIVSRealTime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IVSRealTime_SotoIVSRealTime"
-      ]
+      "label": "@swiftpkg_soto//:SotoIVSRealTime"
     },
     {
       "identity": "soto",
       "name": "SotoIdentityStore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IdentityStore_SotoIdentityStore"
-      ]
+      "label": "@swiftpkg_soto//:SotoIdentityStore"
     },
     {
       "identity": "soto",
       "name": "SotoImagebuilder",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Imagebuilder_SotoImagebuilder"
-      ]
+      "label": "@swiftpkg_soto//:SotoImagebuilder"
     },
     {
       "identity": "soto",
       "name": "SotoInspector",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Inspector_SotoInspector"
-      ]
+      "label": "@swiftpkg_soto//:SotoInspector"
     },
     {
       "identity": "soto",
       "name": "SotoInspector2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Inspector2_SotoInspector2"
-      ]
+      "label": "@swiftpkg_soto//:SotoInspector2"
     },
     {
       "identity": "soto",
       "name": "SotoInternetMonitor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_InternetMonitor_SotoInternetMonitor"
-      ]
+      "label": "@swiftpkg_soto//:SotoInternetMonitor"
     },
     {
       "identity": "soto",
       "name": "SotoIoT",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoT_SotoIoT"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoT"
     },
     {
       "identity": "soto",
       "name": "SotoIoT1ClickDevicesService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoT1ClickDevicesService_SotoIoT1ClickDevicesService"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoT1ClickDevicesService"
     },
     {
       "identity": "soto",
       "name": "SotoIoT1ClickProjects",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoT1ClickProjects_SotoIoT1ClickProjects"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoT1ClickProjects"
     },
     {
       "identity": "soto",
       "name": "SotoIoTAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTAnalytics_SotoIoTAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTAnalytics"
     },
     {
       "identity": "soto",
       "name": "SotoIoTDataPlane",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTDataPlane_SotoIoTDataPlane"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTDataPlane"
     },
     {
       "identity": "soto",
       "name": "SotoIoTDeviceAdvisor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTDeviceAdvisor_SotoIoTDeviceAdvisor"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTDeviceAdvisor"
     },
     {
       "identity": "soto",
       "name": "SotoIoTEvents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTEvents_SotoIoTEvents"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTEvents"
     },
     {
       "identity": "soto",
       "name": "SotoIoTEventsData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTEventsData_SotoIoTEventsData"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTEventsData"
     },
     {
       "identity": "soto",
       "name": "SotoIoTFleetHub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTFleetHub_SotoIoTFleetHub"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTFleetHub"
     },
     {
       "identity": "soto",
       "name": "SotoIoTFleetWise",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTFleetWise_SotoIoTFleetWise"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTFleetWise"
     },
     {
       "identity": "soto",
       "name": "SotoIoTJobsDataPlane",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTJobsDataPlane_SotoIoTJobsDataPlane"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTJobsDataPlane"
     },
     {
       "identity": "soto",
       "name": "SotoIoTRoboRunner",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTRoboRunner_SotoIoTRoboRunner"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTRoboRunner"
     },
     {
       "identity": "soto",
       "name": "SotoIoTSecureTunneling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTSecureTunneling_SotoIoTSecureTunneling"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTSecureTunneling"
     },
     {
       "identity": "soto",
       "name": "SotoIoTSiteWise",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTSiteWise_SotoIoTSiteWise"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTSiteWise"
     },
     {
       "identity": "soto",
       "name": "SotoIoTThingsGraph",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTThingsGraph_SotoIoTThingsGraph"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTThingsGraph"
     },
     {
       "identity": "soto",
       "name": "SotoIoTTwinMaker",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTTwinMaker_SotoIoTTwinMaker"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTTwinMaker"
     },
     {
       "identity": "soto",
       "name": "SotoIoTWireless",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_IoTWireless_SotoIoTWireless"
-      ]
+      "label": "@swiftpkg_soto//:SotoIoTWireless"
     },
     {
       "identity": "soto",
       "name": "SotoIvschat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Ivschat_SotoIvschat"
-      ]
+      "label": "@swiftpkg_soto//:SotoIvschat"
     },
     {
       "identity": "soto",
       "name": "SotoKMS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KMS_SotoKMS"
-      ]
+      "label": "@swiftpkg_soto//:SotoKMS"
     },
     {
       "identity": "soto",
       "name": "SotoKafka",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Kafka_SotoKafka"
-      ]
+      "label": "@swiftpkg_soto//:SotoKafka"
     },
     {
       "identity": "soto",
       "name": "SotoKafkaConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KafkaConnect_SotoKafkaConnect"
-      ]
+      "label": "@swiftpkg_soto//:SotoKafkaConnect"
     },
     {
       "identity": "soto",
       "name": "SotoKendra",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Kendra_SotoKendra"
-      ]
+      "label": "@swiftpkg_soto//:SotoKendra"
     },
     {
       "identity": "soto",
       "name": "SotoKendraRanking",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KendraRanking_SotoKendraRanking"
-      ]
+      "label": "@swiftpkg_soto//:SotoKendraRanking"
     },
     {
       "identity": "soto",
       "name": "SotoKeyspaces",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Keyspaces_SotoKeyspaces"
-      ]
+      "label": "@swiftpkg_soto//:SotoKeyspaces"
     },
     {
       "identity": "soto",
       "name": "SotoKinesis",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Kinesis_SotoKinesis"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesis"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisAnalytics_SotoKinesisAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisAnalytics"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisAnalyticsV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisAnalyticsV2_SotoKinesisAnalyticsV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisAnalyticsV2"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisVideo",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideo_SotoKinesisVideo"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisVideo"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisVideoArchivedMedia",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoArchivedMedia_SotoKinesisVideoArchivedMedia"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisVideoArchivedMedia"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisVideoMedia",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoMedia_SotoKinesisVideoMedia"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisVideoMedia"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisVideoSignaling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoSignaling_SotoKinesisVideoSignaling"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisVideoSignaling"
     },
     {
       "identity": "soto",
       "name": "SotoKinesisVideoWebRTCStorage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_KinesisVideoWebRTCStorage_SotoKinesisVideoWebRTCStorage"
-      ]
+      "label": "@swiftpkg_soto//:SotoKinesisVideoWebRTCStorage"
     },
     {
       "identity": "soto",
       "name": "SotoLakeFormation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LakeFormation_SotoLakeFormation"
-      ]
+      "label": "@swiftpkg_soto//:SotoLakeFormation"
     },
     {
       "identity": "soto",
       "name": "SotoLambda",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Lambda_SotoLambda"
-      ]
+      "label": "@swiftpkg_soto//:SotoLambda"
     },
     {
       "identity": "soto",
       "name": "SotoLexModelBuildingService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LexModelBuildingService_SotoLexModelBuildingService"
-      ]
+      "label": "@swiftpkg_soto//:SotoLexModelBuildingService"
     },
     {
       "identity": "soto",
       "name": "SotoLexModelsV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LexModelsV2_SotoLexModelsV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoLexModelsV2"
     },
     {
       "identity": "soto",
       "name": "SotoLexRuntimeService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LexRuntimeService_SotoLexRuntimeService"
-      ]
+      "label": "@swiftpkg_soto//:SotoLexRuntimeService"
     },
     {
       "identity": "soto",
       "name": "SotoLexRuntimeV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LexRuntimeV2_SotoLexRuntimeV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoLexRuntimeV2"
     },
     {
       "identity": "soto",
       "name": "SotoLicenseManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LicenseManager_SotoLicenseManager"
-      ]
+      "label": "@swiftpkg_soto//:SotoLicenseManager"
     },
     {
       "identity": "soto",
       "name": "SotoLicenseManagerLinuxSubscriptions",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LicenseManagerLinuxSubscriptions_SotoLicenseManagerLinuxSubscriptions"
-      ]
+      "label": "@swiftpkg_soto//:SotoLicenseManagerLinuxSubscriptions"
     },
     {
       "identity": "soto",
       "name": "SotoLicenseManagerUserSubscriptions",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LicenseManagerUserSubscriptions_SotoLicenseManagerUserSubscriptions"
-      ]
+      "label": "@swiftpkg_soto//:SotoLicenseManagerUserSubscriptions"
     },
     {
       "identity": "soto",
       "name": "SotoLightsail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Lightsail_SotoLightsail"
-      ]
+      "label": "@swiftpkg_soto//:SotoLightsail"
     },
     {
       "identity": "soto",
       "name": "SotoLocation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Location_SotoLocation"
-      ]
+      "label": "@swiftpkg_soto//:SotoLocation"
     },
     {
       "identity": "soto",
       "name": "SotoLookoutEquipment",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LookoutEquipment_SotoLookoutEquipment"
-      ]
+      "label": "@swiftpkg_soto//:SotoLookoutEquipment"
     },
     {
       "identity": "soto",
       "name": "SotoLookoutMetrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LookoutMetrics_SotoLookoutMetrics"
-      ]
+      "label": "@swiftpkg_soto//:SotoLookoutMetrics"
     },
     {
       "identity": "soto",
       "name": "SotoLookoutVision",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_LookoutVision_SotoLookoutVision"
-      ]
+      "label": "@swiftpkg_soto//:SotoLookoutVision"
     },
     {
       "identity": "soto",
       "name": "SotoM2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_M2_SotoM2"
-      ]
+      "label": "@swiftpkg_soto//:SotoM2"
     },
     {
       "identity": "soto",
       "name": "SotoMQ",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MQ_SotoMQ"
-      ]
+      "label": "@swiftpkg_soto//:SotoMQ"
     },
     {
       "identity": "soto",
       "name": "SotoMTurk",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MTurk_SotoMTurk"
-      ]
+      "label": "@swiftpkg_soto//:SotoMTurk"
     },
     {
       "identity": "soto",
       "name": "SotoMWAA",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MWAA_SotoMWAA"
-      ]
+      "label": "@swiftpkg_soto//:SotoMWAA"
     },
     {
       "identity": "soto",
       "name": "SotoMachineLearning",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MachineLearning_SotoMachineLearning"
-      ]
+      "label": "@swiftpkg_soto//:SotoMachineLearning"
     },
     {
       "identity": "soto",
       "name": "SotoMacie",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Macie_SotoMacie"
-      ]
+      "label": "@swiftpkg_soto//:SotoMacie"
     },
     {
       "identity": "soto",
       "name": "SotoMacie2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Macie2_SotoMacie2"
-      ]
+      "label": "@swiftpkg_soto//:SotoMacie2"
     },
     {
       "identity": "soto",
       "name": "SotoManagedBlockchain",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ManagedBlockchain_SotoManagedBlockchain"
-      ]
+      "label": "@swiftpkg_soto//:SotoManagedBlockchain"
     },
     {
       "identity": "soto",
       "name": "SotoMarketplaceCatalog",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceCatalog_SotoMarketplaceCatalog"
-      ]
+      "label": "@swiftpkg_soto//:SotoMarketplaceCatalog"
     },
     {
       "identity": "soto",
       "name": "SotoMarketplaceCommerceAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceCommerceAnalytics_SotoMarketplaceCommerceAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:SotoMarketplaceCommerceAnalytics"
     },
     {
       "identity": "soto",
       "name": "SotoMarketplaceEntitlementService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceEntitlementService_SotoMarketplaceEntitlementService"
-      ]
+      "label": "@swiftpkg_soto//:SotoMarketplaceEntitlementService"
     },
     {
       "identity": "soto",
       "name": "SotoMarketplaceMetering",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MarketplaceMetering_SotoMarketplaceMetering"
-      ]
+      "label": "@swiftpkg_soto//:SotoMarketplaceMetering"
     },
     {
       "identity": "soto",
       "name": "SotoMediaConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaConnect_SotoMediaConnect"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaConnect"
     },
     {
       "identity": "soto",
       "name": "SotoMediaConvert",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaConvert_SotoMediaConvert"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaConvert"
     },
     {
       "identity": "soto",
       "name": "SotoMediaLive",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaLive_SotoMediaLive"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaLive"
     },
     {
       "identity": "soto",
       "name": "SotoMediaPackage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaPackage_SotoMediaPackage"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaPackage"
     },
     {
       "identity": "soto",
       "name": "SotoMediaPackageV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaPackageV2_SotoMediaPackageV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaPackageV2"
     },
     {
       "identity": "soto",
       "name": "SotoMediaPackageVod",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaPackageVod_SotoMediaPackageVod"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaPackageVod"
     },
     {
       "identity": "soto",
       "name": "SotoMediaStore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaStore_SotoMediaStore"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaStore"
     },
     {
       "identity": "soto",
       "name": "SotoMediaStoreData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaStoreData_SotoMediaStoreData"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaStoreData"
     },
     {
       "identity": "soto",
       "name": "SotoMediaTailor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MediaTailor_SotoMediaTailor"
-      ]
+      "label": "@swiftpkg_soto//:SotoMediaTailor"
     },
     {
       "identity": "soto",
       "name": "SotoMemoryDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MemoryDB_SotoMemoryDB"
-      ]
+      "label": "@swiftpkg_soto//:SotoMemoryDB"
     },
     {
       "identity": "soto",
       "name": "SotoMgn",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Mgn_SotoMgn"
-      ]
+      "label": "@swiftpkg_soto//:SotoMgn"
     },
     {
       "identity": "soto",
       "name": "SotoMigrationHub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MigrationHub_SotoMigrationHub"
-      ]
+      "label": "@swiftpkg_soto//:SotoMigrationHub"
     },
     {
       "identity": "soto",
       "name": "SotoMigrationHubConfig",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubConfig_SotoMigrationHubConfig"
-      ]
+      "label": "@swiftpkg_soto//:SotoMigrationHubConfig"
     },
     {
       "identity": "soto",
       "name": "SotoMigrationHubOrchestrator",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubOrchestrator_SotoMigrationHubOrchestrator"
-      ]
+      "label": "@swiftpkg_soto//:SotoMigrationHubOrchestrator"
     },
     {
       "identity": "soto",
       "name": "SotoMigrationHubRefactorSpaces",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubRefactorSpaces_SotoMigrationHubRefactorSpaces"
-      ]
+      "label": "@swiftpkg_soto//:SotoMigrationHubRefactorSpaces"
     },
     {
       "identity": "soto",
       "name": "SotoMigrationHubStrategy",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_MigrationHubStrategy_SotoMigrationHubStrategy"
-      ]
+      "label": "@swiftpkg_soto//:SotoMigrationHubStrategy"
     },
     {
       "identity": "soto",
       "name": "SotoMobile",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Mobile_SotoMobile"
-      ]
+      "label": "@swiftpkg_soto//:SotoMobile"
     },
     {
       "identity": "soto",
       "name": "SotoNeptune",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Neptune_SotoNeptune"
-      ]
+      "label": "@swiftpkg_soto//:SotoNeptune"
     },
     {
       "identity": "soto",
       "name": "SotoNetworkFirewall",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_NetworkFirewall_SotoNetworkFirewall"
-      ]
+      "label": "@swiftpkg_soto//:SotoNetworkFirewall"
     },
     {
       "identity": "soto",
       "name": "SotoNetworkManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_NetworkManager_SotoNetworkManager"
-      ]
+      "label": "@swiftpkg_soto//:SotoNetworkManager"
     },
     {
       "identity": "soto",
       "name": "SotoNimble",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Nimble_SotoNimble"
-      ]
+      "label": "@swiftpkg_soto//:SotoNimble"
     },
     {
       "identity": "soto",
       "name": "SotoOAM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_OAM_SotoOAM"
-      ]
+      "label": "@swiftpkg_soto//:SotoOAM"
     },
     {
       "identity": "soto",
       "name": "SotoOSIS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_OSIS_SotoOSIS"
-      ]
+      "label": "@swiftpkg_soto//:SotoOSIS"
     },
     {
       "identity": "soto",
       "name": "SotoOmics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Omics_SotoOmics"
-      ]
+      "label": "@swiftpkg_soto//:SotoOmics"
     },
     {
       "identity": "soto",
       "name": "SotoOpenSearch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_OpenSearch_SotoOpenSearch"
-      ]
+      "label": "@swiftpkg_soto//:SotoOpenSearch"
     },
     {
       "identity": "soto",
       "name": "SotoOpenSearchServerless",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_OpenSearchServerless_SotoOpenSearchServerless"
-      ]
+      "label": "@swiftpkg_soto//:SotoOpenSearchServerless"
     },
     {
       "identity": "soto",
       "name": "SotoOpsWorks",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_OpsWorks_SotoOpsWorks"
-      ]
+      "label": "@swiftpkg_soto//:SotoOpsWorks"
     },
     {
       "identity": "soto",
       "name": "SotoOpsWorksCM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_OpsWorksCM_SotoOpsWorksCM"
-      ]
+      "label": "@swiftpkg_soto//:SotoOpsWorksCM"
     },
     {
       "identity": "soto",
       "name": "SotoOrganizations",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Organizations_SotoOrganizations"
-      ]
+      "label": "@swiftpkg_soto//:SotoOrganizations"
     },
     {
       "identity": "soto",
       "name": "SotoOutposts",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Outposts_SotoOutposts"
-      ]
+      "label": "@swiftpkg_soto//:SotoOutposts"
     },
     {
       "identity": "soto",
       "name": "SotoPI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PI_SotoPI"
-      ]
+      "label": "@swiftpkg_soto//:SotoPI"
     },
     {
       "identity": "soto",
       "name": "SotoPanorama",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Panorama_SotoPanorama"
-      ]
+      "label": "@swiftpkg_soto//:SotoPanorama"
     },
     {
       "identity": "soto",
       "name": "SotoPaymentCryptography",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PaymentCryptography_SotoPaymentCryptography"
-      ]
+      "label": "@swiftpkg_soto//:SotoPaymentCryptography"
     },
     {
       "identity": "soto",
       "name": "SotoPaymentCryptographyData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PaymentCryptographyData_SotoPaymentCryptographyData"
-      ]
+      "label": "@swiftpkg_soto//:SotoPaymentCryptographyData"
     },
     {
       "identity": "soto",
       "name": "SotoPersonalize",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Personalize_SotoPersonalize"
-      ]
+      "label": "@swiftpkg_soto//:SotoPersonalize"
     },
     {
       "identity": "soto",
       "name": "SotoPersonalizeEvents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PersonalizeEvents_SotoPersonalizeEvents"
-      ]
+      "label": "@swiftpkg_soto//:SotoPersonalizeEvents"
     },
     {
       "identity": "soto",
       "name": "SotoPersonalizeRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PersonalizeRuntime_SotoPersonalizeRuntime"
-      ]
+      "label": "@swiftpkg_soto//:SotoPersonalizeRuntime"
     },
     {
       "identity": "soto",
       "name": "SotoPinpoint",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Pinpoint_SotoPinpoint"
-      ]
+      "label": "@swiftpkg_soto//:SotoPinpoint"
     },
     {
       "identity": "soto",
       "name": "SotoPinpointEmail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PinpointEmail_SotoPinpointEmail"
-      ]
+      "label": "@swiftpkg_soto//:SotoPinpointEmail"
     },
     {
       "identity": "soto",
       "name": "SotoPinpointSMSVoice",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PinpointSMSVoice_SotoPinpointSMSVoice"
-      ]
+      "label": "@swiftpkg_soto//:SotoPinpointSMSVoice"
     },
     {
       "identity": "soto",
       "name": "SotoPinpointSMSVoiceV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PinpointSMSVoiceV2_SotoPinpointSMSVoiceV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoPinpointSMSVoiceV2"
     },
     {
       "identity": "soto",
       "name": "SotoPipes",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Pipes_SotoPipes"
-      ]
+      "label": "@swiftpkg_soto//:SotoPipes"
     },
     {
       "identity": "soto",
       "name": "SotoPolly",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Polly_SotoPolly"
-      ]
+      "label": "@swiftpkg_soto//:SotoPolly"
     },
     {
       "identity": "soto",
       "name": "SotoPricing",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Pricing_SotoPricing"
-      ]
+      "label": "@swiftpkg_soto//:SotoPricing"
     },
     {
       "identity": "soto",
       "name": "SotoPrivateNetworks",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_PrivateNetworks_SotoPrivateNetworks"
-      ]
+      "label": "@swiftpkg_soto//:SotoPrivateNetworks"
     },
     {
       "identity": "soto",
       "name": "SotoProton",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Proton_SotoProton"
-      ]
+      "label": "@swiftpkg_soto//:SotoProton"
     },
     {
       "identity": "soto",
       "name": "SotoQLDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_QLDB_SotoQLDB"
-      ]
+      "label": "@swiftpkg_soto//:SotoQLDB"
     },
     {
       "identity": "soto",
       "name": "SotoQLDBSession",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_QLDBSession_SotoQLDBSession"
-      ]
+      "label": "@swiftpkg_soto//:SotoQLDBSession"
     },
     {
       "identity": "soto",
       "name": "SotoQuickSight",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_QuickSight_SotoQuickSight"
-      ]
+      "label": "@swiftpkg_soto//:SotoQuickSight"
     },
     {
       "identity": "soto",
       "name": "SotoRAM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RAM_SotoRAM"
-      ]
+      "label": "@swiftpkg_soto//:SotoRAM"
     },
     {
       "identity": "soto",
       "name": "SotoRDS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RDS_SotoRDS"
-      ]
+      "label": "@swiftpkg_soto//:SotoRDS"
     },
     {
       "identity": "soto",
       "name": "SotoRDSData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RDSData_SotoRDSData"
-      ]
+      "label": "@swiftpkg_soto//:SotoRDSData"
     },
     {
       "identity": "soto",
       "name": "SotoRUM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RUM_SotoRUM"
-      ]
+      "label": "@swiftpkg_soto//:SotoRUM"
     },
     {
       "identity": "soto",
       "name": "SotoRbin",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Rbin_SotoRbin"
-      ]
+      "label": "@swiftpkg_soto//:SotoRbin"
     },
     {
       "identity": "soto",
       "name": "SotoRedshift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Redshift_SotoRedshift"
-      ]
+      "label": "@swiftpkg_soto//:SotoRedshift"
     },
     {
       "identity": "soto",
       "name": "SotoRedshiftData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RedshiftData_SotoRedshiftData"
-      ]
+      "label": "@swiftpkg_soto//:SotoRedshiftData"
     },
     {
       "identity": "soto",
       "name": "SotoRedshiftServerless",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RedshiftServerless_SotoRedshiftServerless"
-      ]
+      "label": "@swiftpkg_soto//:SotoRedshiftServerless"
     },
     {
       "identity": "soto",
       "name": "SotoRekognition",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Rekognition_SotoRekognition"
-      ]
+      "label": "@swiftpkg_soto//:SotoRekognition"
     },
     {
       "identity": "soto",
       "name": "SotoResiliencehub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Resiliencehub_SotoResiliencehub"
-      ]
+      "label": "@swiftpkg_soto//:SotoResiliencehub"
     },
     {
       "identity": "soto",
       "name": "SotoResourceExplorer2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ResourceExplorer2_SotoResourceExplorer2"
-      ]
+      "label": "@swiftpkg_soto//:SotoResourceExplorer2"
     },
     {
       "identity": "soto",
       "name": "SotoResourceGroups",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ResourceGroups_SotoResourceGroups"
-      ]
+      "label": "@swiftpkg_soto//:SotoResourceGroups"
     },
     {
       "identity": "soto",
       "name": "SotoResourceGroupsTaggingAPI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ResourceGroupsTaggingAPI_SotoResourceGroupsTaggingAPI"
-      ]
+      "label": "@swiftpkg_soto//:SotoResourceGroupsTaggingAPI"
     },
     {
       "identity": "soto",
       "name": "SotoRoboMaker",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RoboMaker_SotoRoboMaker"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoboMaker"
     },
     {
       "identity": "soto",
       "name": "SotoRolesAnywhere",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_RolesAnywhere_SotoRolesAnywhere"
-      ]
+      "label": "@swiftpkg_soto//:SotoRolesAnywhere"
     },
     {
       "identity": "soto",
       "name": "SotoRoute53",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Route53_SotoRoute53"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoute53"
     },
     {
       "identity": "soto",
       "name": "SotoRoute53Domains",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Route53Domains_SotoRoute53Domains"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoute53Domains"
     },
     {
       "identity": "soto",
       "name": "SotoRoute53RecoveryCluster",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Route53RecoveryCluster_SotoRoute53RecoveryCluster"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoute53RecoveryCluster"
     },
     {
       "identity": "soto",
       "name": "SotoRoute53RecoveryControlConfig",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Route53RecoveryControlConfig_SotoRoute53RecoveryControlConfig"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoute53RecoveryControlConfig"
     },
     {
       "identity": "soto",
       "name": "SotoRoute53RecoveryReadiness",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Route53RecoveryReadiness_SotoRoute53RecoveryReadiness"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoute53RecoveryReadiness"
     },
     {
       "identity": "soto",
       "name": "SotoRoute53Resolver",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Route53Resolver_SotoRoute53Resolver"
-      ]
+      "label": "@swiftpkg_soto//:SotoRoute53Resolver"
     },
     {
       "identity": "soto",
       "name": "SotoS3",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_SotoS3"
-      ]
+      "label": "@swiftpkg_soto//:SotoS3"
     },
     {
       "identity": "soto",
       "name": "SotoS3Control",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_S3Control_SotoS3Control"
-      ]
+      "label": "@swiftpkg_soto//:SotoS3Control"
     },
     {
       "identity": "soto",
       "name": "SotoS3Outposts",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_S3Outposts_SotoS3Outposts"
-      ]
+      "label": "@swiftpkg_soto//:SotoS3Outposts"
     },
     {
       "identity": "soto",
       "name": "SotoSES",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SES_SotoSES"
-      ]
+      "label": "@swiftpkg_soto//:SotoSES"
     },
     {
       "identity": "soto",
       "name": "SotoSESv2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SESv2_SotoSESv2"
-      ]
+      "label": "@swiftpkg_soto//:SotoSESv2"
     },
     {
       "identity": "soto",
       "name": "SotoSFN",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SFN_SotoSFN"
-      ]
+      "label": "@swiftpkg_soto//:SotoSFN"
     },
     {
       "identity": "soto",
       "name": "SotoSMS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SMS_SotoSMS"
-      ]
+      "label": "@swiftpkg_soto//:SotoSMS"
     },
     {
       "identity": "soto",
       "name": "SotoSNS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SNS_SotoSNS"
-      ]
+      "label": "@swiftpkg_soto//:SotoSNS"
     },
     {
       "identity": "soto",
       "name": "SotoSQS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SQS_SotoSQS"
-      ]
+      "label": "@swiftpkg_soto//:SotoSQS"
     },
     {
       "identity": "soto",
       "name": "SotoSSM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SSM_SotoSSM"
-      ]
+      "label": "@swiftpkg_soto//:SotoSSM"
     },
     {
       "identity": "soto",
       "name": "SotoSSMContacts",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SSMContacts_SotoSSMContacts"
-      ]
+      "label": "@swiftpkg_soto//:SotoSSMContacts"
     },
     {
       "identity": "soto",
       "name": "SotoSSMIncidents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SSMIncidents_SotoSSMIncidents"
-      ]
+      "label": "@swiftpkg_soto//:SotoSSMIncidents"
     },
     {
       "identity": "soto",
       "name": "SotoSSO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SSO_SotoSSO"
-      ]
+      "label": "@swiftpkg_soto//:SotoSSO"
     },
     {
       "identity": "soto",
       "name": "SotoSSOAdmin",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SSOAdmin_SotoSSOAdmin"
-      ]
+      "label": "@swiftpkg_soto//:SotoSSOAdmin"
     },
     {
       "identity": "soto",
       "name": "SotoSSOOIDC",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SSOOIDC_SotoSSOOIDC"
-      ]
+      "label": "@swiftpkg_soto//:SotoSSOOIDC"
     },
     {
       "identity": "soto",
       "name": "SotoSTS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_SotoSTS"
-      ]
+      "label": "@swiftpkg_soto//:SotoSTS"
     },
     {
       "identity": "soto",
       "name": "SotoSWF",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SWF_SotoSWF"
-      ]
+      "label": "@swiftpkg_soto//:SotoSWF"
     },
     {
       "identity": "soto",
       "name": "SotoSageMaker",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SageMaker_SotoSageMaker"
-      ]
+      "label": "@swiftpkg_soto//:SotoSageMaker"
     },
     {
       "identity": "soto",
       "name": "SotoSageMakerA2IRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SageMakerA2IRuntime_SotoSageMakerA2IRuntime"
-      ]
+      "label": "@swiftpkg_soto//:SotoSageMakerA2IRuntime"
     },
     {
       "identity": "soto",
       "name": "SotoSageMakerFeatureStoreRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SageMakerFeatureStoreRuntime_SotoSageMakerFeatureStoreRuntime"
-      ]
+      "label": "@swiftpkg_soto//:SotoSageMakerFeatureStoreRuntime"
     },
     {
       "identity": "soto",
       "name": "SotoSageMakerGeospatial",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SageMakerGeospatial_SotoSageMakerGeospatial"
-      ]
+      "label": "@swiftpkg_soto//:SotoSageMakerGeospatial"
     },
     {
       "identity": "soto",
       "name": "SotoSageMakerMetrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SageMakerMetrics_SotoSageMakerMetrics"
-      ]
+      "label": "@swiftpkg_soto//:SotoSageMakerMetrics"
     },
     {
       "identity": "soto",
       "name": "SotoSageMakerRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SageMakerRuntime_SotoSageMakerRuntime"
-      ]
+      "label": "@swiftpkg_soto//:SotoSageMakerRuntime"
     },
     {
       "identity": "soto",
       "name": "SotoSagemakerEdge",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SagemakerEdge_SotoSagemakerEdge"
-      ]
+      "label": "@swiftpkg_soto//:SotoSagemakerEdge"
     },
     {
       "identity": "soto",
       "name": "SotoSavingsPlans",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SavingsPlans_SotoSavingsPlans"
-      ]
+      "label": "@swiftpkg_soto//:SotoSavingsPlans"
     },
     {
       "identity": "soto",
       "name": "SotoScheduler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Scheduler_SotoScheduler"
-      ]
+      "label": "@swiftpkg_soto//:SotoScheduler"
     },
     {
       "identity": "soto",
       "name": "SotoSchemas",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Schemas_SotoSchemas"
-      ]
+      "label": "@swiftpkg_soto//:SotoSchemas"
     },
     {
       "identity": "soto",
       "name": "SotoSecretsManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SecretsManager_SotoSecretsManager"
-      ]
+      "label": "@swiftpkg_soto//:SotoSecretsManager"
     },
     {
       "identity": "soto",
       "name": "SotoSecurityHub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SecurityHub_SotoSecurityHub"
-      ]
+      "label": "@swiftpkg_soto//:SotoSecurityHub"
     },
     {
       "identity": "soto",
       "name": "SotoSecurityLake",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SecurityLake_SotoSecurityLake"
-      ]
+      "label": "@swiftpkg_soto//:SotoSecurityLake"
     },
     {
       "identity": "soto",
       "name": "SotoServerlessApplicationRepository",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ServerlessApplicationRepository_SotoServerlessApplicationRepository"
-      ]
+      "label": "@swiftpkg_soto//:SotoServerlessApplicationRepository"
     },
     {
       "identity": "soto",
       "name": "SotoServiceCatalog",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ServiceCatalog_SotoServiceCatalog"
-      ]
+      "label": "@swiftpkg_soto//:SotoServiceCatalog"
     },
     {
       "identity": "soto",
       "name": "SotoServiceCatalogAppRegistry",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ServiceCatalogAppRegistry_SotoServiceCatalogAppRegistry"
-      ]
+      "label": "@swiftpkg_soto//:SotoServiceCatalogAppRegistry"
     },
     {
       "identity": "soto",
       "name": "SotoServiceDiscovery",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ServiceDiscovery_SotoServiceDiscovery"
-      ]
+      "label": "@swiftpkg_soto//:SotoServiceDiscovery"
     },
     {
       "identity": "soto",
       "name": "SotoServiceQuotas",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_ServiceQuotas_SotoServiceQuotas"
-      ]
+      "label": "@swiftpkg_soto//:SotoServiceQuotas"
     },
     {
       "identity": "soto",
       "name": "SotoShield",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Shield_SotoShield"
-      ]
+      "label": "@swiftpkg_soto//:SotoShield"
     },
     {
       "identity": "soto",
       "name": "SotoSigner",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Signer_SotoSigner"
-      ]
+      "label": "@swiftpkg_soto//:SotoSigner"
     },
     {
       "identity": "soto",
       "name": "SotoSimSpaceWeaver",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SimSpaceWeaver_SotoSimSpaceWeaver"
-      ]
+      "label": "@swiftpkg_soto//:SotoSimSpaceWeaver"
     },
     {
       "identity": "soto",
       "name": "SotoSnowDeviceManagement",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SnowDeviceManagement_SotoSnowDeviceManagement"
-      ]
+      "label": "@swiftpkg_soto//:SotoSnowDeviceManagement"
     },
     {
       "identity": "soto",
       "name": "SotoSnowball",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Snowball_SotoSnowball"
-      ]
+      "label": "@swiftpkg_soto//:SotoSnowball"
     },
     {
       "identity": "soto",
       "name": "SotoSsmSap",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SsmSap_SotoSsmSap"
-      ]
+      "label": "@swiftpkg_soto//:SotoSsmSap"
     },
     {
       "identity": "soto",
       "name": "SotoStorageGateway",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_StorageGateway_SotoStorageGateway"
-      ]
+      "label": "@swiftpkg_soto//:SotoStorageGateway"
     },
     {
       "identity": "soto",
       "name": "SotoSupport",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Support_SotoSupport"
-      ]
+      "label": "@swiftpkg_soto//:SotoSupport"
     },
     {
       "identity": "soto",
       "name": "SotoSupportApp",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_SupportApp_SotoSupportApp"
-      ]
+      "label": "@swiftpkg_soto//:SotoSupportApp"
     },
     {
       "identity": "soto",
       "name": "SotoSynthetics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Synthetics_SotoSynthetics"
-      ]
+      "label": "@swiftpkg_soto//:SotoSynthetics"
     },
     {
       "identity": "soto",
       "name": "SotoTextract",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Textract_SotoTextract"
-      ]
+      "label": "@swiftpkg_soto//:SotoTextract"
     },
     {
       "identity": "soto",
       "name": "SotoTimestreamQuery",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_TimestreamQuery_SotoTimestreamQuery"
-      ]
+      "label": "@swiftpkg_soto//:SotoTimestreamQuery"
     },
     {
       "identity": "soto",
       "name": "SotoTimestreamWrite",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_TimestreamWrite_SotoTimestreamWrite"
-      ]
+      "label": "@swiftpkg_soto//:SotoTimestreamWrite"
     },
     {
       "identity": "soto",
       "name": "SotoTnb",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Tnb_SotoTnb"
-      ]
+      "label": "@swiftpkg_soto//:SotoTnb"
     },
     {
       "identity": "soto",
       "name": "SotoTranscribe",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Transcribe_SotoTranscribe"
-      ]
+      "label": "@swiftpkg_soto//:SotoTranscribe"
     },
     {
       "identity": "soto",
       "name": "SotoTranscribeStreaming",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_TranscribeStreaming_SotoTranscribeStreaming"
-      ]
+      "label": "@swiftpkg_soto//:SotoTranscribeStreaming"
     },
     {
       "identity": "soto",
       "name": "SotoTransfer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Transfer_SotoTransfer"
-      ]
+      "label": "@swiftpkg_soto//:SotoTransfer"
     },
     {
       "identity": "soto",
       "name": "SotoTranslate",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Translate_SotoTranslate"
-      ]
+      "label": "@swiftpkg_soto//:SotoTranslate"
     },
     {
       "identity": "soto",
       "name": "SotoVPCLattice",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_VPCLattice_SotoVPCLattice"
-      ]
+      "label": "@swiftpkg_soto//:SotoVPCLattice"
     },
     {
       "identity": "soto",
       "name": "SotoVerifiedPermissions",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_VerifiedPermissions_SotoVerifiedPermissions"
-      ]
+      "label": "@swiftpkg_soto//:SotoVerifiedPermissions"
     },
     {
       "identity": "soto",
       "name": "SotoVoiceID",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_VoiceID_SotoVoiceID"
-      ]
+      "label": "@swiftpkg_soto//:SotoVoiceID"
     },
     {
       "identity": "soto",
       "name": "SotoWAF",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WAF_SotoWAF"
-      ]
+      "label": "@swiftpkg_soto//:SotoWAF"
     },
     {
       "identity": "soto",
       "name": "SotoWAFRegional",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WAFRegional_SotoWAFRegional"
-      ]
+      "label": "@swiftpkg_soto//:SotoWAFRegional"
     },
     {
       "identity": "soto",
       "name": "SotoWAFV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WAFV2_SotoWAFV2"
-      ]
+      "label": "@swiftpkg_soto//:SotoWAFV2"
     },
     {
       "identity": "soto",
       "name": "SotoWellArchitected",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WellArchitected_SotoWellArchitected"
-      ]
+      "label": "@swiftpkg_soto//:SotoWellArchitected"
     },
     {
       "identity": "soto",
       "name": "SotoWisdom",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_Wisdom_SotoWisdom"
-      ]
+      "label": "@swiftpkg_soto//:SotoWisdom"
     },
     {
       "identity": "soto",
       "name": "SotoWorkDocs",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WorkDocs_SotoWorkDocs"
-      ]
+      "label": "@swiftpkg_soto//:SotoWorkDocs"
     },
     {
       "identity": "soto",
       "name": "SotoWorkLink",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WorkLink_SotoWorkLink"
-      ]
+      "label": "@swiftpkg_soto//:SotoWorkLink"
     },
     {
       "identity": "soto",
       "name": "SotoWorkMail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WorkMail_SotoWorkMail"
-      ]
+      "label": "@swiftpkg_soto//:SotoWorkMail"
     },
     {
       "identity": "soto",
       "name": "SotoWorkMailMessageFlow",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WorkMailMessageFlow_SotoWorkMailMessageFlow"
-      ]
+      "label": "@swiftpkg_soto//:SotoWorkMailMessageFlow"
     },
     {
       "identity": "soto",
       "name": "SotoWorkSpaces",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WorkSpaces_SotoWorkSpaces"
-      ]
+      "label": "@swiftpkg_soto//:SotoWorkSpaces"
     },
     {
       "identity": "soto",
       "name": "SotoWorkSpacesWeb",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_WorkSpacesWeb_SotoWorkSpacesWeb"
-      ]
+      "label": "@swiftpkg_soto//:SotoWorkSpacesWeb"
     },
     {
       "identity": "soto",
       "name": "SotoXRay",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_Soto_Services_XRay_SotoXRay"
-      ]
+      "label": "@swiftpkg_soto//:SotoXRay"
     },
     {
       "identity": "swift-atomics",
       "name": "Atomics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_atomics//:Sources_Atomics"
-      ]
+      "label": "@swiftpkg_swift_atomics//:Atomics"
     },
     {
       "identity": "swift-collections",
       "name": "Collections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_Collections"
-      ]
+      "label": "@swiftpkg_swift_collections//:Collections"
     },
     {
       "identity": "swift-collections",
       "name": "DequeModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_DequeModule"
-      ]
+      "label": "@swiftpkg_swift_collections//:DequeModule"
     },
     {
       "identity": "swift-collections",
       "name": "OrderedCollections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_OrderedCollections"
-      ]
+      "label": "@swiftpkg_swift_collections//:OrderedCollections"
     },
     {
       "identity": "swift-log",
       "name": "Logging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_log//:Sources_Logging"
-      ]
+      "label": "@swiftpkg_swift_log//:Logging"
     },
     {
       "identity": "swift-metrics",
       "name": "CoreMetrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_CoreMetrics"
-      ]
+      "label": "@swiftpkg_swift_metrics//:CoreMetrics"
     },
     {
       "identity": "swift-metrics",
       "name": "Metrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_Metrics"
-      ]
+      "label": "@swiftpkg_swift_metrics//:Metrics"
     },
     {
       "identity": "swift-metrics",
       "name": "MetricsTestKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_MetricsTestKit"
-      ]
+      "label": "@swiftpkg_swift_metrics//:MetricsTestKit"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOExtras"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOExtras"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOHTTPCompression",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOHTTPCompression"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOHTTPCompression"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOSOCKS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOSOCKS"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOSOCKS"
     },
     {
       "identity": "swift-nio-http2",
       "name": "NIOHTTP2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_http2//:Sources_NIOHTTP2"
-      ]
+      "label": "@swiftpkg_swift_nio_http2//:NIOHTTP2"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOSSL",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOSSL"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSL"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOSSLHTTP1Client",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOSSLHTTP1Client"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSLHTTP1Client"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOTLSServer",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOTLSServer"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOTLSServer"
     },
     {
       "identity": "swift-nio-transport-services",
       "name": "NIOTransportServices",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_transport_services//:Sources_NIOTransportServices"
-      ]
+      "label": "@swiftpkg_swift_nio_transport_services//:NIOTransportServices"
     },
     {
       "identity": "swift-nio",
       "name": "NIO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIO"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIO"
     },
     {
       "identity": "swift-nio",
       "name": "NIOConcurrencyHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers"
     },
     {
       "identity": "swift-nio",
       "name": "NIOCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOCore"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOCore"
     },
     {
       "identity": "swift-nio",
       "name": "NIOEmbedded",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOEmbedded"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded"
     },
     {
       "identity": "swift-nio",
       "name": "NIOFoundationCompat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat"
     },
     {
       "identity": "swift-nio",
       "name": "NIOHTTP1",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOHTTP1"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1"
     },
     {
       "identity": "swift-nio",
       "name": "NIOPosix",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOPosix"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOPosix"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTLS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTLS"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTLS"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTestUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTestUtils"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils"
     },
     {
       "identity": "swift-nio",
       "name": "NIOWebSocket",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOWebSocket"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket"
     },
     {
       "identity": "swift-nio",
       "name": "_NIOConcurrency",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources__NIOConcurrency"
-      ]
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency"
     }
   ],
   "packages": [

--- a/examples/stripe_example/PaymentSheet/PaymentSheetExample/BUILD.bazel
+++ b/examples/stripe_example/PaymentSheet/PaymentSheetExample/BUILD.bazel
@@ -27,7 +27,7 @@ swift_library(
     module_name = "PaymentSheetExample",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = ["@swiftpkg_stripe_ios//:StripePaymentSheet_StripePaymentSheet"],
+    deps = ["@swiftpkg_stripe_ios//:StripePaymentSheet"],
 )
 
 ios_application(

--- a/examples/stripe_example/swift_deps_index.json
+++ b/examples/stripe_example/swift_deps_index.json
@@ -4,10 +4,21 @@
   ],
   "modules": [
     {
+      "name": "Stripe",
+      "c99name": "Stripe",
+      "src_type": "swift",
+      "label": "@swiftpkg_stripe_ios//:Stripe.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:Stripe.rspm_modulemap",
+      "package_identity": "stripe-ios",
+      "product_memberships": [
+        "Stripe"
+      ]
+    },
+    {
       "name": "Stripe3DS2",
       "c99name": "Stripe3DS2",
       "src_type": "objc",
-      "label": "@swiftpkg_stripe_ios//:Stripe3DS2_Stripe3DS2",
+      "label": "@swiftpkg_stripe_ios//:Stripe3DS2.rspm",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "Stripe",
@@ -20,8 +31,8 @@
       "name": "StripeApplePay",
       "c99name": "StripeApplePay",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeApplePay_StripeApplePay",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeApplePay_StripeApplePay_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeApplePay.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeApplePay.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "Stripe",
@@ -33,8 +44,8 @@
       "name": "StripeCameraCore",
       "c99name": "StripeCameraCore",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeCameraCore_StripeCameraCore",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeCameraCore_StripeCameraCore_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeCameraCore.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeCameraCore.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "StripeIdentity"
@@ -44,8 +55,8 @@
       "name": "StripeCardScan",
       "c99name": "StripeCardScan",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeCardScan_StripeCardScan",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeCardScan_StripeCardScan_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeCardScan.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeCardScan.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "StripeCardScan"
@@ -55,8 +66,8 @@
       "name": "StripeCore",
       "c99name": "StripeCore",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeCore_StripeCore",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeCore_StripeCore_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeCore.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeCore.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "Stripe",
@@ -73,8 +84,8 @@
       "name": "StripeFinancialConnections",
       "c99name": "StripeFinancialConnections",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeFinancialConnections_StripeFinancialConnections",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeFinancialConnections_StripeFinancialConnections_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeFinancialConnections.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeFinancialConnections.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "StripeFinancialConnections"
@@ -84,8 +95,8 @@
       "name": "StripeIdentity",
       "c99name": "StripeIdentity",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeIdentity_StripeIdentity",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeIdentity_StripeIdentity_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeIdentity.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeIdentity.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "StripeIdentity"
@@ -95,23 +106,10 @@
       "name": "StripePaymentSheet",
       "c99name": "StripePaymentSheet",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripePaymentSheet_StripePaymentSheet",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripePaymentSheet_StripePaymentSheet_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripePaymentSheet.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripePaymentSheet.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
-        "StripePaymentSheet"
-      ]
-    },
-    {
-      "name": "StripePaymentsUI",
-      "c99name": "StripePaymentsUI",
-      "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripePaymentsUI_StripePaymentsUI",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripePaymentsUI_StripePaymentsUI_modulemap",
-      "package_identity": "stripe-ios",
-      "product_memberships": [
-        "Stripe",
-        "StripePaymentsUI",
         "StripePaymentSheet"
       ]
     },
@@ -119,8 +117,8 @@
       "name": "StripePayments",
       "c99name": "StripePayments",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripePayments_StripePayments",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripePayments_StripePayments_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripePayments.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripePayments.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "Stripe",
@@ -130,11 +128,24 @@
       ]
     },
     {
+      "name": "StripePaymentsUI",
+      "c99name": "StripePaymentsUI",
+      "src_type": "swift",
+      "label": "@swiftpkg_stripe_ios//:StripePaymentsUI.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripePaymentsUI.rspm_modulemap",
+      "package_identity": "stripe-ios",
+      "product_memberships": [
+        "Stripe",
+        "StripePaymentsUI",
+        "StripePaymentSheet"
+      ]
+    },
+    {
       "name": "StripeUICore",
       "c99name": "StripeUICore",
       "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:StripeUICore_StripeUICore",
-      "modulemap_label": "@swiftpkg_stripe_ios//:StripeUICore_StripeUICore_modulemap",
+      "label": "@swiftpkg_stripe_ios//:StripeUICore.rspm",
+      "modulemap_label": "@swiftpkg_stripe_ios//:StripeUICore.rspm_modulemap",
       "package_identity": "stripe-ios",
       "product_memberships": [
         "Stripe",
@@ -143,17 +154,6 @@
         "StripeIdentity",
         "StripeFinancialConnections"
       ]
-    },
-    {
-      "name": "Stripe",
-      "c99name": "Stripe",
-      "src_type": "swift",
-      "label": "@swiftpkg_stripe_ios//:Stripe_StripeiOS_Stripe",
-      "modulemap_label": "@swiftpkg_stripe_ios//:Stripe_StripeiOS_Stripe_modulemap",
-      "package_identity": "stripe-ios",
-      "product_memberships": [
-        "Stripe"
-      ]
     }
   ],
   "products": [
@@ -161,65 +161,49 @@
       "identity": "stripe-ios",
       "name": "Stripe",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:Stripe_StripeiOS_Stripe"
-      ]
+      "label": "@swiftpkg_stripe_ios//:Stripe"
     },
     {
       "identity": "stripe-ios",
       "name": "StripeApplePay",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripeApplePay_StripeApplePay"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripeApplePay"
     },
     {
       "identity": "stripe-ios",
       "name": "StripeCardScan",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripeCardScan_StripeCardScan"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripeCardScan"
     },
     {
       "identity": "stripe-ios",
       "name": "StripeFinancialConnections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripeFinancialConnections_StripeFinancialConnections"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripeFinancialConnections"
     },
     {
       "identity": "stripe-ios",
       "name": "StripeIdentity",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripeIdentity_StripeIdentity"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripeIdentity"
     },
     {
       "identity": "stripe-ios",
       "name": "StripePaymentSheet",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripePaymentSheet_StripePaymentSheet"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripePaymentSheet"
     },
     {
       "identity": "stripe-ios",
       "name": "StripePayments",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripePayments_StripePayments"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripePayments"
     },
     {
       "identity": "stripe-ios",
       "name": "StripePaymentsUI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_stripe_ios//:StripePaymentsUI_StripePaymentsUI"
-      ]
+      "label": "@swiftpkg_stripe_ios//:StripePaymentsUI"
     }
   ],
   "packages": [

--- a/examples/tca_example/Package.resolved
+++ b/examples/tca_example/Package.resolved
@@ -82,6 +82,24 @@
       }
     },
     {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "42240120b2a8797595433288ab4118f8042214c3",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    },
+    {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",

--- a/examples/tca_example/Sources/BUILD.bazel
+++ b/examples/tca_example/Sources/BUILD.bazel
@@ -7,7 +7,7 @@ swift_library(
     module_name = "TCAExample",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = ["@swiftpkg_swift_composable_architecture//:Sources_ComposableArchitecture"],
+    deps = ["@swiftpkg_swift_composable_architecture//:ComposableArchitecture"],
 )
 
 ios_application(

--- a/examples/tca_example/Tests/BUILD.bazel
+++ b/examples/tca_example/Tests/BUILD.bazel
@@ -9,7 +9,7 @@ swift_library(
     tags = ["manual"],
     deps = [
         "//Sources:TCAExample",
-        "@swiftpkg_swift_composable_architecture//:Sources_ComposableArchitecture",
+        "@swiftpkg_swift_composable_architecture//:ComposableArchitecture",
     ],
 )
 

--- a/examples/tca_example/swift_deps_index.json
+++ b/examples/tca_example/swift_deps_index.json
@@ -7,8 +7,8 @@
       "name": "CombineSchedulers",
       "c99name": "CombineSchedulers",
       "src_type": "swift",
-      "label": "@swiftpkg_combine_schedulers//:Sources_CombineSchedulers",
-      "modulemap_label": "@swiftpkg_combine_schedulers//:Sources_CombineSchedulers_modulemap",
+      "label": "@swiftpkg_combine_schedulers//:CombineSchedulers.rspm",
+      "modulemap_label": "@swiftpkg_combine_schedulers//:CombineSchedulers.rspm_modulemap",
       "package_identity": "combine-schedulers",
       "product_memberships": [
         "CombineSchedulers"
@@ -18,7 +18,17 @@
       "name": "CasePaths",
       "c99name": "CasePaths",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_case_paths//:Sources_CasePaths",
+      "label": "@swiftpkg_swift_case_paths//:CasePaths.rspm",
+      "package_identity": "swift-case-paths",
+      "product_memberships": [
+        "CasePaths"
+      ]
+    },
+    {
+      "name": "CasePathsMacros",
+      "c99name": "CasePathsMacros",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_case_paths//:CasePathsMacros.rspm",
       "package_identity": "swift-case-paths",
       "product_memberships": [
         "CasePaths"
@@ -28,7 +38,7 @@
       "name": "Clocks",
       "c99name": "Clocks",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_clocks//:Sources_Clocks",
+      "label": "@swiftpkg_swift_clocks//:Clocks.rspm",
       "package_identity": "swift-clocks",
       "product_memberships": [
         "Clocks"
@@ -38,7 +48,7 @@
       "name": "Collections",
       "c99name": "Collections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_Collections",
+      "label": "@swiftpkg_swift_collections//:Collections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections"
@@ -48,7 +58,7 @@
       "name": "DequeModule",
       "c99name": "DequeModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_DequeModule",
+      "label": "@swiftpkg_swift_collections//:DequeModule.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -59,7 +69,7 @@
       "name": "OrderedCollections",
       "c99name": "OrderedCollections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_OrderedCollections",
+      "label": "@swiftpkg_swift_collections//:OrderedCollections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -70,7 +80,17 @@
       "name": "ComposableArchitecture",
       "c99name": "ComposableArchitecture",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_composable_architecture//:Sources_ComposableArchitecture",
+      "label": "@swiftpkg_swift_composable_architecture//:ComposableArchitecture.rspm",
+      "package_identity": "swift-composable-architecture",
+      "product_memberships": [
+        "ComposableArchitecture"
+      ]
+    },
+    {
+      "name": "ComposableArchitectureMacros",
+      "c99name": "ComposableArchitectureMacros",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_composable_architecture//:ComposableArchitectureMacros.rspm",
       "package_identity": "swift-composable-architecture",
       "product_memberships": [
         "ComposableArchitecture"
@@ -80,7 +100,7 @@
       "name": "ConcurrencyExtras",
       "c99name": "ConcurrencyExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_concurrency_extras//:Sources_ConcurrencyExtras",
+      "label": "@swiftpkg_swift_concurrency_extras//:ConcurrencyExtras.rspm",
       "package_identity": "swift-concurrency-extras",
       "product_memberships": [
         "ConcurrencyExtras"
@@ -90,7 +110,7 @@
       "name": "CustomDump",
       "c99name": "CustomDump",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_custom_dump//:Sources_CustomDump",
+      "label": "@swiftpkg_swift_custom_dump//:CustomDump.rspm",
       "package_identity": "swift-custom-dump",
       "product_memberships": [
         "CustomDump"
@@ -100,27 +120,304 @@
       "name": "Dependencies",
       "c99name": "Dependencies",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_dependencies//:Sources_Dependencies",
+      "label": "@swiftpkg_swift_dependencies//:Dependencies.rspm",
       "package_identity": "swift-dependencies",
       "product_memberships": [
         "Dependencies"
       ]
     },
     {
+      "name": "DependenciesMacros",
+      "c99name": "DependenciesMacros",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_dependencies//:DependenciesMacros.rspm",
+      "package_identity": "swift-dependencies",
+      "product_memberships": [
+        "DependenciesMacros"
+      ]
+    },
+    {
+      "name": "DependenciesMacrosPlugin",
+      "c99name": "DependenciesMacrosPlugin",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_dependencies//:DependenciesMacrosPlugin.rspm",
+      "package_identity": "swift-dependencies",
+      "product_memberships": [
+        "DependenciesMacros"
+      ]
+    },
+    {
       "name": "IdentifiedCollections",
       "c99name": "IdentifiedCollections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_identified_collections//:Sources_IdentifiedCollections",
+      "label": "@swiftpkg_swift_identified_collections//:IdentifiedCollections.rspm",
       "package_identity": "swift-identified-collections",
       "product_memberships": [
         "IdentifiedCollections"
       ]
     },
     {
+      "name": "Perception",
+      "c99name": "Perception",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_perception//:Perception.rspm",
+      "package_identity": "swift-perception",
+      "product_memberships": [
+        "Perception"
+      ]
+    },
+    {
+      "name": "PerceptionMacros",
+      "c99name": "PerceptionMacros",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_perception//:PerceptionMacros.rspm",
+      "package_identity": "swift-perception",
+      "product_memberships": [
+        "Perception"
+      ]
+    },
+    {
+      "name": "SwiftBasicFormat",
+      "c99name": "SwiftBasicFormat",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftBasicFormat.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftBasicFormat",
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftParserDiagnostics",
+        "SwiftRefactor",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftCompilerPlugin",
+      "c99name": "SwiftCompilerPlugin",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftCompilerPlugin.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin"
+      ]
+    },
+    {
+      "name": "SwiftCompilerPluginMessageHandling",
+      "c99name": "SwiftCompilerPluginMessageHandling",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftCompilerPluginMessageHandling.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling"
+      ]
+    },
+    {
+      "name": "SwiftDiagnostics",
+      "c99name": "SwiftDiagnostics",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftDiagnostics.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftDiagnostics",
+        "SwiftOperators",
+        "SwiftParserDiagnostics",
+        "SwiftRefactor",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftIDEUtils",
+      "c99name": "SwiftIDEUtils",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftIDEUtils.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftIDEUtils"
+      ]
+    },
+    {
+      "name": "SwiftOperators",
+      "c99name": "SwiftOperators",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftOperators.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftOperators",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftParser",
+      "c99name": "SwiftParser",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftParser.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftOperators",
+        "SwiftParser",
+        "SwiftParserDiagnostics",
+        "SwiftRefactor",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftParserDiagnostics",
+      "c99name": "SwiftParserDiagnostics",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftParserDiagnostics.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftParserDiagnostics",
+        "SwiftRefactor",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftRefactor",
+      "c99name": "SwiftRefactor",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftRefactor.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftRefactor"
+      ]
+    },
+    {
+      "name": "SwiftSyntax",
+      "c99name": "SwiftSyntax",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntax.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftBasicFormat",
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftDiagnostics",
+        "SwiftIDEUtils",
+        "SwiftOperators",
+        "SwiftParser",
+        "SwiftParserDiagnostics",
+        "SwiftRefactor",
+        "SwiftSyntax",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftSyntax509",
+      "c99name": "SwiftSyntax509",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntax509.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftBasicFormat",
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftDiagnostics",
+        "SwiftIDEUtils",
+        "SwiftOperators",
+        "SwiftParser",
+        "SwiftParserDiagnostics",
+        "SwiftRefactor",
+        "SwiftSyntax",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftSyntaxBuilder",
+      "c99name": "SwiftSyntaxBuilder",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxBuilder.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftRefactor",
+        "SwiftSyntaxBuilder",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftSyntaxMacroExpansion",
+      "c99name": "SwiftSyntaxMacroExpansion",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxMacroExpansion.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftSyntaxMacros",
+      "c99name": "SwiftSyntaxMacros",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxMacros.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftCompilerPlugin",
+        "SwiftCompilerPluginMessageHandling",
+        "SwiftSyntaxMacros",
+        "SwiftSyntaxMacroExpansion",
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "SwiftSyntaxMacrosTestSupport",
+      "c99name": "SwiftSyntaxMacrosTestSupport",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxMacrosTestSupport.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
+      "name": "_SwiftSyntaxTestSupport",
+      "c99name": "_SwiftSyntaxTestSupport",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_syntax//:_SwiftSyntaxTestSupport.rspm",
+      "package_identity": "swift-syntax",
+      "product_memberships": [
+        "SwiftSyntaxMacrosTestSupport"
+      ]
+    },
+    {
       "name": "SwiftUINavigation",
       "c99name": "SwiftUINavigation",
       "src_type": "swift",
-      "label": "@swiftpkg_swiftui_navigation//:Sources_SwiftUINavigation",
+      "label": "@swiftpkg_swiftui_navigation//:SwiftUINavigation.rspm",
       "package_identity": "swiftui-navigation",
       "product_memberships": [
         "SwiftUINavigation"
@@ -130,7 +427,7 @@
       "name": "SwiftUINavigationCore",
       "c99name": "SwiftUINavigationCore",
       "src_type": "swift",
-      "label": "@swiftpkg_swiftui_navigation//:Sources_SwiftUINavigationCore",
+      "label": "@swiftpkg_swiftui_navigation//:SwiftUINavigationCore.rspm",
       "package_identity": "swiftui-navigation",
       "product_memberships": [
         "SwiftUINavigation",
@@ -141,7 +438,7 @@
       "name": "XCTestDynamicOverlay",
       "c99name": "XCTestDynamicOverlay",
       "src_type": "swift",
-      "label": "@swiftpkg_xctest_dynamic_overlay//:Sources_XCTestDynamicOverlay",
+      "label": "@swiftpkg_xctest_dynamic_overlay//:XCTestDynamicOverlay.rspm",
       "package_identity": "xctest-dynamic-overlay",
       "product_memberships": [
         "XCTestDynamicOverlay"
@@ -153,113 +450,181 @@
       "identity": "combine-schedulers",
       "name": "CombineSchedulers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_combine_schedulers//:Sources_CombineSchedulers"
-      ]
+      "label": "@swiftpkg_combine_schedulers//:CombineSchedulers"
     },
     {
       "identity": "swift-case-paths",
       "name": "CasePaths",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_case_paths//:Sources_CasePaths"
-      ]
+      "label": "@swiftpkg_swift_case_paths//:CasePaths"
     },
     {
       "identity": "swift-clocks",
       "name": "Clocks",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_clocks//:Sources_Clocks"
-      ]
+      "label": "@swiftpkg_swift_clocks//:Clocks"
     },
     {
       "identity": "swift-collections",
       "name": "Collections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_Collections"
-      ]
+      "label": "@swiftpkg_swift_collections//:Collections"
     },
     {
       "identity": "swift-collections",
       "name": "DequeModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_DequeModule"
-      ]
+      "label": "@swiftpkg_swift_collections//:DequeModule"
     },
     {
       "identity": "swift-collections",
       "name": "OrderedCollections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_OrderedCollections"
-      ]
+      "label": "@swiftpkg_swift_collections//:OrderedCollections"
     },
     {
       "identity": "swift-composable-architecture",
       "name": "ComposableArchitecture",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_composable_architecture//:Sources_ComposableArchitecture"
-      ]
+      "label": "@swiftpkg_swift_composable_architecture//:ComposableArchitecture"
     },
     {
       "identity": "swift-concurrency-extras",
       "name": "ConcurrencyExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_concurrency_extras//:Sources_ConcurrencyExtras"
-      ]
+      "label": "@swiftpkg_swift_concurrency_extras//:ConcurrencyExtras"
     },
     {
       "identity": "swift-custom-dump",
       "name": "CustomDump",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_custom_dump//:Sources_CustomDump"
-      ]
+      "label": "@swiftpkg_swift_custom_dump//:CustomDump"
     },
     {
       "identity": "swift-dependencies",
       "name": "Dependencies",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_dependencies//:Sources_Dependencies"
-      ]
+      "label": "@swiftpkg_swift_dependencies//:Dependencies"
+    },
+    {
+      "identity": "swift-dependencies",
+      "name": "DependenciesMacros",
+      "type": "library",
+      "label": "@swiftpkg_swift_dependencies//:DependenciesMacros"
     },
     {
       "identity": "swift-identified-collections",
       "name": "IdentifiedCollections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_identified_collections//:Sources_IdentifiedCollections"
-      ]
+      "label": "@swiftpkg_swift_identified_collections//:IdentifiedCollections"
+    },
+    {
+      "identity": "swift-perception",
+      "name": "Perception",
+      "type": "library",
+      "label": "@swiftpkg_swift_perception//:Perception"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftBasicFormat",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftBasicFormat"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftCompilerPlugin",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftCompilerPlugin"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftCompilerPluginMessageHandling",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftCompilerPluginMessageHandling"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftDiagnostics",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftDiagnostics"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftIDEUtils",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftIDEUtils"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftOperators",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftOperators"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftParser",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftParser"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftParserDiagnostics",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftParserDiagnostics"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftRefactor",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftRefactor"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftSyntax",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntax"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftSyntaxBuilder",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxBuilder"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftSyntaxMacroExpansion",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxMacroExpansion"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftSyntaxMacros",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxMacros"
+    },
+    {
+      "identity": "swift-syntax",
+      "name": "SwiftSyntaxMacrosTestSupport",
+      "type": "library",
+      "label": "@swiftpkg_swift_syntax//:SwiftSyntaxMacrosTestSupport"
     },
     {
       "identity": "swiftui-navigation",
       "name": "SwiftUINavigation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swiftui_navigation//:Sources_SwiftUINavigation"
-      ]
+      "label": "@swiftpkg_swiftui_navigation//:SwiftUINavigation"
     },
     {
       "identity": "swiftui-navigation",
       "name": "SwiftUINavigationCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swiftui_navigation//:Sources_SwiftUINavigationCore"
-      ]
+      "label": "@swiftpkg_swiftui_navigation//:SwiftUINavigationCore"
     },
     {
       "identity": "xctest-dynamic-overlay",
       "name": "XCTestDynamicOverlay",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_xctest_dynamic_overlay//:Sources_XCTestDynamicOverlay"
-      ]
+      "label": "@swiftpkg_xctest_dynamic_overlay//:XCTestDynamicOverlay"
     }
   ],
   "packages": [
@@ -342,6 +707,24 @@
         "commit": "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
         "remote": "https://github.com/pointfreeco/swift-identified-collections",
         "version": "1.0.0"
+      }
+    },
+    {
+      "name": "swiftpkg_swift_perception",
+      "identity": "swift-perception",
+      "remote": {
+        "commit": "42240120b2a8797595433288ab4118f8042214c3",
+        "remote": "https://github.com/pointfreeco/swift-perception",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "name": "swiftpkg_swift_syntax",
+      "identity": "swift-syntax",
+      "remote": {
+        "commit": "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "remote": "https://github.com/apple/swift-syntax",
+        "version": "509.1.1"
       }
     },
     {

--- a/examples/vapor_example/Sources/App/BUILD.bazel
+++ b/examples/vapor_example/Sources/App/BUILD.bazel
@@ -12,8 +12,8 @@ swift_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
-        "@swiftpkg_fluent//:Sources_Fluent",
-        "@swiftpkg_fluent_sqlite_driver//:Sources_FluentSQLiteDriver",
-        "@swiftpkg_vapor//:Sources_Vapor",
+        "@swiftpkg_fluent//:Fluent",
+        "@swiftpkg_fluent_sqlite_driver//:FluentSQLiteDriver",
+        "@swiftpkg_vapor//:Vapor",
     ],
 )

--- a/examples/vapor_example/Sources/Run/BUILD.bazel
+++ b/examples/vapor_example/Sources/Run/BUILD.bazel
@@ -7,6 +7,6 @@ swift_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//Sources/App",
-        "@swiftpkg_vapor//:Sources_Vapor",
+        "@swiftpkg_vapor//:Vapor",
     ],
 )

--- a/examples/vapor_example/Tests/AppTests/BUILD.bazel
+++ b/examples/vapor_example/Tests/AppTests/BUILD.bazel
@@ -9,6 +9,6 @@ swift_test(
     module_name = "AppTests",
     deps = [
         "//Sources/App",
-        "@swiftpkg_vapor//:Sources_XCTVapor",
+        "@swiftpkg_vapor//:XCTVapor",
     ],
 )

--- a/examples/vapor_example/swift/Package.resolved
+++ b/examples/vapor_example/swift/Package.resolved
@@ -118,15 +118,6 @@
       }
     },
     {
-      "identity" : "swift-backtrace",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-backtrace.git",
-      "state" : {
-        "revision" : "80746bdd0ac8a7d83aad5d89dac3cbf15de652e6",
-        "version" : "1.3.4"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",

--- a/examples/vapor_example/swift/deps.bzl
+++ b/examples/vapor_example/swift/deps.bzl
@@ -105,14 +105,6 @@ def swift_dependencies():
         remote = "https://github.com/apple/swift-atomics.git",
     )
 
-    # version: 1.3.4
-    swift_package(
-        name = "swiftpkg_swift_backtrace",
-        commit = "80746bdd0ac8a7d83aad5d89dac3cbf15de652e6",
-        dependencies_index = "@//swift:deps_index.json",
-        remote = "https://github.com/swift-server/swift-backtrace.git",
-    )
-
     # version: 1.0.4
     swift_package(
         name = "swiftpkg_swift_collections",

--- a/examples/vapor_example/swift/deps_index.json
+++ b/examples/vapor_example/swift/deps_index.json
@@ -9,7 +9,7 @@
       "name": "AsyncHTTPClient",
       "c99name": "AsyncHTTPClient",
       "src_type": "swift",
-      "label": "@swiftpkg_async_http_client//:Sources_AsyncHTTPClient",
+      "label": "@swiftpkg_async_http_client//:AsyncHTTPClient.rspm",
       "package_identity": "async-http-client",
       "product_memberships": [
         "AsyncHTTPClient"
@@ -19,7 +19,7 @@
       "name": "CAsyncHTTPClient",
       "c99name": "CAsyncHTTPClient",
       "src_type": "clang",
-      "label": "@swiftpkg_async_http_client//:Sources_CAsyncHTTPClient",
+      "label": "@swiftpkg_async_http_client//:CAsyncHTTPClient.rspm",
       "package_identity": "async-http-client",
       "product_memberships": [
         "AsyncHTTPClient"
@@ -29,7 +29,7 @@
       "name": "AsyncKit",
       "c99name": "AsyncKit",
       "src_type": "swift",
-      "label": "@swiftpkg_async_kit//:Sources_AsyncKit",
+      "label": "@swiftpkg_async_kit//:AsyncKit.rspm",
       "package_identity": "async-kit",
       "product_memberships": [
         "AsyncKit"
@@ -39,7 +39,7 @@
       "name": "ConsoleKit",
       "c99name": "ConsoleKit",
       "src_type": "swift",
-      "label": "@swiftpkg_console_kit//:Sources_ConsoleKit",
+      "label": "@swiftpkg_console_kit//:ConsoleKit.rspm",
       "package_identity": "console-kit",
       "product_memberships": [
         "ConsoleKit"
@@ -49,7 +49,7 @@
       "name": "ConsoleKitCommands",
       "c99name": "ConsoleKitCommands",
       "src_type": "swift",
-      "label": "@swiftpkg_console_kit//:Sources_ConsoleKitCommands",
+      "label": "@swiftpkg_console_kit//:ConsoleKitCommands.rspm",
       "package_identity": "console-kit",
       "product_memberships": [
         "ConsoleKit",
@@ -60,7 +60,7 @@
       "name": "ConsoleKitTerminal",
       "c99name": "ConsoleKitTerminal",
       "src_type": "swift",
-      "label": "@swiftpkg_console_kit//:Sources_ConsoleKitTerminal",
+      "label": "@swiftpkg_console_kit//:ConsoleKitTerminal.rspm",
       "package_identity": "console-kit",
       "product_memberships": [
         "ConsoleKit",
@@ -72,7 +72,7 @@
       "name": "Fluent",
       "c99name": "Fluent",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent//:Sources_Fluent",
+      "label": "@swiftpkg_fluent//:Fluent.rspm",
       "package_identity": "fluent",
       "product_memberships": [
         "Fluent"
@@ -82,7 +82,7 @@
       "name": "FluentBenchmark",
       "c99name": "FluentBenchmark",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_FluentBenchmark",
+      "label": "@swiftpkg_fluent_kit//:FluentBenchmark.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "FluentBenchmark"
@@ -92,7 +92,7 @@
       "name": "FluentKit",
       "c99name": "FluentKit",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_FluentKit",
+      "label": "@swiftpkg_fluent_kit//:FluentKit.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "FluentKit",
@@ -105,7 +105,7 @@
       "name": "FluentSQL",
       "c99name": "FluentSQL",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_FluentSQL",
+      "label": "@swiftpkg_fluent_kit//:FluentSQL.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "FluentBenchmark",
@@ -116,7 +116,7 @@
       "name": "XCTFluent",
       "c99name": "XCTFluent",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_XCTFluent",
+      "label": "@swiftpkg_fluent_kit//:XCTFluent.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "XCTFluent"
@@ -126,7 +126,7 @@
       "name": "FluentSQLiteDriver",
       "c99name": "FluentSQLiteDriver",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_sqlite_driver//:Sources_FluentSQLiteDriver",
+      "label": "@swiftpkg_fluent_sqlite_driver//:FluentSQLiteDriver.rspm",
       "package_identity": "fluent-sqlite-driver",
       "product_memberships": [
         "FluentSQLiteDriver"
@@ -136,7 +136,7 @@
       "name": "MultipartKit",
       "c99name": "MultipartKit",
       "src_type": "swift",
-      "label": "@swiftpkg_multipart_kit//:Sources_MultipartKit",
+      "label": "@swiftpkg_multipart_kit//:MultipartKit.rspm",
       "package_identity": "multipart-kit",
       "product_memberships": [
         "MultipartKit"
@@ -146,7 +146,7 @@
       "name": "RoutingKit",
       "c99name": "RoutingKit",
       "src_type": "swift",
-      "label": "@swiftpkg_routing_kit//:Sources_RoutingKit",
+      "label": "@swiftpkg_routing_kit//:RoutingKit.rspm",
       "package_identity": "routing-kit",
       "product_memberships": [
         "RoutingKit"
@@ -156,7 +156,7 @@
       "name": "SQLKit",
       "c99name": "SQLKit",
       "src_type": "swift",
-      "label": "@swiftpkg_sql_kit//:Sources_SQLKit",
+      "label": "@swiftpkg_sql_kit//:SQLKit.rspm",
       "package_identity": "sql-kit",
       "product_memberships": [
         "SQLKit",
@@ -167,7 +167,7 @@
       "name": "SQLKitBenchmark",
       "c99name": "SQLKitBenchmark",
       "src_type": "swift",
-      "label": "@swiftpkg_sql_kit//:Sources_SQLKitBenchmark",
+      "label": "@swiftpkg_sql_kit//:SQLKitBenchmark.rspm",
       "package_identity": "sql-kit",
       "product_memberships": [
         "SQLKitBenchmark"
@@ -177,7 +177,7 @@
       "name": "SQLiteKit",
       "c99name": "SQLiteKit",
       "src_type": "swift",
-      "label": "@swiftpkg_sqlite_kit//:Sources_SQLiteKit",
+      "label": "@swiftpkg_sqlite_kit//:SQLiteKit.rspm",
       "package_identity": "sqlite-kit",
       "product_memberships": [
         "SQLiteKit"
@@ -187,7 +187,7 @@
       "name": "CSQLite",
       "c99name": "CSQLite",
       "src_type": "clang",
-      "label": "@swiftpkg_sqlite_nio//:Sources_CSQLite",
+      "label": "@swiftpkg_sqlite_nio//:CSQLite.rspm",
       "package_identity": "sqlite-nio",
       "product_memberships": [
         "SQLiteNIO"
@@ -197,7 +197,7 @@
       "name": "SQLiteNIO",
       "c99name": "SQLiteNIO",
       "src_type": "swift",
-      "label": "@swiftpkg_sqlite_nio//:Sources_SQLiteNIO",
+      "label": "@swiftpkg_sqlite_nio//:SQLiteNIO.rspm",
       "package_identity": "sqlite-nio",
       "product_memberships": [
         "SQLiteNIO"
@@ -207,7 +207,7 @@
       "name": "Algorithms",
       "c99name": "Algorithms",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_algorithms//:Sources_Algorithms",
+      "label": "@swiftpkg_swift_algorithms//:Algorithms.rspm",
       "package_identity": "swift-algorithms",
       "product_memberships": [
         "Algorithms"
@@ -217,7 +217,7 @@
       "name": "Atomics",
       "c99name": "Atomics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_atomics//:Sources_Atomics",
+      "label": "@swiftpkg_swift_atomics//:Atomics.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -227,37 +227,17 @@
       "name": "_AtomicsShims",
       "c99name": "_AtomicsShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_atomics//:Sources__AtomicsShims",
+      "label": "@swiftpkg_swift_atomics//:_AtomicsShims.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
       ]
     },
     {
-      "name": "Backtrace",
-      "c99name": "Backtrace",
-      "src_type": "swift",
-      "label": "@swiftpkg_swift_backtrace//:Sources_Backtrace",
-      "package_identity": "swift-backtrace",
-      "product_memberships": [
-        "Backtrace"
-      ]
-    },
-    {
-      "name": "CBacktrace",
-      "c99name": "CBacktrace",
-      "src_type": "clang",
-      "label": "@swiftpkg_swift_backtrace//:Sources_CBacktrace",
-      "package_identity": "swift-backtrace",
-      "product_memberships": [
-        "Backtrace"
-      ]
-    },
-    {
       "name": "Collections",
       "c99name": "Collections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_Collections",
+      "label": "@swiftpkg_swift_collections//:Collections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections"
@@ -267,7 +247,7 @@
       "name": "DequeModule",
       "c99name": "DequeModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_DequeModule",
+      "label": "@swiftpkg_swift_collections//:DequeModule.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -278,7 +258,7 @@
       "name": "OrderedCollections",
       "c99name": "OrderedCollections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_OrderedCollections",
+      "label": "@swiftpkg_swift_collections//:OrderedCollections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -289,7 +269,7 @@
       "name": "CCryptoBoringSSL",
       "c99name": "CCryptoBoringSSL",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_crypto//:Sources_CCryptoBoringSSL",
+      "label": "@swiftpkg_swift_crypto//:CCryptoBoringSSL.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -300,7 +280,7 @@
       "name": "CCryptoBoringSSLShims",
       "c99name": "CCryptoBoringSSLShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_crypto//:Sources_CCryptoBoringSSLShims",
+      "label": "@swiftpkg_swift_crypto//:CCryptoBoringSSLShims.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -311,7 +291,7 @@
       "name": "Crypto",
       "c99name": "Crypto",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_crypto//:Sources_Crypto",
+      "label": "@swiftpkg_swift_crypto//:Crypto.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -322,7 +302,7 @@
       "name": "CryptoBoringWrapper",
       "c99name": "CryptoBoringWrapper",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_crypto//:Sources_CryptoBoringWrapper",
+      "label": "@swiftpkg_swift_crypto//:CryptoBoringWrapper.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -333,7 +313,7 @@
       "name": "_CryptoExtras",
       "c99name": "_CryptoExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_crypto//:Sources__CryptoExtras",
+      "label": "@swiftpkg_swift_crypto//:_CryptoExtras.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "_CryptoExtras"
@@ -343,7 +323,7 @@
       "name": "Logging",
       "c99name": "Logging",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_log//:Sources_Logging",
+      "label": "@swiftpkg_swift_log//:Logging.rspm",
       "package_identity": "swift-log",
       "product_memberships": [
         "Logging"
@@ -353,7 +333,7 @@
       "name": "CoreMetrics",
       "c99name": "CoreMetrics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_CoreMetrics",
+      "label": "@swiftpkg_swift_metrics//:CoreMetrics.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "CoreMetrics",
@@ -365,7 +345,7 @@
       "name": "Metrics",
       "c99name": "Metrics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_Metrics",
+      "label": "@swiftpkg_swift_metrics//:Metrics.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "Metrics",
@@ -376,7 +356,7 @@
       "name": "MetricsTestKit",
       "c99name": "MetricsTestKit",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_MetricsTestKit",
+      "label": "@swiftpkg_swift_metrics//:MetricsTestKit.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "MetricsTestKit"
@@ -386,7 +366,7 @@
       "name": "CNIOAtomics",
       "c99name": "CNIOAtomics",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOAtomics",
+      "label": "@swiftpkg_swift_nio//:CNIOAtomics.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -406,7 +386,7 @@
       "name": "CNIODarwin",
       "c99name": "CNIODarwin",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIODarwin",
+      "label": "@swiftpkg_swift_nio//:CNIODarwin.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -425,7 +405,7 @@
       "name": "CNIOLLHTTP",
       "c99name": "CNIOLLHTTP",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLLHTTP",
+      "label": "@swiftpkg_swift_nio//:CNIOLLHTTP.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -437,7 +417,7 @@
       "name": "CNIOLinux",
       "c99name": "CNIOLinux",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLinux",
+      "label": "@swiftpkg_swift_nio//:CNIOLinux.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -456,7 +436,7 @@
       "name": "CNIOSHA1",
       "c99name": "CNIOSHA1",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOSHA1",
+      "label": "@swiftpkg_swift_nio//:CNIOSHA1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -466,7 +446,7 @@
       "name": "CNIOWindows",
       "c99name": "CNIOWindows",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOWindows",
+      "label": "@swiftpkg_swift_nio//:CNIOWindows.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -485,7 +465,7 @@
       "name": "NIO",
       "c99name": "NIO",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIO",
+      "label": "@swiftpkg_swift_nio//:NIO.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -501,7 +481,7 @@
       "name": "NIOConcurrencyHelpers",
       "c99name": "NIOConcurrencyHelpers",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers",
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -521,7 +501,7 @@
       "name": "NIOCore",
       "c99name": "NIOCore",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOCore",
+      "label": "@swiftpkg_swift_nio//:NIOCore.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -540,7 +520,7 @@
       "name": "NIOEmbedded",
       "c99name": "NIOEmbedded",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOEmbedded",
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -557,7 +537,7 @@
       "name": "NIOFoundationCompat",
       "c99name": "NIOFoundationCompat",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat",
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOFoundationCompat"
@@ -567,7 +547,7 @@
       "name": "NIOHTTP1",
       "c99name": "NIOHTTP1",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOHTTP1",
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -579,7 +559,7 @@
       "name": "NIOPosix",
       "c99name": "NIOPosix",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOPosix",
+      "label": "@swiftpkg_swift_nio//:NIOPosix.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -596,7 +576,7 @@
       "name": "NIOTLS",
       "c99name": "NIOTLS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTLS",
+      "label": "@swiftpkg_swift_nio//:NIOTLS.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTLS"
@@ -606,7 +586,7 @@
       "name": "NIOTestUtils",
       "c99name": "NIOTestUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTestUtils",
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTestUtils"
@@ -616,7 +596,7 @@
       "name": "NIOWebSocket",
       "c99name": "NIOWebSocket",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOWebSocket",
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -626,7 +606,7 @@
       "name": "_NIOBase64",
       "c99name": "_NIOBase64",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIOBase64",
+      "label": "@swiftpkg_swift_nio//:_NIOBase64.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -645,7 +625,7 @@
       "name": "_NIOConcurrency",
       "c99name": "_NIOConcurrency",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIOConcurrency",
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "_NIOConcurrency"
@@ -655,7 +635,7 @@
       "name": "_NIODataStructures",
       "c99name": "_NIODataStructures",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIODataStructures",
+      "label": "@swiftpkg_swift_nio//:_NIODataStructures.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -674,7 +654,7 @@
       "name": "CNIOExtrasZlib",
       "c99name": "CNIOExtrasZlib",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_CNIOExtrasZlib",
+      "label": "@swiftpkg_swift_nio_extras//:CNIOExtrasZlib.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOHTTPCompression"
@@ -684,7 +664,7 @@
       "name": "NIOExtras",
       "c99name": "NIOExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOExtras",
+      "label": "@swiftpkg_swift_nio_extras//:NIOExtras.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOExtras"
@@ -694,7 +674,7 @@
       "name": "NIOHTTPCompression",
       "c99name": "NIOHTTPCompression",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOHTTPCompression",
+      "label": "@swiftpkg_swift_nio_extras//:NIOHTTPCompression.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOHTTPCompression"
@@ -704,7 +684,7 @@
       "name": "NIOSOCKS",
       "c99name": "NIOSOCKS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOSOCKS",
+      "label": "@swiftpkg_swift_nio_extras//:NIOSOCKS.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOSOCKS"
@@ -714,7 +694,7 @@
       "name": "NIOHPACK",
       "c99name": "NIOHPACK",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_http2//:Sources_NIOHPACK",
+      "label": "@swiftpkg_swift_nio_http2//:NIOHPACK.rspm",
       "package_identity": "swift-nio-http2",
       "product_memberships": [
         "NIOHTTP2"
@@ -724,7 +704,7 @@
       "name": "NIOHTTP2",
       "c99name": "NIOHTTP2",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_http2//:Sources_NIOHTTP2",
+      "label": "@swiftpkg_swift_nio_http2//:NIOHTTP2.rspm",
       "package_identity": "swift-nio-http2",
       "product_memberships": [
         "NIOHTTP2"
@@ -734,7 +714,7 @@
       "name": "CNIOBoringSSL",
       "c99name": "CNIOBoringSSL",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_CNIOBoringSSL",
+      "label": "@swiftpkg_swift_nio_ssl//:CNIOBoringSSL.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -746,7 +726,7 @@
       "name": "CNIOBoringSSLShims",
       "c99name": "CNIOBoringSSLShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_CNIOBoringSSLShims",
+      "label": "@swiftpkg_swift_nio_ssl//:CNIOBoringSSLShims.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -758,7 +738,7 @@
       "name": "NIOSSL",
       "c99name": "NIOSSL",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOSSL",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSL.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -770,7 +750,7 @@
       "name": "NIOSSLHTTP1Client",
       "c99name": "NIOSSLHTTP1Client",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOSSLHTTP1Client",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSLHTTP1Client.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSLHTTP1Client"
@@ -780,7 +760,7 @@
       "name": "NIOTLSServer",
       "c99name": "NIOTLSServer",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOTLSServer",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOTLSServer.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOTLSServer"
@@ -790,7 +770,7 @@
       "name": "NIOTransportServices",
       "c99name": "NIOTransportServices",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_transport_services//:Sources_NIOTransportServices",
+      "label": "@swiftpkg_swift_nio_transport_services//:NIOTransportServices.rspm",
       "package_identity": "swift-nio-transport-services",
       "product_memberships": [
         "NIOTransportServices"
@@ -800,7 +780,7 @@
       "name": "ComplexModule",
       "c99name": "ComplexModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_numerics//:Sources_ComplexModule",
+      "label": "@swiftpkg_swift_numerics//:ComplexModule.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "ComplexModule",
@@ -811,7 +791,7 @@
       "name": "Numerics",
       "c99name": "Numerics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_numerics//:Sources_Numerics",
+      "label": "@swiftpkg_swift_numerics//:Numerics.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "Numerics"
@@ -821,7 +801,7 @@
       "name": "RealModule",
       "c99name": "RealModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_numerics//:Sources_RealModule",
+      "label": "@swiftpkg_swift_numerics//:RealModule.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "ComplexModule",
@@ -833,7 +813,7 @@
       "name": "_NumericsShims",
       "c99name": "_NumericsShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_numerics//:Sources__NumericsShims",
+      "label": "@swiftpkg_swift_numerics//:_NumericsShims.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "ComplexModule",
@@ -845,7 +825,7 @@
       "name": "CVaporBcrypt",
       "c99name": "CVaporBcrypt",
       "src_type": "clang",
-      "label": "@swiftpkg_vapor//:Sources_CVaporBcrypt",
+      "label": "@swiftpkg_vapor//:CVaporBcrypt.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "Vapor",
@@ -856,7 +836,7 @@
       "name": "Vapor",
       "c99name": "Vapor",
       "src_type": "swift",
-      "label": "@swiftpkg_vapor//:Sources_Vapor",
+      "label": "@swiftpkg_vapor//:Vapor.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "Vapor",
@@ -867,7 +847,7 @@
       "name": "XCTVapor",
       "c99name": "XCTVapor",
       "src_type": "swift",
-      "label": "@swiftpkg_vapor//:Sources_XCTVapor",
+      "label": "@swiftpkg_vapor//:XCTVapor.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "XCTVapor"
@@ -877,7 +857,7 @@
       "name": "WebSocketKit",
       "c99name": "WebSocketKit",
       "src_type": "swift",
-      "label": "@swiftpkg_websocket_kit//:Sources_WebSocketKit",
+      "label": "@swiftpkg_websocket_kit//:WebSocketKit.rspm",
       "package_identity": "websocket-kit",
       "product_memberships": [
         "WebSocketKit"
@@ -889,433 +869,319 @@
       "identity": "async-http-client",
       "name": "AsyncHTTPClient",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_async_http_client//:Sources_AsyncHTTPClient"
-      ]
+      "label": "@swiftpkg_async_http_client//:AsyncHTTPClient"
     },
     {
       "identity": "async-kit",
       "name": "AsyncKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_async_kit//:Sources_AsyncKit"
-      ]
+      "label": "@swiftpkg_async_kit//:AsyncKit"
     },
     {
       "identity": "console-kit",
       "name": "ConsoleKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_console_kit//:Sources_ConsoleKit"
-      ]
+      "label": "@swiftpkg_console_kit//:ConsoleKit"
     },
     {
       "identity": "console-kit",
       "name": "ConsoleKitCommands",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_console_kit//:Sources_ConsoleKitCommands"
-      ]
+      "label": "@swiftpkg_console_kit//:ConsoleKitCommands"
     },
     {
       "identity": "console-kit",
       "name": "ConsoleKitTerminal",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_console_kit//:Sources_ConsoleKitTerminal"
-      ]
+      "label": "@swiftpkg_console_kit//:ConsoleKitTerminal"
     },
     {
       "identity": "fluent-kit",
       "name": "FluentBenchmark",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_FluentBenchmark"
-      ]
+      "label": "@swiftpkg_fluent_kit//:FluentBenchmark"
     },
     {
       "identity": "fluent-kit",
       "name": "FluentKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_FluentKit"
-      ]
+      "label": "@swiftpkg_fluent_kit//:FluentKit"
     },
     {
       "identity": "fluent-kit",
       "name": "FluentSQL",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_FluentSQL"
-      ]
+      "label": "@swiftpkg_fluent_kit//:FluentSQL"
     },
     {
       "identity": "fluent-kit",
       "name": "XCTFluent",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_XCTFluent"
-      ]
+      "label": "@swiftpkg_fluent_kit//:XCTFluent"
     },
     {
       "identity": "fluent-sqlite-driver",
       "name": "FluentSQLiteDriver",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_sqlite_driver//:Sources_FluentSQLiteDriver"
-      ]
+      "label": "@swiftpkg_fluent_sqlite_driver//:FluentSQLiteDriver"
     },
     {
       "identity": "fluent",
       "name": "Fluent",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent//:Sources_Fluent"
-      ]
+      "label": "@swiftpkg_fluent//:Fluent"
     },
     {
       "identity": "multipart-kit",
       "name": "MultipartKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_multipart_kit//:Sources_MultipartKit"
-      ]
+      "label": "@swiftpkg_multipart_kit//:MultipartKit"
     },
     {
       "identity": "routing-kit",
       "name": "RoutingKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_routing_kit//:Sources_RoutingKit"
-      ]
+      "label": "@swiftpkg_routing_kit//:RoutingKit"
     },
     {
       "identity": "sql-kit",
       "name": "SQLKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sql_kit//:Sources_SQLKit"
-      ]
+      "label": "@swiftpkg_sql_kit//:SQLKit"
     },
     {
       "identity": "sql-kit",
       "name": "SQLKitBenchmark",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sql_kit//:Sources_SQLKitBenchmark"
-      ]
+      "label": "@swiftpkg_sql_kit//:SQLKitBenchmark"
     },
     {
       "identity": "sqlite-kit",
       "name": "SQLiteKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sqlite_kit//:Sources_SQLiteKit"
-      ]
+      "label": "@swiftpkg_sqlite_kit//:SQLiteKit"
     },
     {
       "identity": "sqlite-nio",
       "name": "SQLiteNIO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sqlite_nio//:Sources_SQLiteNIO"
-      ]
+      "label": "@swiftpkg_sqlite_nio//:SQLiteNIO"
     },
     {
       "identity": "swift-algorithms",
       "name": "Algorithms",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_algorithms//:Sources_Algorithms"
-      ]
+      "label": "@swiftpkg_swift_algorithms//:Algorithms"
     },
     {
       "identity": "swift-atomics",
       "name": "Atomics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_atomics//:Sources_Atomics"
-      ]
-    },
-    {
-      "identity": "swift-backtrace",
-      "name": "Backtrace",
-      "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_backtrace//:Sources_Backtrace"
-      ]
+      "label": "@swiftpkg_swift_atomics//:Atomics"
     },
     {
       "identity": "swift-collections",
       "name": "Collections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_Collections"
-      ]
+      "label": "@swiftpkg_swift_collections//:Collections"
     },
     {
       "identity": "swift-collections",
       "name": "DequeModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_DequeModule"
-      ]
+      "label": "@swiftpkg_swift_collections//:DequeModule"
     },
     {
       "identity": "swift-collections",
       "name": "OrderedCollections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_OrderedCollections"
-      ]
+      "label": "@swiftpkg_swift_collections//:OrderedCollections"
     },
     {
       "identity": "swift-crypto",
       "name": "Crypto",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_crypto//:Sources_Crypto"
-      ]
+      "label": "@swiftpkg_swift_crypto//:Crypto"
     },
     {
       "identity": "swift-crypto",
       "name": "_CryptoExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_crypto//:Sources__CryptoExtras"
-      ]
+      "label": "@swiftpkg_swift_crypto//:_CryptoExtras"
     },
     {
       "identity": "swift-log",
       "name": "Logging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_log//:Sources_Logging"
-      ]
+      "label": "@swiftpkg_swift_log//:Logging"
     },
     {
       "identity": "swift-metrics",
       "name": "CoreMetrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_CoreMetrics"
-      ]
+      "label": "@swiftpkg_swift_metrics//:CoreMetrics"
     },
     {
       "identity": "swift-metrics",
       "name": "Metrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_Metrics"
-      ]
+      "label": "@swiftpkg_swift_metrics//:Metrics"
     },
     {
       "identity": "swift-metrics",
       "name": "MetricsTestKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_MetricsTestKit"
-      ]
+      "label": "@swiftpkg_swift_metrics//:MetricsTestKit"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOExtras"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOExtras"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOHTTPCompression",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOHTTPCompression"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOHTTPCompression"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOSOCKS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOSOCKS"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOSOCKS"
     },
     {
       "identity": "swift-nio-http2",
       "name": "NIOHTTP2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_http2//:Sources_NIOHTTP2"
-      ]
+      "label": "@swiftpkg_swift_nio_http2//:NIOHTTP2"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOSSL",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOSSL"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSL"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOSSLHTTP1Client",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOSSLHTTP1Client"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSLHTTP1Client"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOTLSServer",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOTLSServer"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOTLSServer"
     },
     {
       "identity": "swift-nio-transport-services",
       "name": "NIOTransportServices",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_transport_services//:Sources_NIOTransportServices"
-      ]
+      "label": "@swiftpkg_swift_nio_transport_services//:NIOTransportServices"
     },
     {
       "identity": "swift-nio",
       "name": "NIO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIO"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIO"
     },
     {
       "identity": "swift-nio",
       "name": "NIOConcurrencyHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers"
     },
     {
       "identity": "swift-nio",
       "name": "NIOCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOCore"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOCore"
     },
     {
       "identity": "swift-nio",
       "name": "NIOEmbedded",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOEmbedded"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded"
     },
     {
       "identity": "swift-nio",
       "name": "NIOFoundationCompat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat"
     },
     {
       "identity": "swift-nio",
       "name": "NIOHTTP1",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOHTTP1"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1"
     },
     {
       "identity": "swift-nio",
       "name": "NIOPosix",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOPosix"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOPosix"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTLS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTLS"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTLS"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTestUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTestUtils"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils"
     },
     {
       "identity": "swift-nio",
       "name": "NIOWebSocket",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOWebSocket"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket"
     },
     {
       "identity": "swift-nio",
       "name": "_NIOConcurrency",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources__NIOConcurrency"
-      ]
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency"
     },
     {
       "identity": "swift-numerics",
       "name": "ComplexModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_numerics//:Sources_ComplexModule"
-      ]
+      "label": "@swiftpkg_swift_numerics//:ComplexModule"
     },
     {
       "identity": "swift-numerics",
       "name": "Numerics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_numerics//:Sources_Numerics"
-      ]
+      "label": "@swiftpkg_swift_numerics//:Numerics"
     },
     {
       "identity": "swift-numerics",
       "name": "RealModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_numerics//:Sources_RealModule"
-      ]
+      "label": "@swiftpkg_swift_numerics//:RealModule"
     },
     {
       "identity": "vapor",
       "name": "Vapor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_vapor//:Sources_Vapor"
-      ]
+      "label": "@swiftpkg_vapor//:Vapor"
     },
     {
       "identity": "vapor",
       "name": "XCTVapor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_vapor//:Sources_XCTVapor"
-      ]
+      "label": "@swiftpkg_vapor//:XCTVapor"
     },
     {
       "identity": "websocket-kit",
       "name": "WebSocketKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_websocket_kit//:Sources_WebSocketKit"
-      ]
+      "label": "@swiftpkg_websocket_kit//:WebSocketKit"
     }
   ],
   "packages": [
@@ -1434,15 +1300,6 @@
         "commit": "6c89474e62719ddcc1e9614989fff2f68208fe10",
         "remote": "https://github.com/apple/swift-atomics.git",
         "version": "1.1.0"
-      }
-    },
-    {
-      "name": "swiftpkg_swift_backtrace",
-      "identity": "swift-backtrace",
-      "remote": {
-        "commit": "80746bdd0ac8a7d83aad5d89dac3cbf15de652e6",
-        "remote": "https://github.com/swift-server/swift-backtrace.git",
-        "version": "1.3.4"
       }
     },
     {

--- a/examples/xcmetrics_example/BUILD.bazel
+++ b/examples/xcmetrics_example/BUILD.bazel
@@ -41,13 +41,7 @@ build_test(
     targets = [
         "@swiftpkg_xcmetrics//:XCMetrics",
         "@swiftpkg_xcmetrics//:XCMetricsBackend",
-    ],
-)
-
-test_suite(
-    name = "xcode_metrics_package_build_tests",
-    tests = [
-        "@swiftpkg_xcmetrics//:XCMetricsClientBuildTest",
-        "@swiftpkg_xcmetrics//:XCMetricsUtilsBuildTest",
+        "@swiftpkg_xcmetrics//:XCMetricsClient",
+        "@swiftpkg_xcmetrics//:XCMetricsUtils",
     ],
 )

--- a/examples/xcmetrics_example/set_up_clean_test
+++ b/examples/xcmetrics_example/set_up_clean_test
@@ -58,14 +58,8 @@ build_test(
     targets = [
         "@swiftpkg_xcmetrics//:XCMetrics",
         "@swiftpkg_xcmetrics//:XCMetricsBackend",
-    ],
-)
-
-test_suite(
-    name = "xcode_metrics_package_build_tests",
-    tests = [
-        "@swiftpkg_xcmetrics//:XCMetricsClientBuildTest",
-        "@swiftpkg_xcmetrics//:XCMetricsUtilsBuildTest",
+        "@swiftpkg_xcmetrics//:XCMetricsClient",
+        "@swiftpkg_xcmetrics//:XCMetricsUtils",
     ],
 )
 EOF

--- a/examples/xcmetrics_example/swift_deps_index.json
+++ b/examples/xcmetrics_example/swift_deps_index.json
@@ -7,7 +7,7 @@
       "name": "AsyncHTTPClient",
       "c99name": "AsyncHTTPClient",
       "src_type": "swift",
-      "label": "@swiftpkg_async_http_client//:Sources_AsyncHTTPClient",
+      "label": "@swiftpkg_async_http_client//:AsyncHTTPClient.rspm",
       "package_identity": "async-http-client",
       "product_memberships": [
         "AsyncHTTPClient"
@@ -17,7 +17,7 @@
       "name": "CAsyncHTTPClient",
       "c99name": "CAsyncHTTPClient",
       "src_type": "clang",
-      "label": "@swiftpkg_async_http_client//:Sources_CAsyncHTTPClient",
+      "label": "@swiftpkg_async_http_client//:CAsyncHTTPClient.rspm",
       "package_identity": "async-http-client",
       "product_memberships": [
         "AsyncHTTPClient"
@@ -27,7 +27,7 @@
       "name": "AsyncKit",
       "c99name": "AsyncKit",
       "src_type": "swift",
-      "label": "@swiftpkg_async_kit//:Sources_AsyncKit",
+      "label": "@swiftpkg_async_kit//:AsyncKit.rspm",
       "package_identity": "async-kit",
       "product_memberships": [
         "AsyncKit"
@@ -37,7 +37,7 @@
       "name": "ConsoleKit",
       "c99name": "ConsoleKit",
       "src_type": "swift",
-      "label": "@swiftpkg_console_kit//:Sources_ConsoleKit",
+      "label": "@swiftpkg_console_kit//:ConsoleKit.rspm",
       "package_identity": "console-kit",
       "product_memberships": [
         "ConsoleKit"
@@ -47,7 +47,7 @@
       "name": "CryptoSwift",
       "c99name": "CryptoSwift",
       "src_type": "swift",
-      "label": "@swiftpkg_cryptoswift//:Sources_CryptoSwift",
+      "label": "@swiftpkg_cryptoswift//:CryptoSwift.rspm",
       "package_identity": "cryptoswift",
       "product_memberships": [
         "CryptoSwift"
@@ -57,7 +57,7 @@
       "name": "Fluent",
       "c99name": "Fluent",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent//:Sources_Fluent",
+      "label": "@swiftpkg_fluent//:Fluent.rspm",
       "package_identity": "fluent",
       "product_memberships": [
         "Fluent"
@@ -67,7 +67,7 @@
       "name": "FluentBenchmark",
       "c99name": "FluentBenchmark",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_FluentBenchmark",
+      "label": "@swiftpkg_fluent_kit//:FluentBenchmark.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "FluentBenchmark"
@@ -77,7 +77,7 @@
       "name": "FluentKit",
       "c99name": "FluentKit",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_FluentKit",
+      "label": "@swiftpkg_fluent_kit//:FluentKit.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "FluentKit",
@@ -90,7 +90,7 @@
       "name": "FluentSQL",
       "c99name": "FluentSQL",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_FluentSQL",
+      "label": "@swiftpkg_fluent_kit//:FluentSQL.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "FluentBenchmark",
@@ -101,7 +101,7 @@
       "name": "XCTFluent",
       "c99name": "XCTFluent",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_kit//:Sources_XCTFluent",
+      "label": "@swiftpkg_fluent_kit//:XCTFluent.rspm",
       "package_identity": "fluent-kit",
       "product_memberships": [
         "XCTFluent"
@@ -111,7 +111,7 @@
       "name": "FluentPostgresDriver",
       "c99name": "FluentPostgresDriver",
       "src_type": "swift",
-      "label": "@swiftpkg_fluent_postgres_driver//:Sources_FluentPostgresDriver",
+      "label": "@swiftpkg_fluent_postgres_driver//:FluentPostgresDriver.rspm",
       "package_identity": "fluent-postgres-driver",
       "product_memberships": [
         "FluentPostgresDriver"
@@ -121,7 +121,7 @@
       "name": "Core",
       "c99name": "Core",
       "src_type": "swift",
-      "label": "@swiftpkg_google_cloud_kit//:Core_Sources_Core",
+      "label": "@swiftpkg_google_cloud_kit//:Core.rspm",
       "package_identity": "google-cloud-kit",
       "product_memberships": [
         "GoogleCloudKit",
@@ -137,7 +137,7 @@
       "name": "Datastore",
       "c99name": "Datastore",
       "src_type": "swift",
-      "label": "@swiftpkg_google_cloud_kit//:Datastore_Sources_Datastore",
+      "label": "@swiftpkg_google_cloud_kit//:Datastore.rspm",
       "package_identity": "google-cloud-kit",
       "product_memberships": [
         "GoogleCloudKit",
@@ -148,7 +148,7 @@
       "name": "PubSub",
       "c99name": "PubSub",
       "src_type": "swift",
-      "label": "@swiftpkg_google_cloud_kit//:PubSub_Sources_PubSub",
+      "label": "@swiftpkg_google_cloud_kit//:PubSub.rspm",
       "package_identity": "google-cloud-kit",
       "product_memberships": [
         "GoogleCloudKit",
@@ -159,7 +159,7 @@
       "name": "SecretManager",
       "c99name": "SecretManager",
       "src_type": "swift",
-      "label": "@swiftpkg_google_cloud_kit//:SecretManager_Sources_SecretManager",
+      "label": "@swiftpkg_google_cloud_kit//:SecretManager.rspm",
       "package_identity": "google-cloud-kit",
       "product_memberships": [
         "GoogleCloudKit",
@@ -170,7 +170,7 @@
       "name": "Storage",
       "c99name": "Storage",
       "src_type": "swift",
-      "label": "@swiftpkg_google_cloud_kit//:Storage_Sources_Storage",
+      "label": "@swiftpkg_google_cloud_kit//:Storage.rspm",
       "package_identity": "google-cloud-kit",
       "product_memberships": [
         "GoogleCloudKit",
@@ -181,7 +181,7 @@
       "name": "Translation",
       "c99name": "Translation",
       "src_type": "swift",
-      "label": "@swiftpkg_google_cloud_kit//:Translation_Sources_Translation",
+      "label": "@swiftpkg_google_cloud_kit//:Translation.rspm",
       "package_identity": "google-cloud-kit",
       "product_memberships": [
         "GoogleCloudTranslation"
@@ -191,7 +191,7 @@
       "name": "GRPC",
       "c99name": "GRPC",
       "src_type": "swift",
-      "label": "@swiftpkg_grpc_swift//:Sources_GRPC",
+      "label": "@swiftpkg_grpc_swift//:GRPC.rspm",
       "package_identity": "grpc-swift",
       "product_memberships": [
         "GRPC"
@@ -201,7 +201,7 @@
       "name": "protoc-gen-grpc-swift",
       "c99name": "protoc_gen_grpc_swift",
       "src_type": "swift",
-      "label": "@swiftpkg_grpc_swift//:Sources_protoc-gen-grpc-swift",
+      "label": "@swiftpkg_grpc_swift//:protoc-gen-grpc-swift.rspm",
       "package_identity": "grpc-swift",
       "product_memberships": [
         "protoc-gen-grpc-swift"
@@ -211,7 +211,7 @@
       "name": "Gzip",
       "c99name": "Gzip",
       "src_type": "swift",
-      "label": "@swiftpkg_gzipswift//:Sources_Gzip",
+      "label": "@swiftpkg_gzipswift//:Gzip.rspm",
       "package_identity": "gzipswift",
       "product_memberships": [
         "Gzip"
@@ -221,7 +221,7 @@
       "name": "system-zlib",
       "c99name": "system_zlib",
       "src_type": "clang",
-      "label": "@swiftpkg_gzipswift//:Sources_system-zlib",
+      "label": "@swiftpkg_gzipswift//:system-zlib.rspm",
       "package_identity": "gzipswift",
       "product_memberships": [
         "Gzip"
@@ -231,7 +231,7 @@
       "name": "HypertextApplicationLanguage",
       "c99name": "HypertextApplicationLanguage",
       "src_type": "swift",
-      "label": "@swiftpkg_hypertextapplicationlanguage//:Sources_HypertextApplicationLanguage",
+      "label": "@swiftpkg_hypertextapplicationlanguage//:HypertextApplicationLanguage.rspm",
       "package_identity": "hypertextapplicationlanguage",
       "product_memberships": [
         "HypertextApplicationLanguage"
@@ -241,7 +241,7 @@
       "name": "CJWTKitBoringSSL",
       "c99name": "CJWTKitBoringSSL",
       "src_type": "clang",
-      "label": "@swiftpkg_jwt_kit//:Sources_CJWTKitBoringSSL",
+      "label": "@swiftpkg_jwt_kit//:CJWTKitBoringSSL.rspm",
       "package_identity": "jwt-kit",
       "product_memberships": [
         "JWTKit"
@@ -251,7 +251,7 @@
       "name": "JWTKit",
       "c99name": "JWTKit",
       "src_type": "swift",
-      "label": "@swiftpkg_jwt_kit//:Sources_JWTKit",
+      "label": "@swiftpkg_jwt_kit//:JWTKit.rspm",
       "package_identity": "jwt-kit",
       "product_memberships": [
         "JWTKit"
@@ -261,7 +261,7 @@
       "name": "MobiusCore",
       "c99name": "MobiusCore",
       "src_type": "swift",
-      "label": "@swiftpkg_mobius.swift//:MobiusCore_Source_MobiusCore",
+      "label": "@swiftpkg_mobius.swift//:MobiusCore.rspm",
       "package_identity": "mobius.swift",
       "product_memberships": [
         "MobiusCore",
@@ -274,7 +274,7 @@
       "name": "MobiusExtras",
       "c99name": "MobiusExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_mobius.swift//:MobiusExtras_Source_MobiusExtras",
+      "label": "@swiftpkg_mobius.swift//:MobiusExtras.rspm",
       "package_identity": "mobius.swift",
       "product_memberships": [
         "MobiusExtras"
@@ -284,7 +284,7 @@
       "name": "MobiusNimble",
       "c99name": "MobiusNimble",
       "src_type": "swift",
-      "label": "@swiftpkg_mobius.swift//:MobiusNimble_Source_MobiusNimble",
+      "label": "@swiftpkg_mobius.swift//:MobiusNimble.rspm",
       "package_identity": "mobius.swift",
       "product_memberships": [
         "MobiusNimble"
@@ -294,7 +294,7 @@
       "name": "MobiusTest",
       "c99name": "MobiusTest",
       "src_type": "swift",
-      "label": "@swiftpkg_mobius.swift//:MobiusTest_Source_MobiusTest",
+      "label": "@swiftpkg_mobius.swift//:MobiusTest.rspm",
       "package_identity": "mobius.swift",
       "product_memberships": [
         "MobiusNimble",
@@ -305,17 +305,18 @@
       "name": "MultipartKit",
       "c99name": "MultipartKit",
       "src_type": "swift",
-      "label": "@swiftpkg_multipart_kit//:Sources_MultipartKit",
+      "label": "@swiftpkg_multipart_kit//:MultipartKit.rspm",
       "package_identity": "multipart-kit",
       "product_memberships": [
         "MultipartKit"
       ]
     },
     {
-      "name": "NimbleCwlCatchExceptionSupport",
-      "c99name": "NimbleCwlCatchExceptionSupport",
-      "src_type": "objc",
-      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Dependencies_CwlCatchException_Sources_CwlCatchExceptionSupport_NimbleCwlCatchExceptionSupport",
+      "name": "Nimble",
+      "c99name": "Nimble",
+      "src_type": "swift",
+      "label": "@swiftpkg_nimble//:Nimble.rspm",
+      "modulemap_label": "@swiftpkg_nimble//:Nimble.rspm_modulemap",
       "package_identity": "nimble",
       "product_memberships": [
         "Nimble"
@@ -325,7 +326,17 @@
       "name": "NimbleCwlCatchException",
       "c99name": "NimbleCwlCatchException",
       "src_type": "swift",
-      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Dependencies_CwlCatchException_Sources_CwlCatchException_NimbleCwlCatchException",
+      "label": "@swiftpkg_nimble//:NimbleCwlCatchException.rspm",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
+      "name": "NimbleCwlCatchExceptionSupport",
+      "c99name": "NimbleCwlCatchExceptionSupport",
+      "src_type": "objc",
+      "label": "@swiftpkg_nimble//:NimbleCwlCatchExceptionSupport.rspm",
       "package_identity": "nimble",
       "product_memberships": [
         "Nimble"
@@ -335,7 +346,7 @@
       "name": "NimbleCwlMachBadInstructionHandler",
       "c99name": "NimbleCwlMachBadInstructionHandler",
       "src_type": "objc",
-      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Sources_CwlMachBadInstructionHandler_NimbleCwlMachBadInstructionHandler",
+      "label": "@swiftpkg_nimble//:NimbleCwlMachBadInstructionHandler.rspm",
       "package_identity": "nimble",
       "product_memberships": [
         "Nimble"
@@ -345,19 +356,8 @@
       "name": "NimbleCwlPreconditionTesting",
       "c99name": "NimbleCwlPreconditionTesting",
       "src_type": "swift",
-      "label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Sources_CwlPreconditionTesting_NimbleCwlPreconditionTesting",
-      "modulemap_label": "@swiftpkg_nimble//:Carthage_Checkouts_CwlPreconditionTesting_Sources_CwlPreconditionTesting_NimbleCwlPreconditionTesting_modulemap",
-      "package_identity": "nimble",
-      "product_memberships": [
-        "Nimble"
-      ]
-    },
-    {
-      "name": "Nimble",
-      "c99name": "Nimble",
-      "src_type": "swift",
-      "label": "@swiftpkg_nimble//:Sources_Nimble",
-      "modulemap_label": "@swiftpkg_nimble//:Sources_Nimble_modulemap",
+      "label": "@swiftpkg_nimble//:NimbleCwlPreconditionTesting.rspm",
+      "modulemap_label": "@swiftpkg_nimble//:NimbleCwlPreconditionTesting.rspm_modulemap",
       "package_identity": "nimble",
       "product_memberships": [
         "Nimble"
@@ -367,7 +367,7 @@
       "name": "PathKit",
       "c99name": "PathKit",
       "src_type": "swift",
-      "label": "@swiftpkg_pathkit//:Sources_PathKit",
+      "label": "@swiftpkg_pathkit//:PathKit.rspm",
       "package_identity": "pathkit",
       "product_memberships": [
         "PathKit"
@@ -377,7 +377,7 @@
       "name": "INIParser",
       "c99name": "INIParser",
       "src_type": "swift",
-      "label": "@swiftpkg_perfect_iniparser//:Sources_INIParser",
+      "label": "@swiftpkg_perfect_iniparser//:INIParser.rspm",
       "package_identity": "perfect-iniparser",
       "product_memberships": [
         "INIParser"
@@ -387,7 +387,7 @@
       "name": "PostgresKit",
       "c99name": "PostgresKit",
       "src_type": "swift",
-      "label": "@swiftpkg_postgres_kit//:Sources_PostgresKit",
+      "label": "@swiftpkg_postgres_kit//:PostgresKit.rspm",
       "package_identity": "postgres-kit",
       "product_memberships": [
         "PostgresKit"
@@ -397,7 +397,7 @@
       "name": "PostgresNIO",
       "c99name": "PostgresNIO",
       "src_type": "swift",
-      "label": "@swiftpkg_postgres_nio//:Sources_PostgresNIO",
+      "label": "@swiftpkg_postgres_nio//:PostgresNIO.rspm",
       "package_identity": "postgres-nio",
       "product_memberships": [
         "PostgresNIO"
@@ -407,7 +407,7 @@
       "name": "Queues",
       "c99name": "Queues",
       "src_type": "swift",
-      "label": "@swiftpkg_queues//:Sources_Queues",
+      "label": "@swiftpkg_queues//:Queues.rspm",
       "package_identity": "queues",
       "product_memberships": [
         "Queues",
@@ -418,7 +418,7 @@
       "name": "XCTQueues",
       "c99name": "XCTQueues",
       "src_type": "swift",
-      "label": "@swiftpkg_queues//:Sources_XCTQueues",
+      "label": "@swiftpkg_queues//:XCTQueues.rspm",
       "package_identity": "queues",
       "product_memberships": [
         "XCTQueues"
@@ -428,7 +428,7 @@
       "name": "QueuesRedisDriver",
       "c99name": "QueuesRedisDriver",
       "src_type": "swift",
-      "label": "@swiftpkg_queues_redis_driver//:Sources_QueuesRedisDriver",
+      "label": "@swiftpkg_queues_redis_driver//:QueuesRedisDriver.rspm",
       "package_identity": "queues-redis-driver",
       "product_memberships": [
         "QueuesRedisDriver"
@@ -438,8 +438,8 @@
       "name": "Quick",
       "c99name": "Quick",
       "src_type": "swift",
-      "label": "@swiftpkg_quick//:Sources_Quick",
-      "modulemap_label": "@swiftpkg_quick//:Sources_Quick_modulemap",
+      "label": "@swiftpkg_quick//:Quick.rspm",
+      "modulemap_label": "@swiftpkg_quick//:Quick.rspm_modulemap",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -449,7 +449,7 @@
       "name": "QuickObjCRuntime",
       "c99name": "QuickObjCRuntime",
       "src_type": "objc",
-      "label": "@swiftpkg_quick//:Sources_QuickObjCRuntime",
+      "label": "@swiftpkg_quick//:QuickObjCRuntime.rspm",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -459,7 +459,7 @@
       "name": "Redis",
       "c99name": "Redis",
       "src_type": "swift",
-      "label": "@swiftpkg_redis//:Sources_Redis",
+      "label": "@swiftpkg_redis//:Redis.rspm",
       "package_identity": "redis",
       "product_memberships": [
         "Redis"
@@ -469,7 +469,7 @@
       "name": "RediStack",
       "c99name": "RediStack",
       "src_type": "swift",
-      "label": "@swiftpkg_redistack//:Sources_RediStack",
+      "label": "@swiftpkg_redistack//:RediStack.rspm",
       "package_identity": "redistack",
       "product_memberships": [
         "RediStack",
@@ -481,7 +481,7 @@
       "name": "RediStackTestUtils",
       "c99name": "RediStackTestUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_redistack//:Sources_RediStackTestUtils",
+      "label": "@swiftpkg_redistack//:RediStackTestUtils.rspm",
       "package_identity": "redistack",
       "product_memberships": [
         "RediStackTestUtils"
@@ -491,7 +491,7 @@
       "name": "RedisTypes",
       "c99name": "RedisTypes",
       "src_type": "swift",
-      "label": "@swiftpkg_redistack//:Sources_RedisTypes",
+      "label": "@swiftpkg_redistack//:RedisTypes.rspm",
       "package_identity": "redistack",
       "product_memberships": [
         "RedisTypes"
@@ -501,61 +501,17 @@
       "name": "RoutingKit",
       "c99name": "RoutingKit",
       "src_type": "swift",
-      "label": "@swiftpkg_routing_kit//:Sources_RoutingKit",
+      "label": "@swiftpkg_routing_kit//:RoutingKit.rspm",
       "package_identity": "routing-kit",
       "product_memberships": [
         "RoutingKit"
       ]
     },
     {
-      "name": "APIGatewayMiddleware",
-      "c99name": "APIGatewayMiddleware",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_APIGateway_APIGatewayMiddleware",
-      "package_identity": "soto",
-      "product_memberships": [
-        "AWSSDKSwift",
-        "APIGateway"
-      ]
-    },
-    {
-      "name": "GlacierMiddleware",
-      "c99name": "GlacierMiddleware",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_Glacier_GlacierMiddleware",
-      "package_identity": "soto",
-      "product_memberships": [
-        "AWSSDKSwift",
-        "Glacier"
-      ]
-    },
-    {
-      "name": "S3ControlMiddleware",
-      "c99name": "S3ControlMiddleware",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_S3Control_S3ControlMiddleware",
-      "package_identity": "soto",
-      "product_memberships": [
-        "AWSSDKSwift",
-        "S3Control"
-      ]
-    },
-    {
-      "name": "S3Middleware",
-      "c99name": "S3Middleware",
-      "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_S3_S3Middleware",
-      "package_identity": "soto",
-      "product_memberships": [
-        "AWSSDKSwift",
-        "S3"
-      ]
-    },
-    {
       "name": "ACM",
       "c99name": "ACM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ACM",
+      "label": "@swiftpkg_soto//:ACM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -566,7 +522,7 @@
       "name": "ACMPCA",
       "c99name": "ACMPCA",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ACMPCA",
+      "label": "@swiftpkg_soto//:ACMPCA.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -577,7 +533,18 @@
       "name": "APIGateway",
       "c99name": "APIGateway",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_APIGateway",
+      "label": "@swiftpkg_soto//:APIGateway.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "AWSSDKSwift",
+        "APIGateway"
+      ]
+    },
+    {
+      "name": "APIGatewayMiddleware",
+      "c99name": "APIGatewayMiddleware",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:APIGatewayMiddleware.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -588,7 +555,7 @@
       "name": "AWSBackup",
       "c99name": "AWSBackup",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AWSBackup",
+      "label": "@swiftpkg_soto//:AWSBackup.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -599,7 +566,7 @@
       "name": "AWSDirectoryService",
       "c99name": "AWSDirectoryService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AWSDirectoryService",
+      "label": "@swiftpkg_soto//:AWSDirectoryService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -610,7 +577,7 @@
       "name": "AccessAnalyzer",
       "c99name": "AccessAnalyzer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AccessAnalyzer",
+      "label": "@swiftpkg_soto//:AccessAnalyzer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -621,7 +588,7 @@
       "name": "AlexaForBusiness",
       "c99name": "AlexaForBusiness",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AlexaForBusiness",
+      "label": "@swiftpkg_soto//:AlexaForBusiness.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -632,7 +599,7 @@
       "name": "Amplify",
       "c99name": "Amplify",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Amplify",
+      "label": "@swiftpkg_soto//:Amplify.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -643,7 +610,7 @@
       "name": "ApiGatewayManagementApi",
       "c99name": "ApiGatewayManagementApi",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApiGatewayManagementApi",
+      "label": "@swiftpkg_soto//:ApiGatewayManagementApi.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -654,7 +621,7 @@
       "name": "ApiGatewayV2",
       "c99name": "ApiGatewayV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApiGatewayV2",
+      "label": "@swiftpkg_soto//:ApiGatewayV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -665,7 +632,7 @@
       "name": "AppConfig",
       "c99name": "AppConfig",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppConfig",
+      "label": "@swiftpkg_soto//:AppConfig.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -676,7 +643,7 @@
       "name": "AppMesh",
       "c99name": "AppMesh",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppMesh",
+      "label": "@swiftpkg_soto//:AppMesh.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -687,7 +654,7 @@
       "name": "AppStream",
       "c99name": "AppStream",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppStream",
+      "label": "@swiftpkg_soto//:AppStream.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -698,7 +665,7 @@
       "name": "AppSync",
       "c99name": "AppSync",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppSync",
+      "label": "@swiftpkg_soto//:AppSync.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -709,7 +676,7 @@
       "name": "Appflow",
       "c99name": "Appflow",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Appflow",
+      "label": "@swiftpkg_soto//:Appflow.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -720,7 +687,7 @@
       "name": "ApplicationAutoScaling",
       "c99name": "ApplicationAutoScaling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationAutoScaling",
+      "label": "@swiftpkg_soto//:ApplicationAutoScaling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -731,7 +698,7 @@
       "name": "ApplicationDiscoveryService",
       "c99name": "ApplicationDiscoveryService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationDiscoveryService",
+      "label": "@swiftpkg_soto//:ApplicationDiscoveryService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -742,7 +709,7 @@
       "name": "ApplicationInsights",
       "c99name": "ApplicationInsights",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationInsights",
+      "label": "@swiftpkg_soto//:ApplicationInsights.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -753,7 +720,7 @@
       "name": "Athena",
       "c99name": "Athena",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Athena",
+      "label": "@swiftpkg_soto//:Athena.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -764,7 +731,7 @@
       "name": "AugmentedAIRuntime",
       "c99name": "AugmentedAIRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AugmentedAIRuntime",
+      "label": "@swiftpkg_soto//:AugmentedAIRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -775,7 +742,7 @@
       "name": "AutoScaling",
       "c99name": "AutoScaling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AutoScaling",
+      "label": "@swiftpkg_soto//:AutoScaling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -786,7 +753,7 @@
       "name": "AutoScalingPlans",
       "c99name": "AutoScalingPlans",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AutoScalingPlans",
+      "label": "@swiftpkg_soto//:AutoScalingPlans.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -797,7 +764,7 @@
       "name": "Batch",
       "c99name": "Batch",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Batch",
+      "label": "@swiftpkg_soto//:Batch.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -808,7 +775,7 @@
       "name": "Braket",
       "c99name": "Braket",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Braket",
+      "label": "@swiftpkg_soto//:Braket.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -819,7 +786,7 @@
       "name": "Budgets",
       "c99name": "Budgets",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Budgets",
+      "label": "@swiftpkg_soto//:Budgets.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -830,7 +797,7 @@
       "name": "Chime",
       "c99name": "Chime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Chime",
+      "label": "@swiftpkg_soto//:Chime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -841,7 +808,7 @@
       "name": "Cloud9",
       "c99name": "Cloud9",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Cloud9",
+      "label": "@swiftpkg_soto//:Cloud9.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -852,7 +819,7 @@
       "name": "CloudDirectory",
       "c99name": "CloudDirectory",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudDirectory",
+      "label": "@swiftpkg_soto//:CloudDirectory.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -863,7 +830,7 @@
       "name": "CloudFormation",
       "c99name": "CloudFormation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudFormation",
+      "label": "@swiftpkg_soto//:CloudFormation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -874,7 +841,7 @@
       "name": "CloudFront",
       "c99name": "CloudFront",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudFront",
+      "label": "@swiftpkg_soto//:CloudFront.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -885,7 +852,7 @@
       "name": "CloudHSM",
       "c99name": "CloudHSM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudHSM",
+      "label": "@swiftpkg_soto//:CloudHSM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -896,7 +863,7 @@
       "name": "CloudHSMV2",
       "c99name": "CloudHSMV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudHSMV2",
+      "label": "@swiftpkg_soto//:CloudHSMV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -907,7 +874,7 @@
       "name": "CloudSearch",
       "c99name": "CloudSearch",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudSearch",
+      "label": "@swiftpkg_soto//:CloudSearch.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -918,7 +885,7 @@
       "name": "CloudSearchDomain",
       "c99name": "CloudSearchDomain",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudSearchDomain",
+      "label": "@swiftpkg_soto//:CloudSearchDomain.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -929,7 +896,7 @@
       "name": "CloudTrail",
       "c99name": "CloudTrail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudTrail",
+      "label": "@swiftpkg_soto//:CloudTrail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -940,7 +907,7 @@
       "name": "CloudWatch",
       "c99name": "CloudWatch",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatch",
+      "label": "@swiftpkg_soto//:CloudWatch.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -951,7 +918,7 @@
       "name": "CloudWatchEvents",
       "c99name": "CloudWatchEvents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatchEvents",
+      "label": "@swiftpkg_soto//:CloudWatchEvents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -962,7 +929,7 @@
       "name": "CloudWatchLogs",
       "c99name": "CloudWatchLogs",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatchLogs",
+      "label": "@swiftpkg_soto//:CloudWatchLogs.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -973,7 +940,7 @@
       "name": "CodeArtifact",
       "c99name": "CodeArtifact",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeArtifact",
+      "label": "@swiftpkg_soto//:CodeArtifact.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -984,7 +951,7 @@
       "name": "CodeBuild",
       "c99name": "CodeBuild",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeBuild",
+      "label": "@swiftpkg_soto//:CodeBuild.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -995,7 +962,7 @@
       "name": "CodeCommit",
       "c99name": "CodeCommit",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeCommit",
+      "label": "@swiftpkg_soto//:CodeCommit.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1006,7 +973,7 @@
       "name": "CodeDeploy",
       "c99name": "CodeDeploy",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeDeploy",
+      "label": "@swiftpkg_soto//:CodeDeploy.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1017,7 +984,7 @@
       "name": "CodeGuruProfiler",
       "c99name": "CodeGuruProfiler",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeGuruProfiler",
+      "label": "@swiftpkg_soto//:CodeGuruProfiler.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1028,7 +995,7 @@
       "name": "CodeGuruReviewer",
       "c99name": "CodeGuruReviewer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeGuruReviewer",
+      "label": "@swiftpkg_soto//:CodeGuruReviewer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1039,7 +1006,7 @@
       "name": "CodePipeline",
       "c99name": "CodePipeline",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodePipeline",
+      "label": "@swiftpkg_soto//:CodePipeline.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1050,7 +1017,7 @@
       "name": "CodeStar",
       "c99name": "CodeStar",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStar",
+      "label": "@swiftpkg_soto//:CodeStar.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1061,7 +1028,7 @@
       "name": "CodeStarNotifications",
       "c99name": "CodeStarNotifications",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStarNotifications",
+      "label": "@swiftpkg_soto//:CodeStarNotifications.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1072,7 +1039,7 @@
       "name": "CodeStarconnections",
       "c99name": "CodeStarconnections",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStarconnections",
+      "label": "@swiftpkg_soto//:CodeStarconnections.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1083,7 +1050,7 @@
       "name": "CognitoIdentity",
       "c99name": "CognitoIdentity",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoIdentity",
+      "label": "@swiftpkg_soto//:CognitoIdentity.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1094,7 +1061,7 @@
       "name": "CognitoIdentityProvider",
       "c99name": "CognitoIdentityProvider",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoIdentityProvider",
+      "label": "@swiftpkg_soto//:CognitoIdentityProvider.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1105,7 +1072,7 @@
       "name": "CognitoSync",
       "c99name": "CognitoSync",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoSync",
+      "label": "@swiftpkg_soto//:CognitoSync.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1116,7 +1083,7 @@
       "name": "Comprehend",
       "c99name": "Comprehend",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Comprehend",
+      "label": "@swiftpkg_soto//:Comprehend.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1127,7 +1094,7 @@
       "name": "ComprehendMedical",
       "c99name": "ComprehendMedical",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ComprehendMedical",
+      "label": "@swiftpkg_soto//:ComprehendMedical.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1138,7 +1105,7 @@
       "name": "ComputeOptimizer",
       "c99name": "ComputeOptimizer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ComputeOptimizer",
+      "label": "@swiftpkg_soto//:ComputeOptimizer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1149,7 +1116,7 @@
       "name": "ConfigService",
       "c99name": "ConfigService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ConfigService",
+      "label": "@swiftpkg_soto//:ConfigService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1160,7 +1127,7 @@
       "name": "Connect",
       "c99name": "Connect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Connect",
+      "label": "@swiftpkg_soto//:Connect.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1171,7 +1138,7 @@
       "name": "ConnectParticipant",
       "c99name": "ConnectParticipant",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ConnectParticipant",
+      "label": "@swiftpkg_soto//:ConnectParticipant.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1182,7 +1149,7 @@
       "name": "CostExplorer",
       "c99name": "CostExplorer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CostExplorer",
+      "label": "@swiftpkg_soto//:CostExplorer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1193,7 +1160,7 @@
       "name": "CostandUsageReportService",
       "c99name": "CostandUsageReportService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CostandUsageReportService",
+      "label": "@swiftpkg_soto//:CostandUsageReportService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1204,7 +1171,7 @@
       "name": "DAX",
       "c99name": "DAX",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DAX",
+      "label": "@swiftpkg_soto//:DAX.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1215,7 +1182,7 @@
       "name": "DLM",
       "c99name": "DLM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DLM",
+      "label": "@swiftpkg_soto//:DLM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1226,7 +1193,7 @@
       "name": "DataExchange",
       "c99name": "DataExchange",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataExchange",
+      "label": "@swiftpkg_soto//:DataExchange.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1237,7 +1204,7 @@
       "name": "DataPipeline",
       "c99name": "DataPipeline",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataPipeline",
+      "label": "@swiftpkg_soto//:DataPipeline.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1248,7 +1215,7 @@
       "name": "DataSync",
       "c99name": "DataSync",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataSync",
+      "label": "@swiftpkg_soto//:DataSync.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1259,7 +1226,7 @@
       "name": "DatabaseMigrationService",
       "c99name": "DatabaseMigrationService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DatabaseMigrationService",
+      "label": "@swiftpkg_soto//:DatabaseMigrationService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1270,7 +1237,7 @@
       "name": "Detective",
       "c99name": "Detective",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Detective",
+      "label": "@swiftpkg_soto//:Detective.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1281,7 +1248,7 @@
       "name": "DeviceFarm",
       "c99name": "DeviceFarm",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DeviceFarm",
+      "label": "@swiftpkg_soto//:DeviceFarm.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1292,7 +1259,7 @@
       "name": "DirectConnect",
       "c99name": "DirectConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DirectConnect",
+      "label": "@swiftpkg_soto//:DirectConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1303,7 +1270,7 @@
       "name": "DocDB",
       "c99name": "DocDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DocDB",
+      "label": "@swiftpkg_soto//:DocDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1314,7 +1281,7 @@
       "name": "DynamoDB",
       "c99name": "DynamoDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DynamoDB",
+      "label": "@swiftpkg_soto//:DynamoDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1325,7 +1292,7 @@
       "name": "DynamoDBStreams",
       "c99name": "DynamoDBStreams",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DynamoDBStreams",
+      "label": "@swiftpkg_soto//:DynamoDBStreams.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1336,7 +1303,7 @@
       "name": "EBS",
       "c99name": "EBS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EBS",
+      "label": "@swiftpkg_soto//:EBS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1347,7 +1314,7 @@
       "name": "EC2",
       "c99name": "EC2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EC2",
+      "label": "@swiftpkg_soto//:EC2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1358,7 +1325,7 @@
       "name": "EC2InstanceConnect",
       "c99name": "EC2InstanceConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EC2InstanceConnect",
+      "label": "@swiftpkg_soto//:EC2InstanceConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1369,7 +1336,7 @@
       "name": "ECR",
       "c99name": "ECR",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ECR",
+      "label": "@swiftpkg_soto//:ECR.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1380,7 +1347,7 @@
       "name": "ECS",
       "c99name": "ECS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ECS",
+      "label": "@swiftpkg_soto//:ECS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1391,7 +1358,7 @@
       "name": "EFS",
       "c99name": "EFS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EFS",
+      "label": "@swiftpkg_soto//:EFS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1402,7 +1369,7 @@
       "name": "EKS",
       "c99name": "EKS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EKS",
+      "label": "@swiftpkg_soto//:EKS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1413,7 +1380,7 @@
       "name": "ELB",
       "c99name": "ELB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ELB",
+      "label": "@swiftpkg_soto//:ELB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1424,7 +1391,7 @@
       "name": "ELBV2",
       "c99name": "ELBV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ELBV2",
+      "label": "@swiftpkg_soto//:ELBV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1435,7 +1402,7 @@
       "name": "EMR",
       "c99name": "EMR",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EMR",
+      "label": "@swiftpkg_soto//:EMR.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1446,7 +1413,7 @@
       "name": "ElastiCache",
       "c99name": "ElastiCache",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElastiCache",
+      "label": "@swiftpkg_soto//:ElastiCache.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1457,7 +1424,7 @@
       "name": "ElasticBeanstalk",
       "c99name": "ElasticBeanstalk",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticBeanstalk",
+      "label": "@swiftpkg_soto//:ElasticBeanstalk.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1468,7 +1435,7 @@
       "name": "ElasticInference",
       "c99name": "ElasticInference",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticInference",
+      "label": "@swiftpkg_soto//:ElasticInference.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1479,7 +1446,7 @@
       "name": "ElasticTranscoder",
       "c99name": "ElasticTranscoder",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticTranscoder",
+      "label": "@swiftpkg_soto//:ElasticTranscoder.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1490,7 +1457,7 @@
       "name": "ElasticsearchService",
       "c99name": "ElasticsearchService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticsearchService",
+      "label": "@swiftpkg_soto//:ElasticsearchService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1501,7 +1468,7 @@
       "name": "EventBridge",
       "c99name": "EventBridge",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EventBridge",
+      "label": "@swiftpkg_soto//:EventBridge.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1512,7 +1479,7 @@
       "name": "FMS",
       "c99name": "FMS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FMS",
+      "label": "@swiftpkg_soto//:FMS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1523,7 +1490,7 @@
       "name": "FSx",
       "c99name": "FSx",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FSx",
+      "label": "@swiftpkg_soto//:FSx.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1534,7 +1501,7 @@
       "name": "Firehose",
       "c99name": "Firehose",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Firehose",
+      "label": "@swiftpkg_soto//:Firehose.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1545,7 +1512,7 @@
       "name": "ForecastQueryService",
       "c99name": "ForecastQueryService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ForecastQueryService",
+      "label": "@swiftpkg_soto//:ForecastQueryService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1556,7 +1523,7 @@
       "name": "ForecastService",
       "c99name": "ForecastService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ForecastService",
+      "label": "@swiftpkg_soto//:ForecastService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1567,7 +1534,7 @@
       "name": "FraudDetector",
       "c99name": "FraudDetector",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FraudDetector",
+      "label": "@swiftpkg_soto//:FraudDetector.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1578,7 +1545,7 @@
       "name": "GameLift",
       "c99name": "GameLift",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GameLift",
+      "label": "@swiftpkg_soto//:GameLift.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1589,7 +1556,18 @@
       "name": "Glacier",
       "c99name": "Glacier",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Glacier",
+      "label": "@swiftpkg_soto//:Glacier.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "AWSSDKSwift",
+        "Glacier"
+      ]
+    },
+    {
+      "name": "GlacierMiddleware",
+      "c99name": "GlacierMiddleware",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:GlacierMiddleware.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1600,7 +1578,7 @@
       "name": "GlobalAccelerator",
       "c99name": "GlobalAccelerator",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GlobalAccelerator",
+      "label": "@swiftpkg_soto//:GlobalAccelerator.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1611,7 +1589,7 @@
       "name": "Glue",
       "c99name": "Glue",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Glue",
+      "label": "@swiftpkg_soto//:Glue.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1622,7 +1600,7 @@
       "name": "Greengrass",
       "c99name": "Greengrass",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Greengrass",
+      "label": "@swiftpkg_soto//:Greengrass.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1633,7 +1611,7 @@
       "name": "GroundStation",
       "c99name": "GroundStation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GroundStation",
+      "label": "@swiftpkg_soto//:GroundStation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1644,7 +1622,7 @@
       "name": "GuardDuty",
       "c99name": "GuardDuty",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GuardDuty",
+      "label": "@swiftpkg_soto//:GuardDuty.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1655,7 +1633,7 @@
       "name": "Health",
       "c99name": "Health",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Health",
+      "label": "@swiftpkg_soto//:Health.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1666,7 +1644,7 @@
       "name": "Honeycode",
       "c99name": "Honeycode",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Honeycode",
+      "label": "@swiftpkg_soto//:Honeycode.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1677,7 +1655,7 @@
       "name": "IAM",
       "c99name": "IAM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IAM",
+      "label": "@swiftpkg_soto//:IAM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1688,7 +1666,7 @@
       "name": "IVS",
       "c99name": "IVS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IVS",
+      "label": "@swiftpkg_soto//:IVS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1699,7 +1677,7 @@
       "name": "IdentityStore",
       "c99name": "IdentityStore",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IdentityStore",
+      "label": "@swiftpkg_soto//:IdentityStore.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1710,7 +1688,7 @@
       "name": "Imagebuilder",
       "c99name": "Imagebuilder",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Imagebuilder",
+      "label": "@swiftpkg_soto//:Imagebuilder.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1721,7 +1699,7 @@
       "name": "ImportExport",
       "c99name": "ImportExport",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ImportExport",
+      "label": "@swiftpkg_soto//:ImportExport.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1732,7 +1710,7 @@
       "name": "Inspector",
       "c99name": "Inspector",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Inspector",
+      "label": "@swiftpkg_soto//:Inspector.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1743,7 +1721,7 @@
       "name": "IoT",
       "c99name": "IoT",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT",
+      "label": "@swiftpkg_soto//:IoT.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1754,7 +1732,7 @@
       "name": "IoT1ClickDevicesService",
       "c99name": "IoT1ClickDevicesService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT1ClickDevicesService",
+      "label": "@swiftpkg_soto//:IoT1ClickDevicesService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1765,7 +1743,7 @@
       "name": "IoT1ClickProjects",
       "c99name": "IoT1ClickProjects",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT1ClickProjects",
+      "label": "@swiftpkg_soto//:IoT1ClickProjects.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1776,7 +1754,7 @@
       "name": "IoTAnalytics",
       "c99name": "IoTAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTAnalytics",
+      "label": "@swiftpkg_soto//:IoTAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1787,7 +1765,7 @@
       "name": "IoTDataPlane",
       "c99name": "IoTDataPlane",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTDataPlane",
+      "label": "@swiftpkg_soto//:IoTDataPlane.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1798,7 +1776,7 @@
       "name": "IoTEvents",
       "c99name": "IoTEvents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTEvents",
+      "label": "@swiftpkg_soto//:IoTEvents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1809,7 +1787,7 @@
       "name": "IoTEventsData",
       "c99name": "IoTEventsData",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTEventsData",
+      "label": "@swiftpkg_soto//:IoTEventsData.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1820,7 +1798,7 @@
       "name": "IoTJobsDataPlane",
       "c99name": "IoTJobsDataPlane",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTJobsDataPlane",
+      "label": "@swiftpkg_soto//:IoTJobsDataPlane.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1831,7 +1809,7 @@
       "name": "IoTSecureTunneling",
       "c99name": "IoTSecureTunneling",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTSecureTunneling",
+      "label": "@swiftpkg_soto//:IoTSecureTunneling.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1842,7 +1820,7 @@
       "name": "IoTSiteWise",
       "c99name": "IoTSiteWise",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTSiteWise",
+      "label": "@swiftpkg_soto//:IoTSiteWise.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1853,7 +1831,7 @@
       "name": "IoTThingsGraph",
       "c99name": "IoTThingsGraph",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTThingsGraph",
+      "label": "@swiftpkg_soto//:IoTThingsGraph.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1864,7 +1842,7 @@
       "name": "KMS",
       "c99name": "KMS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KMS",
+      "label": "@swiftpkg_soto//:KMS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1875,7 +1853,7 @@
       "name": "Kafka",
       "c99name": "Kafka",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kafka",
+      "label": "@swiftpkg_soto//:Kafka.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1886,7 +1864,7 @@
       "name": "Kendra",
       "c99name": "Kendra",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kendra",
+      "label": "@swiftpkg_soto//:Kendra.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1897,7 +1875,7 @@
       "name": "Kinesis",
       "c99name": "Kinesis",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kinesis",
+      "label": "@swiftpkg_soto//:Kinesis.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1908,7 +1886,7 @@
       "name": "KinesisAnalytics",
       "c99name": "KinesisAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisAnalytics",
+      "label": "@swiftpkg_soto//:KinesisAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1919,7 +1897,7 @@
       "name": "KinesisAnalyticsV2",
       "c99name": "KinesisAnalyticsV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisAnalyticsV2",
+      "label": "@swiftpkg_soto//:KinesisAnalyticsV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1930,7 +1908,7 @@
       "name": "KinesisVideo",
       "c99name": "KinesisVideo",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideo",
+      "label": "@swiftpkg_soto//:KinesisVideo.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1941,7 +1919,7 @@
       "name": "KinesisVideoArchivedMedia",
       "c99name": "KinesisVideoArchivedMedia",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoArchivedMedia",
+      "label": "@swiftpkg_soto//:KinesisVideoArchivedMedia.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1952,7 +1930,7 @@
       "name": "KinesisVideoMedia",
       "c99name": "KinesisVideoMedia",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoMedia",
+      "label": "@swiftpkg_soto//:KinesisVideoMedia.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1963,7 +1941,7 @@
       "name": "KinesisVideoSignalingChannels",
       "c99name": "KinesisVideoSignalingChannels",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoSignalingChannels",
+      "label": "@swiftpkg_soto//:KinesisVideoSignalingChannels.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1974,7 +1952,7 @@
       "name": "LakeFormation",
       "c99name": "LakeFormation",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LakeFormation",
+      "label": "@swiftpkg_soto//:LakeFormation.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1985,7 +1963,7 @@
       "name": "Lambda",
       "c99name": "Lambda",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Lambda",
+      "label": "@swiftpkg_soto//:Lambda.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -1996,7 +1974,7 @@
       "name": "LexModelBuildingService",
       "c99name": "LexModelBuildingService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LexModelBuildingService",
+      "label": "@swiftpkg_soto//:LexModelBuildingService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2007,7 +1985,7 @@
       "name": "LexRuntimeService",
       "c99name": "LexRuntimeService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LexRuntimeService",
+      "label": "@swiftpkg_soto//:LexRuntimeService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2018,7 +1996,7 @@
       "name": "LicenseManager",
       "c99name": "LicenseManager",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LicenseManager",
+      "label": "@swiftpkg_soto//:LicenseManager.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2029,7 +2007,7 @@
       "name": "Lightsail",
       "c99name": "Lightsail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Lightsail",
+      "label": "@swiftpkg_soto//:Lightsail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2040,7 +2018,7 @@
       "name": "MQ",
       "c99name": "MQ",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MQ",
+      "label": "@swiftpkg_soto//:MQ.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2051,7 +2029,7 @@
       "name": "MTurk",
       "c99name": "MTurk",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MTurk",
+      "label": "@swiftpkg_soto//:MTurk.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2062,7 +2040,7 @@
       "name": "MachineLearning",
       "c99name": "MachineLearning",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MachineLearning",
+      "label": "@swiftpkg_soto//:MachineLearning.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2073,7 +2051,7 @@
       "name": "Macie",
       "c99name": "Macie",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Macie",
+      "label": "@swiftpkg_soto//:Macie.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2084,7 +2062,7 @@
       "name": "Macie2",
       "c99name": "Macie2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Macie2",
+      "label": "@swiftpkg_soto//:Macie2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2095,7 +2073,7 @@
       "name": "ManagedBlockchain",
       "c99name": "ManagedBlockchain",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ManagedBlockchain",
+      "label": "@swiftpkg_soto//:ManagedBlockchain.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2106,7 +2084,7 @@
       "name": "MarketplaceCatalog",
       "c99name": "MarketplaceCatalog",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceCatalog",
+      "label": "@swiftpkg_soto//:MarketplaceCatalog.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2117,7 +2095,7 @@
       "name": "MarketplaceCommerceAnalytics",
       "c99name": "MarketplaceCommerceAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceCommerceAnalytics",
+      "label": "@swiftpkg_soto//:MarketplaceCommerceAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2128,7 +2106,7 @@
       "name": "MarketplaceEntitlementService",
       "c99name": "MarketplaceEntitlementService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceEntitlementService",
+      "label": "@swiftpkg_soto//:MarketplaceEntitlementService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2139,7 +2117,7 @@
       "name": "MarketplaceMetering",
       "c99name": "MarketplaceMetering",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceMetering",
+      "label": "@swiftpkg_soto//:MarketplaceMetering.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2150,7 +2128,7 @@
       "name": "MediaConnect",
       "c99name": "MediaConnect",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaConnect",
+      "label": "@swiftpkg_soto//:MediaConnect.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2161,7 +2139,7 @@
       "name": "MediaConvert",
       "c99name": "MediaConvert",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaConvert",
+      "label": "@swiftpkg_soto//:MediaConvert.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2172,7 +2150,7 @@
       "name": "MediaLive",
       "c99name": "MediaLive",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaLive",
+      "label": "@swiftpkg_soto//:MediaLive.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2183,7 +2161,7 @@
       "name": "MediaPackage",
       "c99name": "MediaPackage",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaPackage",
+      "label": "@swiftpkg_soto//:MediaPackage.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2194,7 +2172,7 @@
       "name": "MediaPackageVod",
       "c99name": "MediaPackageVod",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaPackageVod",
+      "label": "@swiftpkg_soto//:MediaPackageVod.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2205,7 +2183,7 @@
       "name": "MediaStore",
       "c99name": "MediaStore",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaStore",
+      "label": "@swiftpkg_soto//:MediaStore.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2216,7 +2194,7 @@
       "name": "MediaStoreData",
       "c99name": "MediaStoreData",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaStoreData",
+      "label": "@swiftpkg_soto//:MediaStoreData.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2227,7 +2205,7 @@
       "name": "MediaTailor",
       "c99name": "MediaTailor",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaTailor",
+      "label": "@swiftpkg_soto//:MediaTailor.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2238,7 +2216,7 @@
       "name": "MigrationHub",
       "c99name": "MigrationHub",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MigrationHub",
+      "label": "@swiftpkg_soto//:MigrationHub.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2249,7 +2227,7 @@
       "name": "MigrationHubConfig",
       "c99name": "MigrationHubConfig",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MigrationHubConfig",
+      "label": "@swiftpkg_soto//:MigrationHubConfig.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2260,7 +2238,7 @@
       "name": "Mobile",
       "c99name": "Mobile",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Mobile",
+      "label": "@swiftpkg_soto//:Mobile.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2271,7 +2249,7 @@
       "name": "MobileAnalytics",
       "c99name": "MobileAnalytics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MobileAnalytics",
+      "label": "@swiftpkg_soto//:MobileAnalytics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2282,7 +2260,7 @@
       "name": "Neptune",
       "c99name": "Neptune",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Neptune",
+      "label": "@swiftpkg_soto//:Neptune.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2293,7 +2271,7 @@
       "name": "NetworkManager",
       "c99name": "NetworkManager",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_NetworkManager",
+      "label": "@swiftpkg_soto//:NetworkManager.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2304,7 +2282,7 @@
       "name": "OpsWorks",
       "c99name": "OpsWorks",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_OpsWorks",
+      "label": "@swiftpkg_soto//:OpsWorks.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2315,7 +2293,7 @@
       "name": "OpsWorksCM",
       "c99name": "OpsWorksCM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_OpsWorksCM",
+      "label": "@swiftpkg_soto//:OpsWorksCM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2326,7 +2304,7 @@
       "name": "Organizations",
       "c99name": "Organizations",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Organizations",
+      "label": "@swiftpkg_soto//:Organizations.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2337,7 +2315,7 @@
       "name": "Outposts",
       "c99name": "Outposts",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Outposts",
+      "label": "@swiftpkg_soto//:Outposts.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2348,7 +2326,7 @@
       "name": "PI",
       "c99name": "PI",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PI",
+      "label": "@swiftpkg_soto//:PI.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2359,7 +2337,7 @@
       "name": "Personalize",
       "c99name": "Personalize",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Personalize",
+      "label": "@swiftpkg_soto//:Personalize.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2370,7 +2348,7 @@
       "name": "PersonalizeEvents",
       "c99name": "PersonalizeEvents",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PersonalizeEvents",
+      "label": "@swiftpkg_soto//:PersonalizeEvents.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2381,7 +2359,7 @@
       "name": "PersonalizeRuntime",
       "c99name": "PersonalizeRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PersonalizeRuntime",
+      "label": "@swiftpkg_soto//:PersonalizeRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2392,7 +2370,7 @@
       "name": "Pinpoint",
       "c99name": "Pinpoint",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Pinpoint",
+      "label": "@swiftpkg_soto//:Pinpoint.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2403,7 +2381,7 @@
       "name": "PinpointEmail",
       "c99name": "PinpointEmail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PinpointEmail",
+      "label": "@swiftpkg_soto//:PinpointEmail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2414,7 +2392,7 @@
       "name": "PinpointSMSVoice",
       "c99name": "PinpointSMSVoice",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PinpointSMSVoice",
+      "label": "@swiftpkg_soto//:PinpointSMSVoice.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2425,7 +2403,7 @@
       "name": "Polly",
       "c99name": "Polly",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Polly",
+      "label": "@swiftpkg_soto//:Polly.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2436,7 +2414,7 @@
       "name": "Pricing",
       "c99name": "Pricing",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Pricing",
+      "label": "@swiftpkg_soto//:Pricing.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2447,7 +2425,7 @@
       "name": "QLDB",
       "c99name": "QLDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QLDB",
+      "label": "@swiftpkg_soto//:QLDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2458,7 +2436,7 @@
       "name": "QLDBSession",
       "c99name": "QLDBSession",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QLDBSession",
+      "label": "@swiftpkg_soto//:QLDBSession.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2469,7 +2447,7 @@
       "name": "QuickSight",
       "c99name": "QuickSight",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QuickSight",
+      "label": "@swiftpkg_soto//:QuickSight.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2480,7 +2458,7 @@
       "name": "RAM",
       "c99name": "RAM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RAM",
+      "label": "@swiftpkg_soto//:RAM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2491,7 +2469,7 @@
       "name": "RDS",
       "c99name": "RDS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RDS",
+      "label": "@swiftpkg_soto//:RDS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2502,7 +2480,7 @@
       "name": "RDSDataService",
       "c99name": "RDSDataService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RDSDataService",
+      "label": "@swiftpkg_soto//:RDSDataService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2513,7 +2491,7 @@
       "name": "Redshift",
       "c99name": "Redshift",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Redshift",
+      "label": "@swiftpkg_soto//:Redshift.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2524,7 +2502,7 @@
       "name": "RedshiftDataAPIService",
       "c99name": "RedshiftDataAPIService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RedshiftDataAPIService",
+      "label": "@swiftpkg_soto//:RedshiftDataAPIService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2535,7 +2513,7 @@
       "name": "Rekognition",
       "c99name": "Rekognition",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Rekognition",
+      "label": "@swiftpkg_soto//:Rekognition.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2546,7 +2524,7 @@
       "name": "ResourceGroups",
       "c99name": "ResourceGroups",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ResourceGroups",
+      "label": "@swiftpkg_soto//:ResourceGroups.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2557,7 +2535,7 @@
       "name": "ResourceGroupsTaggingAPI",
       "c99name": "ResourceGroupsTaggingAPI",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ResourceGroupsTaggingAPI",
+      "label": "@swiftpkg_soto//:ResourceGroupsTaggingAPI.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2568,7 +2546,7 @@
       "name": "RoboMaker",
       "c99name": "RoboMaker",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RoboMaker",
+      "label": "@swiftpkg_soto//:RoboMaker.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2579,7 +2557,7 @@
       "name": "Route53",
       "c99name": "Route53",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53",
+      "label": "@swiftpkg_soto//:Route53.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2590,7 +2568,7 @@
       "name": "Route53Domains",
       "c99name": "Route53Domains",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53Domains",
+      "label": "@swiftpkg_soto//:Route53Domains.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2601,7 +2579,7 @@
       "name": "Route53Resolver",
       "c99name": "Route53Resolver",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53Resolver",
+      "label": "@swiftpkg_soto//:Route53Resolver.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2612,7 +2590,7 @@
       "name": "S3",
       "c99name": "S3",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_S3",
+      "label": "@swiftpkg_soto//:S3.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2623,7 +2601,7 @@
       "name": "S3Control",
       "c99name": "S3Control",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_S3Control",
+      "label": "@swiftpkg_soto//:S3Control.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2631,10 +2609,32 @@
       ]
     },
     {
+      "name": "S3ControlMiddleware",
+      "c99name": "S3ControlMiddleware",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:S3ControlMiddleware.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "AWSSDKSwift",
+        "S3Control"
+      ]
+    },
+    {
+      "name": "S3Middleware",
+      "c99name": "S3Middleware",
+      "src_type": "swift",
+      "label": "@swiftpkg_soto//:S3Middleware.rspm",
+      "package_identity": "soto",
+      "product_memberships": [
+        "AWSSDKSwift",
+        "S3"
+      ]
+    },
+    {
       "name": "SES",
       "c99name": "SES",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SES",
+      "label": "@swiftpkg_soto//:SES.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2645,7 +2645,7 @@
       "name": "SESV2",
       "c99name": "SESV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SESV2",
+      "label": "@swiftpkg_soto//:SESV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2656,7 +2656,7 @@
       "name": "SFN",
       "c99name": "SFN",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SFN",
+      "label": "@swiftpkg_soto//:SFN.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2667,7 +2667,7 @@
       "name": "SMS",
       "c99name": "SMS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SMS",
+      "label": "@swiftpkg_soto//:SMS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2678,7 +2678,7 @@
       "name": "SNS",
       "c99name": "SNS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SNS",
+      "label": "@swiftpkg_soto//:SNS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2689,7 +2689,7 @@
       "name": "SQS",
       "c99name": "SQS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SQS",
+      "label": "@swiftpkg_soto//:SQS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2700,7 +2700,7 @@
       "name": "SSM",
       "c99name": "SSM",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSM",
+      "label": "@swiftpkg_soto//:SSM.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2711,7 +2711,7 @@
       "name": "SSO",
       "c99name": "SSO",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSO",
+      "label": "@swiftpkg_soto//:SSO.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2722,7 +2722,7 @@
       "name": "SSOAdmin",
       "c99name": "SSOAdmin",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSOAdmin",
+      "label": "@swiftpkg_soto//:SSOAdmin.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2733,7 +2733,7 @@
       "name": "SSOOIDC",
       "c99name": "SSOOIDC",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSOOIDC",
+      "label": "@swiftpkg_soto//:SSOOIDC.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2744,7 +2744,7 @@
       "name": "STS",
       "c99name": "STS",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_STS",
+      "label": "@swiftpkg_soto//:STS.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2755,7 +2755,7 @@
       "name": "SWF",
       "c99name": "SWF",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SWF",
+      "label": "@swiftpkg_soto//:SWF.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2766,7 +2766,7 @@
       "name": "SageMaker",
       "c99name": "SageMaker",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SageMaker",
+      "label": "@swiftpkg_soto//:SageMaker.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2777,7 +2777,7 @@
       "name": "SageMakerRuntime",
       "c99name": "SageMakerRuntime",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SageMakerRuntime",
+      "label": "@swiftpkg_soto//:SageMakerRuntime.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2788,7 +2788,7 @@
       "name": "SavingsPlans",
       "c99name": "SavingsPlans",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SavingsPlans",
+      "label": "@swiftpkg_soto//:SavingsPlans.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2799,7 +2799,7 @@
       "name": "Schemas",
       "c99name": "Schemas",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Schemas",
+      "label": "@swiftpkg_soto//:Schemas.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2810,7 +2810,7 @@
       "name": "SecretsManager",
       "c99name": "SecretsManager",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SecretsManager",
+      "label": "@swiftpkg_soto//:SecretsManager.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2821,7 +2821,7 @@
       "name": "SecurityHub",
       "c99name": "SecurityHub",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SecurityHub",
+      "label": "@swiftpkg_soto//:SecurityHub.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2832,7 +2832,7 @@
       "name": "ServerlessApplicationRepository",
       "c99name": "ServerlessApplicationRepository",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServerlessApplicationRepository",
+      "label": "@swiftpkg_soto//:ServerlessApplicationRepository.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2843,7 +2843,7 @@
       "name": "ServiceCatalog",
       "c99name": "ServiceCatalog",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceCatalog",
+      "label": "@swiftpkg_soto//:ServiceCatalog.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2854,7 +2854,7 @@
       "name": "ServiceDiscovery",
       "c99name": "ServiceDiscovery",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceDiscovery",
+      "label": "@swiftpkg_soto//:ServiceDiscovery.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2865,7 +2865,7 @@
       "name": "ServiceQuotas",
       "c99name": "ServiceQuotas",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceQuotas",
+      "label": "@swiftpkg_soto//:ServiceQuotas.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2876,7 +2876,7 @@
       "name": "Shield",
       "c99name": "Shield",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Shield",
+      "label": "@swiftpkg_soto//:Shield.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2887,7 +2887,7 @@
       "name": "Signer",
       "c99name": "Signer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Signer",
+      "label": "@swiftpkg_soto//:Signer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2898,7 +2898,7 @@
       "name": "SimpleDB",
       "c99name": "SimpleDB",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SimpleDB",
+      "label": "@swiftpkg_soto//:SimpleDB.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2909,7 +2909,7 @@
       "name": "Snowball",
       "c99name": "Snowball",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Snowball",
+      "label": "@swiftpkg_soto//:Snowball.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2920,7 +2920,7 @@
       "name": "StorageGateway",
       "c99name": "StorageGateway",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_StorageGateway",
+      "label": "@swiftpkg_soto//:StorageGateway.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2931,7 +2931,7 @@
       "name": "Support",
       "c99name": "Support",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Support",
+      "label": "@swiftpkg_soto//:Support.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2942,7 +2942,7 @@
       "name": "Synthetics",
       "c99name": "Synthetics",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Synthetics",
+      "label": "@swiftpkg_soto//:Synthetics.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2953,7 +2953,7 @@
       "name": "Textract",
       "c99name": "Textract",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Textract",
+      "label": "@swiftpkg_soto//:Textract.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2964,7 +2964,7 @@
       "name": "TranscribeService",
       "c99name": "TranscribeService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_TranscribeService",
+      "label": "@swiftpkg_soto//:TranscribeService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2975,7 +2975,7 @@
       "name": "TranscribeStreamingService",
       "c99name": "TranscribeStreamingService",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_TranscribeStreamingService",
+      "label": "@swiftpkg_soto//:TranscribeStreamingService.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2986,7 +2986,7 @@
       "name": "Transfer",
       "c99name": "Transfer",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Transfer",
+      "label": "@swiftpkg_soto//:Transfer.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -2997,7 +2997,7 @@
       "name": "Translate",
       "c99name": "Translate",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Translate",
+      "label": "@swiftpkg_soto//:Translate.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3008,7 +3008,7 @@
       "name": "WAF",
       "c99name": "WAF",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAF",
+      "label": "@swiftpkg_soto//:WAF.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3019,7 +3019,7 @@
       "name": "WAFRegional",
       "c99name": "WAFRegional",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAFRegional",
+      "label": "@swiftpkg_soto//:WAFRegional.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3030,7 +3030,7 @@
       "name": "WAFV2",
       "c99name": "WAFV2",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAFV2",
+      "label": "@swiftpkg_soto//:WAFV2.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3041,7 +3041,7 @@
       "name": "WorkDocs",
       "c99name": "WorkDocs",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkDocs",
+      "label": "@swiftpkg_soto//:WorkDocs.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3052,7 +3052,7 @@
       "name": "WorkLink",
       "c99name": "WorkLink",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkLink",
+      "label": "@swiftpkg_soto//:WorkLink.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3063,7 +3063,7 @@
       "name": "WorkMail",
       "c99name": "WorkMail",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkMail",
+      "label": "@swiftpkg_soto//:WorkMail.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3074,7 +3074,7 @@
       "name": "WorkMailMessageFlow",
       "c99name": "WorkMailMessageFlow",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkMailMessageFlow",
+      "label": "@swiftpkg_soto//:WorkMailMessageFlow.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3085,7 +3085,7 @@
       "name": "WorkSpaces",
       "c99name": "WorkSpaces",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkSpaces",
+      "label": "@swiftpkg_soto//:WorkSpaces.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3096,7 +3096,7 @@
       "name": "XRay",
       "c99name": "XRay",
       "src_type": "swift",
-      "label": "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_XRay",
+      "label": "@swiftpkg_soto//:XRay.rspm",
       "package_identity": "soto",
       "product_memberships": [
         "AWSSDKSwift",
@@ -3107,7 +3107,7 @@
       "name": "AWSSDKSwiftCore",
       "c99name": "AWSSDKSwiftCore",
       "src_type": "swift",
-      "label": "@swiftpkg_soto_core//:Sources_AWSSDKSwiftCore",
+      "label": "@swiftpkg_soto_core//:AWSSDKSwiftCore.rspm",
       "package_identity": "soto-core",
       "product_memberships": [
         "AWSSDKSwiftCore"
@@ -3117,7 +3117,7 @@
       "name": "Spectre",
       "c99name": "Spectre",
       "src_type": "swift",
-      "label": "@swiftpkg_spectre//:Sources_Spectre",
+      "label": "@swiftpkg_spectre//:Spectre.rspm",
       "package_identity": "spectre",
       "product_memberships": [
         "Spectre"
@@ -3127,7 +3127,7 @@
       "name": "SQLKit",
       "c99name": "SQLKit",
       "src_type": "swift",
-      "label": "@swiftpkg_sql_kit//:Sources_SQLKit",
+      "label": "@swiftpkg_sql_kit//:SQLKit.rspm",
       "package_identity": "sql-kit",
       "product_memberships": [
         "SQLKit",
@@ -3138,7 +3138,7 @@
       "name": "SQLKitBenchmark",
       "c99name": "SQLKitBenchmark",
       "src_type": "swift",
-      "label": "@swiftpkg_sql_kit//:Sources_SQLKitBenchmark",
+      "label": "@swiftpkg_sql_kit//:SQLKitBenchmark.rspm",
       "package_identity": "sql-kit",
       "product_memberships": [
         "SQLKitBenchmark"
@@ -3148,27 +3148,17 @@
       "name": "Algorithms",
       "c99name": "Algorithms",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_algorithms//:Sources_Algorithms",
+      "label": "@swiftpkg_swift_algorithms//:Algorithms.rspm",
       "package_identity": "swift-algorithms",
       "product_memberships": [
         "Algorithms"
       ]
     },
     {
-      "name": "GenerateManual",
-      "c99name": "GenerateManual",
-      "src_type": "unknown",
-      "label": "@swiftpkg_swift_argument_parser//:Plugins_GenerateManual",
-      "package_identity": "swift-argument-parser",
-      "product_memberships": [
-        "GenerateManual"
-      ]
-    },
-    {
       "name": "ArgumentParser",
       "c99name": "ArgumentParser",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser",
+      "label": "@swiftpkg_swift_argument_parser//:ArgumentParser.rspm",
       "package_identity": "swift-argument-parser",
       "product_memberships": [
         "ArgumentParser",
@@ -3179,7 +3169,7 @@
       "name": "ArgumentParserToolInfo",
       "c99name": "ArgumentParserToolInfo",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_argument_parser//:Sources_ArgumentParserToolInfo",
+      "label": "@swiftpkg_swift_argument_parser//:ArgumentParserToolInfo.rspm",
       "package_identity": "swift-argument-parser",
       "product_memberships": [
         "ArgumentParser",
@@ -3187,10 +3177,20 @@
       ]
     },
     {
+      "name": "GenerateManual",
+      "c99name": "GenerateManual",
+      "src_type": "unknown",
+      "label": "@swiftpkg_swift_argument_parser//:GenerateManual.rspm",
+      "package_identity": "swift-argument-parser",
+      "product_memberships": [
+        "GenerateManual"
+      ]
+    },
+    {
       "name": "generate-manual",
       "c99name": "generate_manual",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_argument_parser//:Tools_generate-manual",
+      "label": "@swiftpkg_swift_argument_parser//:generate-manual.rspm",
       "package_identity": "swift-argument-parser",
       "product_memberships": [
         "GenerateManual"
@@ -3200,7 +3200,7 @@
       "name": "Atomics",
       "c99name": "Atomics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_atomics//:Sources_Atomics",
+      "label": "@swiftpkg_swift_atomics//:Atomics.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -3210,7 +3210,7 @@
       "name": "_AtomicsShims",
       "c99name": "_AtomicsShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_atomics//:Sources__AtomicsShims",
+      "label": "@swiftpkg_swift_atomics//:_AtomicsShims.rspm",
       "package_identity": "swift-atomics",
       "product_memberships": [
         "Atomics"
@@ -3220,7 +3220,7 @@
       "name": "Backtrace",
       "c99name": "Backtrace",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_backtrace//:Sources_Backtrace",
+      "label": "@swiftpkg_swift_backtrace//:Backtrace.rspm",
       "package_identity": "swift-backtrace",
       "product_memberships": [
         "Backtrace"
@@ -3230,7 +3230,7 @@
       "name": "CBacktrace",
       "c99name": "CBacktrace",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_backtrace//:Sources_CBacktrace",
+      "label": "@swiftpkg_swift_backtrace//:CBacktrace.rspm",
       "package_identity": "swift-backtrace",
       "product_memberships": [
         "Backtrace"
@@ -3240,7 +3240,7 @@
       "name": "Collections",
       "c99name": "Collections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_Collections",
+      "label": "@swiftpkg_swift_collections//:Collections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections"
@@ -3250,7 +3250,7 @@
       "name": "DequeModule",
       "c99name": "DequeModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_DequeModule",
+      "label": "@swiftpkg_swift_collections//:DequeModule.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -3261,7 +3261,7 @@
       "name": "OrderedCollections",
       "c99name": "OrderedCollections",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_collections//:Sources_OrderedCollections",
+      "label": "@swiftpkg_swift_collections//:OrderedCollections.rspm",
       "package_identity": "swift-collections",
       "product_memberships": [
         "Collections",
@@ -3272,7 +3272,7 @@
       "name": "CCryptoBoringSSL",
       "c99name": "CCryptoBoringSSL",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_crypto//:Sources_CCryptoBoringSSL",
+      "label": "@swiftpkg_swift_crypto//:CCryptoBoringSSL.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -3283,7 +3283,7 @@
       "name": "CCryptoBoringSSLShims",
       "c99name": "CCryptoBoringSSLShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_crypto//:Sources_CCryptoBoringSSLShims",
+      "label": "@swiftpkg_swift_crypto//:CCryptoBoringSSLShims.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -3294,7 +3294,7 @@
       "name": "Crypto",
       "c99name": "Crypto",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_crypto//:Sources_Crypto",
+      "label": "@swiftpkg_swift_crypto//:Crypto.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -3305,7 +3305,7 @@
       "name": "CryptoBoringWrapper",
       "c99name": "CryptoBoringWrapper",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_crypto//:Sources_CryptoBoringWrapper",
+      "label": "@swiftpkg_swift_crypto//:CryptoBoringWrapper.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "Crypto",
@@ -3316,7 +3316,7 @@
       "name": "_CryptoExtras",
       "c99name": "_CryptoExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_crypto//:Sources__CryptoExtras",
+      "label": "@swiftpkg_swift_crypto//:_CryptoExtras.rspm",
       "package_identity": "swift-crypto",
       "product_memberships": [
         "_CryptoExtras"
@@ -3326,7 +3326,7 @@
       "name": "Logging",
       "c99name": "Logging",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_log//:Sources_Logging",
+      "label": "@swiftpkg_swift_log//:Logging.rspm",
       "package_identity": "swift-log",
       "product_memberships": [
         "Logging"
@@ -3336,7 +3336,7 @@
       "name": "CoreMetrics",
       "c99name": "CoreMetrics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_CoreMetrics",
+      "label": "@swiftpkg_swift_metrics//:CoreMetrics.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "CoreMetrics",
@@ -3348,7 +3348,7 @@
       "name": "Metrics",
       "c99name": "Metrics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_Metrics",
+      "label": "@swiftpkg_swift_metrics//:Metrics.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "Metrics",
@@ -3359,7 +3359,7 @@
       "name": "MetricsTestKit",
       "c99name": "MetricsTestKit",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_metrics//:Sources_MetricsTestKit",
+      "label": "@swiftpkg_swift_metrics//:MetricsTestKit.rspm",
       "package_identity": "swift-metrics",
       "product_memberships": [
         "MetricsTestKit"
@@ -3369,7 +3369,7 @@
       "name": "CNIOAtomics",
       "c99name": "CNIOAtomics",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOAtomics",
+      "label": "@swiftpkg_swift_nio//:CNIOAtomics.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3389,7 +3389,7 @@
       "name": "CNIODarwin",
       "c99name": "CNIODarwin",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIODarwin",
+      "label": "@swiftpkg_swift_nio//:CNIODarwin.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3406,7 +3406,7 @@
       "name": "CNIOLLHTTP",
       "c99name": "CNIOLLHTTP",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLLHTTP",
+      "label": "@swiftpkg_swift_nio//:CNIOLLHTTP.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -3418,7 +3418,7 @@
       "name": "CNIOLinux",
       "c99name": "CNIOLinux",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOLinux",
+      "label": "@swiftpkg_swift_nio//:CNIOLinux.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3437,7 +3437,7 @@
       "name": "CNIOSHA1",
       "c99name": "CNIOSHA1",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOSHA1",
+      "label": "@swiftpkg_swift_nio//:CNIOSHA1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -3447,7 +3447,7 @@
       "name": "CNIOWindows",
       "c99name": "CNIOWindows",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio//:Sources_CNIOWindows",
+      "label": "@swiftpkg_swift_nio//:CNIOWindows.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3466,7 +3466,7 @@
       "name": "NIO",
       "c99name": "NIO",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIO",
+      "label": "@swiftpkg_swift_nio//:NIO.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3482,7 +3482,7 @@
       "name": "NIOConcurrencyHelpers",
       "c99name": "NIOConcurrencyHelpers",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers",
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3502,7 +3502,7 @@
       "name": "NIOCore",
       "c99name": "NIOCore",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOCore",
+      "label": "@swiftpkg_swift_nio//:NIOCore.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOCore",
@@ -3521,7 +3521,7 @@
       "name": "NIOEmbedded",
       "c99name": "NIOEmbedded",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOEmbedded",
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3538,7 +3538,7 @@
       "name": "NIOFoundationCompat",
       "c99name": "NIOFoundationCompat",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat",
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOFoundationCompat"
@@ -3548,7 +3548,7 @@
       "name": "NIOHTTP1",
       "c99name": "NIOHTTP1",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOHTTP1",
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOHTTP1",
@@ -3560,7 +3560,7 @@
       "name": "NIOPosix",
       "c99name": "NIOPosix",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOPosix",
+      "label": "@swiftpkg_swift_nio//:NIOPosix.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3577,7 +3577,7 @@
       "name": "NIOTLS",
       "c99name": "NIOTLS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTLS",
+      "label": "@swiftpkg_swift_nio//:NIOTLS.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTLS"
@@ -3587,7 +3587,7 @@
       "name": "NIOTestUtils",
       "c99name": "NIOTestUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOTestUtils",
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOTestUtils"
@@ -3597,7 +3597,7 @@
       "name": "NIOWebSocket",
       "c99name": "NIOWebSocket",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources_NIOWebSocket",
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIOWebSocket"
@@ -3607,7 +3607,7 @@
       "name": "_NIOConcurrency",
       "c99name": "_NIOConcurrency",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIOConcurrency",
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "_NIOConcurrency"
@@ -3617,7 +3617,7 @@
       "name": "_NIODataStructures",
       "c99name": "_NIODataStructures",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio//:Sources__NIODataStructures",
+      "label": "@swiftpkg_swift_nio//:_NIODataStructures.rspm",
       "package_identity": "swift-nio",
       "product_memberships": [
         "NIO",
@@ -3635,7 +3635,7 @@
       "name": "CNIOExtrasZlib",
       "c99name": "CNIOExtrasZlib",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_CNIOExtrasZlib",
+      "label": "@swiftpkg_swift_nio_extras//:CNIOExtrasZlib.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOHTTPCompression"
@@ -3645,7 +3645,7 @@
       "name": "NIOExtras",
       "c99name": "NIOExtras",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOExtras",
+      "label": "@swiftpkg_swift_nio_extras//:NIOExtras.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOExtras"
@@ -3655,7 +3655,7 @@
       "name": "NIOHTTPCompression",
       "c99name": "NIOHTTPCompression",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOHTTPCompression",
+      "label": "@swiftpkg_swift_nio_extras//:NIOHTTPCompression.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOHTTPCompression"
@@ -3665,7 +3665,7 @@
       "name": "NIOSOCKS",
       "c99name": "NIOSOCKS",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_extras//:Sources_NIOSOCKS",
+      "label": "@swiftpkg_swift_nio_extras//:NIOSOCKS.rspm",
       "package_identity": "swift-nio-extras",
       "product_memberships": [
         "NIOSOCKS"
@@ -3675,7 +3675,7 @@
       "name": "NIOHPACK",
       "c99name": "NIOHPACK",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_http2//:Sources_NIOHPACK",
+      "label": "@swiftpkg_swift_nio_http2//:NIOHPACK.rspm",
       "package_identity": "swift-nio-http2",
       "product_memberships": [
         "NIOHTTP2"
@@ -3685,7 +3685,7 @@
       "name": "NIOHTTP2",
       "c99name": "NIOHTTP2",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_http2//:Sources_NIOHTTP2",
+      "label": "@swiftpkg_swift_nio_http2//:NIOHTTP2.rspm",
       "package_identity": "swift-nio-http2",
       "product_memberships": [
         "NIOHTTP2"
@@ -3695,7 +3695,7 @@
       "name": "CNIOBoringSSL",
       "c99name": "CNIOBoringSSL",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_CNIOBoringSSL",
+      "label": "@swiftpkg_swift_nio_ssl//:CNIOBoringSSL.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -3707,7 +3707,7 @@
       "name": "CNIOBoringSSLShims",
       "c99name": "CNIOBoringSSLShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_CNIOBoringSSLShims",
+      "label": "@swiftpkg_swift_nio_ssl//:CNIOBoringSSLShims.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -3719,7 +3719,7 @@
       "name": "NIOSSL",
       "c99name": "NIOSSL",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOSSL",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSL.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSL",
@@ -3731,7 +3731,7 @@
       "name": "NIOSSLHTTP1Client",
       "c99name": "NIOSSLHTTP1Client",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOSSLHTTP1Client",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSLHTTP1Client.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOSSLHTTP1Client"
@@ -3741,7 +3741,7 @@
       "name": "NIOTLSServer",
       "c99name": "NIOTLSServer",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_ssl//:Sources_NIOTLSServer",
+      "label": "@swiftpkg_swift_nio_ssl//:NIOTLSServer.rspm",
       "package_identity": "swift-nio-ssl",
       "product_memberships": [
         "NIOTLSServer"
@@ -3751,7 +3751,7 @@
       "name": "NIOTransportServices",
       "c99name": "NIOTransportServices",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_nio_transport_services//:Sources_NIOTransportServices",
+      "label": "@swiftpkg_swift_nio_transport_services//:NIOTransportServices.rspm",
       "package_identity": "swift-nio-transport-services",
       "product_memberships": [
         "NIOTransportServices"
@@ -3761,7 +3761,7 @@
       "name": "ComplexModule",
       "c99name": "ComplexModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_numerics//:Sources_ComplexModule",
+      "label": "@swiftpkg_swift_numerics//:ComplexModule.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "ComplexModule",
@@ -3772,7 +3772,7 @@
       "name": "Numerics",
       "c99name": "Numerics",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_numerics//:Sources_Numerics",
+      "label": "@swiftpkg_swift_numerics//:Numerics.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "Numerics"
@@ -3782,7 +3782,7 @@
       "name": "RealModule",
       "c99name": "RealModule",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_numerics//:Sources_RealModule",
+      "label": "@swiftpkg_swift_numerics//:RealModule.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "ComplexModule",
@@ -3794,7 +3794,7 @@
       "name": "_NumericsShims",
       "c99name": "_NumericsShims",
       "src_type": "clang",
-      "label": "@swiftpkg_swift_numerics//:Sources__NumericsShims",
+      "label": "@swiftpkg_swift_numerics//:_NumericsShims.rspm",
       "package_identity": "swift-numerics",
       "product_memberships": [
         "ComplexModule",
@@ -3803,20 +3803,10 @@
       ]
     },
     {
-      "name": "SwiftProtobufPlugin",
-      "c99name": "SwiftProtobufPlugin",
-      "src_type": "unknown",
-      "label": "@swiftpkg_swift_protobuf//:Plugins_SwiftProtobufPlugin",
-      "package_identity": "swift-protobuf",
-      "product_memberships": [
-        "SwiftProtobufPlugin"
-      ]
-    },
-    {
       "name": "SwiftProtobuf",
       "c99name": "SwiftProtobuf",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_protobuf//:Sources_SwiftProtobuf",
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobuf.rspm",
       "package_identity": "swift-protobuf",
       "product_memberships": [
         "protoc-gen-swift",
@@ -3826,10 +3816,20 @@
       ]
     },
     {
+      "name": "SwiftProtobufPlugin",
+      "c99name": "SwiftProtobufPlugin",
+      "src_type": "unknown",
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPlugin.rspm",
+      "package_identity": "swift-protobuf",
+      "product_memberships": [
+        "SwiftProtobufPlugin"
+      ]
+    },
+    {
       "name": "SwiftProtobufPluginLibrary",
       "c99name": "SwiftProtobufPluginLibrary",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_protobuf//:Sources_SwiftProtobufPluginLibrary",
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPluginLibrary.rspm",
       "package_identity": "swift-protobuf",
       "product_memberships": [
         "protoc-gen-swift",
@@ -3841,7 +3841,7 @@
       "name": "protoc-gen-swift",
       "c99name": "protoc_gen_swift",
       "src_type": "swift",
-      "label": "@swiftpkg_swift_protobuf//:Sources_protoc-gen-swift",
+      "label": "@swiftpkg_swift_protobuf//:protoc-gen-swift.rspm",
       "package_identity": "swift-protobuf",
       "product_memberships": [
         "protoc-gen-swift",
@@ -3852,7 +3852,7 @@
       "name": "CVaporBcrypt",
       "c99name": "CVaporBcrypt",
       "src_type": "clang",
-      "label": "@swiftpkg_vapor//:Sources_CVaporBcrypt",
+      "label": "@swiftpkg_vapor//:CVaporBcrypt.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "Vapor",
@@ -3863,7 +3863,7 @@
       "name": "CVaporURLParser",
       "c99name": "CVaporURLParser",
       "src_type": "clang",
-      "label": "@swiftpkg_vapor//:Sources_CVaporURLParser",
+      "label": "@swiftpkg_vapor//:CVaporURLParser.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "Vapor",
@@ -3874,7 +3874,7 @@
       "name": "Vapor",
       "c99name": "Vapor",
       "src_type": "swift",
-      "label": "@swiftpkg_vapor//:Sources_Vapor",
+      "label": "@swiftpkg_vapor//:Vapor.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "Vapor",
@@ -3885,7 +3885,7 @@
       "name": "XCTVapor",
       "c99name": "XCTVapor",
       "src_type": "swift",
-      "label": "@swiftpkg_vapor//:Sources_XCTVapor",
+      "label": "@swiftpkg_vapor//:XCTVapor.rspm",
       "package_identity": "vapor",
       "product_memberships": [
         "XCTVapor"
@@ -3895,7 +3895,7 @@
       "name": "WebSocketKit",
       "c99name": "WebSocketKit",
       "src_type": "swift",
-      "label": "@swiftpkg_websocket_kit//:Sources_WebSocketKit",
+      "label": "@swiftpkg_websocket_kit//:WebSocketKit.rspm",
       "package_identity": "websocket-kit",
       "product_memberships": [
         "WebSocketKit"
@@ -3905,7 +3905,7 @@
       "name": "XCLogParser",
       "c99name": "XCLogParser",
       "src_type": "swift",
-      "label": "@swiftpkg_xclogparser//:Sources_XCLogParser",
+      "label": "@swiftpkg_xclogparser//:XCLogParser.rspm",
       "package_identity": "xclogparser",
       "product_memberships": [
         "xclogparser",
@@ -3916,7 +3916,7 @@
       "name": "XCLogParserApp",
       "c99name": "XCLogParserApp",
       "src_type": "swift",
-      "label": "@swiftpkg_xclogparser//:Sources_XCLogParserApp",
+      "label": "@swiftpkg_xclogparser//:XCLogParserApp.rspm",
       "package_identity": "xclogparser",
       "product_memberships": [
         "xclogparser"
@@ -3926,7 +3926,7 @@
       "name": "XcodeHasher",
       "c99name": "XcodeHasher",
       "src_type": "swift",
-      "label": "@swiftpkg_xclogparser//:Sources_XcodeHasher",
+      "label": "@swiftpkg_xclogparser//:XcodeHasher.rspm",
       "package_identity": "xclogparser",
       "product_memberships": [
         "xclogparser",
@@ -3937,7 +3937,7 @@
       "name": "XCMetricsApp",
       "c99name": "XCMetricsApp",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsApp",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsApp.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetrics"
@@ -3947,7 +3947,7 @@
       "name": "XCMetricsBackend",
       "c99name": "XCMetricsBackend",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsBackend",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsBackend.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetricsBackend"
@@ -3957,7 +3957,7 @@
       "name": "XCMetricsBackendLib",
       "c99name": "XCMetricsBackendLib",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsBackendLib",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsBackendLib.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetricsBackend"
@@ -3967,7 +3967,7 @@
       "name": "XCMetricsClient",
       "c99name": "XCMetricsClient",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsClient",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsClient.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetrics",
@@ -3979,7 +3979,7 @@
       "name": "XCMetricsCommon",
       "c99name": "XCMetricsCommon",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsCommon",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsCommon.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetrics",
@@ -3992,7 +3992,7 @@
       "name": "XCMetricsPlugins",
       "c99name": "XCMetricsPlugins",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsPlugins",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsPlugins.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetricsPlugins"
@@ -4002,7 +4002,7 @@
       "name": "XCMetricsProto",
       "c99name": "XCMetricsProto",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsProto",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsProto.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetrics",
@@ -4014,7 +4014,7 @@
       "name": "XCMetricsUtils",
       "c99name": "XCMetricsUtils",
       "src_type": "swift",
-      "label": "@swiftpkg_xcmetrics//:Sources_XCMetricsUtils",
+      "label": "@swiftpkg_xcmetrics//:XCMetricsUtils.rspm",
       "package_identity": "xcmetrics",
       "product_memberships": [
         "XCMetrics",
@@ -4027,7 +4027,7 @@
       "name": "CYaml",
       "c99name": "CYaml",
       "src_type": "clang",
-      "label": "@swiftpkg_yams//:Sources_CYaml",
+      "label": "@swiftpkg_yams//:CYaml.rspm",
       "package_identity": "yams",
       "product_memberships": [
         "Yams"
@@ -4037,7 +4037,7 @@
       "name": "Yams",
       "c99name": "Yams",
       "src_type": "swift",
-      "label": "@swiftpkg_yams//:Sources_Yams",
+      "label": "@swiftpkg_yams//:Yams.rspm",
       "package_identity": "yams",
       "product_memberships": [
         "Yams"
@@ -4049,2872 +4049,1975 @@
       "identity": "async-http-client",
       "name": "AsyncHTTPClient",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_async_http_client//:Sources_AsyncHTTPClient"
-      ]
+      "label": "@swiftpkg_async_http_client//:AsyncHTTPClient"
     },
     {
       "identity": "async-kit",
       "name": "AsyncKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_async_kit//:Sources_AsyncKit"
-      ]
+      "label": "@swiftpkg_async_kit//:AsyncKit"
     },
     {
       "identity": "console-kit",
       "name": "ConsoleKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_console_kit//:Sources_ConsoleKit"
-      ]
+      "label": "@swiftpkg_console_kit//:ConsoleKit"
     },
     {
       "identity": "cryptoswift",
       "name": "CryptoSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_cryptoswift//:Sources_CryptoSwift"
-      ]
+      "label": "@swiftpkg_cryptoswift//:CryptoSwift"
     },
     {
       "identity": "fluent-kit",
       "name": "FluentBenchmark",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_FluentBenchmark"
-      ]
+      "label": "@swiftpkg_fluent_kit//:FluentBenchmark"
     },
     {
       "identity": "fluent-kit",
       "name": "FluentKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_FluentKit"
-      ]
+      "label": "@swiftpkg_fluent_kit//:FluentKit"
     },
     {
       "identity": "fluent-kit",
       "name": "FluentSQL",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_FluentSQL"
-      ]
+      "label": "@swiftpkg_fluent_kit//:FluentSQL"
     },
     {
       "identity": "fluent-kit",
       "name": "XCTFluent",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_kit//:Sources_XCTFluent"
-      ]
+      "label": "@swiftpkg_fluent_kit//:XCTFluent"
     },
     {
       "identity": "fluent-postgres-driver",
       "name": "FluentPostgresDriver",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent_postgres_driver//:Sources_FluentPostgresDriver"
-      ]
+      "label": "@swiftpkg_fluent_postgres_driver//:FluentPostgresDriver"
     },
     {
       "identity": "fluent",
       "name": "Fluent",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_fluent//:Sources_Fluent"
-      ]
+      "label": "@swiftpkg_fluent//:Fluent"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:Core_Sources_Core"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudCore"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudDatastore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:Datastore_Sources_Datastore"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudDatastore"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:Core_Sources_Core",
-        "@swiftpkg_google_cloud_kit//:Storage_Sources_Storage",
-        "@swiftpkg_google_cloud_kit//:Datastore_Sources_Datastore",
-        "@swiftpkg_google_cloud_kit//:SecretManager_Sources_SecretManager",
-        "@swiftpkg_google_cloud_kit//:PubSub_Sources_PubSub"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudKit"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudPubSub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:PubSub_Sources_PubSub"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudPubSub"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudSecretManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:SecretManager_Sources_SecretManager"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudSecretManager"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudStorage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:Storage_Sources_Storage"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudStorage"
     },
     {
       "identity": "google-cloud-kit",
       "name": "GoogleCloudTranslation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_google_cloud_kit//:Translation_Sources_Translation"
-      ]
+      "label": "@swiftpkg_google_cloud_kit//:GoogleCloudTranslation"
     },
     {
       "identity": "grpc-swift",
       "name": "GRPC",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_grpc_swift//:Sources_GRPC"
-      ]
+      "label": "@swiftpkg_grpc_swift//:GRPC"
     },
     {
       "identity": "grpc-swift",
       "name": "protoc-gen-grpc-swift",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_grpc_swift//:Sources_protoc-gen-grpc-swift"
-      ]
+      "label": "@swiftpkg_grpc_swift//:protoc-gen-grpc-swift"
     },
     {
       "identity": "gzipswift",
       "name": "Gzip",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_gzipswift//:Sources_Gzip"
-      ]
+      "label": "@swiftpkg_gzipswift//:Gzip"
     },
     {
       "identity": "hypertextapplicationlanguage",
       "name": "HypertextApplicationLanguage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_hypertextapplicationlanguage//:Sources_HypertextApplicationLanguage"
-      ]
+      "label": "@swiftpkg_hypertextapplicationlanguage//:HypertextApplicationLanguage"
     },
     {
       "identity": "jwt-kit",
       "name": "JWTKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_jwt_kit//:Sources_JWTKit"
-      ]
+      "label": "@swiftpkg_jwt_kit//:JWTKit"
     },
     {
       "identity": "mobius.swift",
       "name": "MobiusCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_mobius.swift//:MobiusCore_Source_MobiusCore"
-      ]
+      "label": "@swiftpkg_mobius.swift//:MobiusCore"
     },
     {
       "identity": "mobius.swift",
       "name": "MobiusExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_mobius.swift//:MobiusExtras_Source_MobiusExtras"
-      ]
+      "label": "@swiftpkg_mobius.swift//:MobiusExtras"
     },
     {
       "identity": "mobius.swift",
       "name": "MobiusNimble",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_mobius.swift//:MobiusNimble_Source_MobiusNimble"
-      ]
+      "label": "@swiftpkg_mobius.swift//:MobiusNimble"
     },
     {
       "identity": "mobius.swift",
       "name": "MobiusTest",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_mobius.swift//:MobiusTest_Source_MobiusTest"
-      ]
+      "label": "@swiftpkg_mobius.swift//:MobiusTest"
     },
     {
       "identity": "multipart-kit",
       "name": "MultipartKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_multipart_kit//:Sources_MultipartKit"
-      ]
+      "label": "@swiftpkg_multipart_kit//:MultipartKit"
     },
     {
       "identity": "nimble",
       "name": "Nimble",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_nimble//:Sources_Nimble"
-      ]
+      "label": "@swiftpkg_nimble//:Nimble"
     },
     {
       "identity": "pathkit",
       "name": "PathKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_pathkit//:Sources_PathKit"
-      ]
+      "label": "@swiftpkg_pathkit//:PathKit"
     },
     {
       "identity": "perfect-iniparser",
       "name": "INIParser",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_perfect_iniparser//:Sources_INIParser"
-      ]
+      "label": "@swiftpkg_perfect_iniparser//:INIParser"
     },
     {
       "identity": "postgres-kit",
       "name": "PostgresKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_postgres_kit//:Sources_PostgresKit"
-      ]
+      "label": "@swiftpkg_postgres_kit//:PostgresKit"
     },
     {
       "identity": "postgres-nio",
       "name": "PostgresNIO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_postgres_nio//:Sources_PostgresNIO"
-      ]
+      "label": "@swiftpkg_postgres_nio//:PostgresNIO"
     },
     {
       "identity": "queues-redis-driver",
       "name": "QueuesRedisDriver",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_queues_redis_driver//:Sources_QueuesRedisDriver"
-      ]
+      "label": "@swiftpkg_queues_redis_driver//:QueuesRedisDriver"
     },
     {
       "identity": "queues",
       "name": "Queues",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_queues//:Sources_Queues"
-      ]
+      "label": "@swiftpkg_queues//:Queues"
     },
     {
       "identity": "queues",
       "name": "XCTQueues",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_queues//:Sources_XCTQueues"
-      ]
+      "label": "@swiftpkg_queues//:XCTQueues"
     },
     {
       "identity": "quick",
       "name": "Quick",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_quick//:Sources_Quick"
-      ]
+      "label": "@swiftpkg_quick//:Quick"
     },
     {
       "identity": "redistack",
       "name": "RediStack",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_redistack//:Sources_RediStack"
-      ]
+      "label": "@swiftpkg_redistack//:RediStack"
     },
     {
       "identity": "redistack",
       "name": "RediStackTestUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_redistack//:Sources_RediStackTestUtils"
-      ]
+      "label": "@swiftpkg_redistack//:RediStackTestUtils"
     },
     {
       "identity": "redistack",
       "name": "RedisTypes",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_redistack//:Sources_RedisTypes"
-      ]
+      "label": "@swiftpkg_redistack//:RedisTypes"
     },
     {
       "identity": "redis",
       "name": "Redis",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_redis//:Sources_Redis"
-      ]
+      "label": "@swiftpkg_redis//:Redis"
     },
     {
       "identity": "routing-kit",
       "name": "RoutingKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_routing_kit//:Sources_RoutingKit"
-      ]
+      "label": "@swiftpkg_routing_kit//:RoutingKit"
     },
     {
       "identity": "soto-core",
       "name": "AWSSDKSwiftCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto_core//:Sources_AWSSDKSwiftCore"
-      ]
+      "label": "@swiftpkg_soto_core//:AWSSDKSwiftCore"
     },
     {
       "identity": "soto",
       "name": "ACM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ACM"
-      ]
+      "label": "@swiftpkg_soto//:ACM"
     },
     {
       "identity": "soto",
       "name": "ACMPCA",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ACMPCA"
-      ]
+      "label": "@swiftpkg_soto//:ACMPCA"
     },
     {
       "identity": "soto",
       "name": "APIGateway",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_APIGateway"
-      ]
+      "label": "@swiftpkg_soto//:APIGateway"
     },
     {
       "identity": "soto",
       "name": "AWSBackup",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AWSBackup"
-      ]
+      "label": "@swiftpkg_soto//:AWSBackup"
     },
     {
       "identity": "soto",
       "name": "AWSDirectoryService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AWSDirectoryService"
-      ]
+      "label": "@swiftpkg_soto//:AWSDirectoryService"
     },
     {
       "identity": "soto",
       "name": "AWSSDKSwift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ACM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ACMPCA",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_APIGateway",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_APIGateway_APIGatewayMiddleware",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AWSBackup",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AWSDirectoryService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AccessAnalyzer",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AlexaForBusiness",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Amplify",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApiGatewayManagementApi",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApiGatewayV2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppConfig",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppMesh",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppStream",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppSync",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Appflow",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationAutoScaling",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationDiscoveryService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationInsights",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Athena",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AugmentedAIRuntime",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AutoScaling",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AutoScalingPlans",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Batch",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Braket",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Budgets",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Chime",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Cloud9",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudDirectory",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudFormation",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudFront",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudHSM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudHSMV2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudSearch",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudSearchDomain",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudTrail",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatch",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatchEvents",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatchLogs",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeArtifact",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeBuild",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeCommit",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeDeploy",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeGuruProfiler",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeGuruReviewer",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodePipeline",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStar",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStarNotifications",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStarconnections",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoIdentity",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoIdentityProvider",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoSync",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Comprehend",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ComprehendMedical",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ComputeOptimizer",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ConfigService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Connect",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ConnectParticipant",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CostExplorer",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CostandUsageReportService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DAX",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DLM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataExchange",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataPipeline",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataSync",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DatabaseMigrationService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Detective",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DeviceFarm",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DirectConnect",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DocDB",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DynamoDB",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DynamoDBStreams",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EBS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EC2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EC2InstanceConnect",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ECR",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ECS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EFS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EKS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ELB",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ELBV2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EMR",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElastiCache",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticBeanstalk",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticInference",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticTranscoder",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticsearchService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EventBridge",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FMS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FSx",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Firehose",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ForecastQueryService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ForecastService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FraudDetector",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GameLift",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Glacier",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_Glacier_GlacierMiddleware",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GlobalAccelerator",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Glue",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Greengrass",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GroundStation",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GuardDuty",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Health",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Honeycode",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IAM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IVS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IdentityStore",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Imagebuilder",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ImportExport",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Inspector",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT1ClickDevicesService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT1ClickProjects",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTAnalytics",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTDataPlane",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTEvents",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTEventsData",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTJobsDataPlane",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTSecureTunneling",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTSiteWise",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTThingsGraph",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KMS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kafka",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kendra",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kinesis",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisAnalytics",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisAnalyticsV2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideo",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoArchivedMedia",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoMedia",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoSignalingChannels",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LakeFormation",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Lambda",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LexModelBuildingService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LexRuntimeService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LicenseManager",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Lightsail",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MQ",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MTurk",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MachineLearning",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Macie",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Macie2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ManagedBlockchain",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceCatalog",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceCommerceAnalytics",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceEntitlementService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceMetering",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaConnect",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaConvert",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaLive",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaPackage",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaPackageVod",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaStore",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaStoreData",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaTailor",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MigrationHub",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MigrationHubConfig",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Mobile",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MobileAnalytics",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Neptune",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_NetworkManager",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_OpsWorks",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_OpsWorksCM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Organizations",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Outposts",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PI",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Personalize",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PersonalizeEvents",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PersonalizeRuntime",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Pinpoint",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PinpointEmail",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PinpointSMSVoice",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Polly",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Pricing",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QLDB",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QLDBSession",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QuickSight",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RAM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RDS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RDSDataService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Redshift",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RedshiftDataAPIService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Rekognition",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ResourceGroups",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ResourceGroupsTaggingAPI",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RoboMaker",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53Domains",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53Resolver",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_S3",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_S3Control",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_S3Control_S3ControlMiddleware",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Middlewares_S3_S3Middleware",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SES",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SESV2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SFN",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SMS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SNS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SQS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSM",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSO",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSOAdmin",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSOOIDC",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_STS",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SWF",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SageMaker",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SageMakerRuntime",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SavingsPlans",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Schemas",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SecretsManager",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SecurityHub",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServerlessApplicationRepository",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceCatalog",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceDiscovery",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceQuotas",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Shield",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Signer",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SimpleDB",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Snowball",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_StorageGateway",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Support",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Synthetics",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Textract",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_TranscribeService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_TranscribeStreamingService",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Transfer",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Translate",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAF",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAFRegional",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAFV2",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkDocs",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkLink",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkMail",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkMailMessageFlow",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkSpaces",
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_XRay"
-      ]
+      "label": "@swiftpkg_soto//:AWSSDKSwift"
     },
     {
       "identity": "soto",
       "name": "AccessAnalyzer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AccessAnalyzer"
-      ]
+      "label": "@swiftpkg_soto//:AccessAnalyzer"
     },
     {
       "identity": "soto",
       "name": "AlexaForBusiness",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AlexaForBusiness"
-      ]
+      "label": "@swiftpkg_soto//:AlexaForBusiness"
     },
     {
       "identity": "soto",
       "name": "Amplify",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Amplify"
-      ]
+      "label": "@swiftpkg_soto//:Amplify"
     },
     {
       "identity": "soto",
       "name": "ApiGatewayManagementApi",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApiGatewayManagementApi"
-      ]
+      "label": "@swiftpkg_soto//:ApiGatewayManagementApi"
     },
     {
       "identity": "soto",
       "name": "ApiGatewayV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApiGatewayV2"
-      ]
+      "label": "@swiftpkg_soto//:ApiGatewayV2"
     },
     {
       "identity": "soto",
       "name": "AppConfig",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppConfig"
-      ]
+      "label": "@swiftpkg_soto//:AppConfig"
     },
     {
       "identity": "soto",
       "name": "AppMesh",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppMesh"
-      ]
+      "label": "@swiftpkg_soto//:AppMesh"
     },
     {
       "identity": "soto",
       "name": "AppStream",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppStream"
-      ]
+      "label": "@swiftpkg_soto//:AppStream"
     },
     {
       "identity": "soto",
       "name": "AppSync",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AppSync"
-      ]
+      "label": "@swiftpkg_soto//:AppSync"
     },
     {
       "identity": "soto",
       "name": "Appflow",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Appflow"
-      ]
+      "label": "@swiftpkg_soto//:Appflow"
     },
     {
       "identity": "soto",
       "name": "ApplicationAutoScaling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationAutoScaling"
-      ]
+      "label": "@swiftpkg_soto//:ApplicationAutoScaling"
     },
     {
       "identity": "soto",
       "name": "ApplicationDiscoveryService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationDiscoveryService"
-      ]
+      "label": "@swiftpkg_soto//:ApplicationDiscoveryService"
     },
     {
       "identity": "soto",
       "name": "ApplicationInsights",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ApplicationInsights"
-      ]
+      "label": "@swiftpkg_soto//:ApplicationInsights"
     },
     {
       "identity": "soto",
       "name": "Athena",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Athena"
-      ]
+      "label": "@swiftpkg_soto//:Athena"
     },
     {
       "identity": "soto",
       "name": "AugmentedAIRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AugmentedAIRuntime"
-      ]
+      "label": "@swiftpkg_soto//:AugmentedAIRuntime"
     },
     {
       "identity": "soto",
       "name": "AutoScaling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AutoScaling"
-      ]
+      "label": "@swiftpkg_soto//:AutoScaling"
     },
     {
       "identity": "soto",
       "name": "AutoScalingPlans",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_AutoScalingPlans"
-      ]
+      "label": "@swiftpkg_soto//:AutoScalingPlans"
     },
     {
       "identity": "soto",
       "name": "Batch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Batch"
-      ]
+      "label": "@swiftpkg_soto//:Batch"
     },
     {
       "identity": "soto",
       "name": "Braket",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Braket"
-      ]
+      "label": "@swiftpkg_soto//:Braket"
     },
     {
       "identity": "soto",
       "name": "Budgets",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Budgets"
-      ]
+      "label": "@swiftpkg_soto//:Budgets"
     },
     {
       "identity": "soto",
       "name": "Chime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Chime"
-      ]
+      "label": "@swiftpkg_soto//:Chime"
     },
     {
       "identity": "soto",
       "name": "Cloud9",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Cloud9"
-      ]
+      "label": "@swiftpkg_soto//:Cloud9"
     },
     {
       "identity": "soto",
       "name": "CloudDirectory",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudDirectory"
-      ]
+      "label": "@swiftpkg_soto//:CloudDirectory"
     },
     {
       "identity": "soto",
       "name": "CloudFormation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudFormation"
-      ]
+      "label": "@swiftpkg_soto//:CloudFormation"
     },
     {
       "identity": "soto",
       "name": "CloudFront",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudFront"
-      ]
+      "label": "@swiftpkg_soto//:CloudFront"
     },
     {
       "identity": "soto",
       "name": "CloudHSM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudHSM"
-      ]
+      "label": "@swiftpkg_soto//:CloudHSM"
     },
     {
       "identity": "soto",
       "name": "CloudHSMV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudHSMV2"
-      ]
+      "label": "@swiftpkg_soto//:CloudHSMV2"
     },
     {
       "identity": "soto",
       "name": "CloudSearch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudSearch"
-      ]
+      "label": "@swiftpkg_soto//:CloudSearch"
     },
     {
       "identity": "soto",
       "name": "CloudSearchDomain",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudSearchDomain"
-      ]
+      "label": "@swiftpkg_soto//:CloudSearchDomain"
     },
     {
       "identity": "soto",
       "name": "CloudTrail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudTrail"
-      ]
+      "label": "@swiftpkg_soto//:CloudTrail"
     },
     {
       "identity": "soto",
       "name": "CloudWatch",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatch"
-      ]
+      "label": "@swiftpkg_soto//:CloudWatch"
     },
     {
       "identity": "soto",
       "name": "CloudWatchEvents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatchEvents"
-      ]
+      "label": "@swiftpkg_soto//:CloudWatchEvents"
     },
     {
       "identity": "soto",
       "name": "CloudWatchLogs",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CloudWatchLogs"
-      ]
+      "label": "@swiftpkg_soto//:CloudWatchLogs"
     },
     {
       "identity": "soto",
       "name": "CodeArtifact",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeArtifact"
-      ]
+      "label": "@swiftpkg_soto//:CodeArtifact"
     },
     {
       "identity": "soto",
       "name": "CodeBuild",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeBuild"
-      ]
+      "label": "@swiftpkg_soto//:CodeBuild"
     },
     {
       "identity": "soto",
       "name": "CodeCommit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeCommit"
-      ]
+      "label": "@swiftpkg_soto//:CodeCommit"
     },
     {
       "identity": "soto",
       "name": "CodeDeploy",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeDeploy"
-      ]
+      "label": "@swiftpkg_soto//:CodeDeploy"
     },
     {
       "identity": "soto",
       "name": "CodeGuruProfiler",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeGuruProfiler"
-      ]
+      "label": "@swiftpkg_soto//:CodeGuruProfiler"
     },
     {
       "identity": "soto",
       "name": "CodeGuruReviewer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeGuruReviewer"
-      ]
+      "label": "@swiftpkg_soto//:CodeGuruReviewer"
     },
     {
       "identity": "soto",
       "name": "CodePipeline",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodePipeline"
-      ]
+      "label": "@swiftpkg_soto//:CodePipeline"
     },
     {
       "identity": "soto",
       "name": "CodeStar",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStar"
-      ]
+      "label": "@swiftpkg_soto//:CodeStar"
     },
     {
       "identity": "soto",
       "name": "CodeStarNotifications",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStarNotifications"
-      ]
+      "label": "@swiftpkg_soto//:CodeStarNotifications"
     },
     {
       "identity": "soto",
       "name": "CodeStarconnections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CodeStarconnections"
-      ]
+      "label": "@swiftpkg_soto//:CodeStarconnections"
     },
     {
       "identity": "soto",
       "name": "CognitoIdentity",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoIdentity"
-      ]
+      "label": "@swiftpkg_soto//:CognitoIdentity"
     },
     {
       "identity": "soto",
       "name": "CognitoIdentityProvider",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoIdentityProvider"
-      ]
+      "label": "@swiftpkg_soto//:CognitoIdentityProvider"
     },
     {
       "identity": "soto",
       "name": "CognitoSync",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CognitoSync"
-      ]
+      "label": "@swiftpkg_soto//:CognitoSync"
     },
     {
       "identity": "soto",
       "name": "Comprehend",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Comprehend"
-      ]
+      "label": "@swiftpkg_soto//:Comprehend"
     },
     {
       "identity": "soto",
       "name": "ComprehendMedical",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ComprehendMedical"
-      ]
+      "label": "@swiftpkg_soto//:ComprehendMedical"
     },
     {
       "identity": "soto",
       "name": "ComputeOptimizer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ComputeOptimizer"
-      ]
+      "label": "@swiftpkg_soto//:ComputeOptimizer"
     },
     {
       "identity": "soto",
       "name": "ConfigService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ConfigService"
-      ]
+      "label": "@swiftpkg_soto//:ConfigService"
     },
     {
       "identity": "soto",
       "name": "Connect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Connect"
-      ]
+      "label": "@swiftpkg_soto//:Connect"
     },
     {
       "identity": "soto",
       "name": "ConnectParticipant",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ConnectParticipant"
-      ]
+      "label": "@swiftpkg_soto//:ConnectParticipant"
     },
     {
       "identity": "soto",
       "name": "CostExplorer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CostExplorer"
-      ]
+      "label": "@swiftpkg_soto//:CostExplorer"
     },
     {
       "identity": "soto",
       "name": "CostandUsageReportService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_CostandUsageReportService"
-      ]
+      "label": "@swiftpkg_soto//:CostandUsageReportService"
     },
     {
       "identity": "soto",
       "name": "DAX",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DAX"
-      ]
+      "label": "@swiftpkg_soto//:DAX"
     },
     {
       "identity": "soto",
       "name": "DLM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DLM"
-      ]
+      "label": "@swiftpkg_soto//:DLM"
     },
     {
       "identity": "soto",
       "name": "DataExchange",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataExchange"
-      ]
+      "label": "@swiftpkg_soto//:DataExchange"
     },
     {
       "identity": "soto",
       "name": "DataPipeline",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataPipeline"
-      ]
+      "label": "@swiftpkg_soto//:DataPipeline"
     },
     {
       "identity": "soto",
       "name": "DataSync",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DataSync"
-      ]
+      "label": "@swiftpkg_soto//:DataSync"
     },
     {
       "identity": "soto",
       "name": "DatabaseMigrationService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DatabaseMigrationService"
-      ]
+      "label": "@swiftpkg_soto//:DatabaseMigrationService"
     },
     {
       "identity": "soto",
       "name": "Detective",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Detective"
-      ]
+      "label": "@swiftpkg_soto//:Detective"
     },
     {
       "identity": "soto",
       "name": "DeviceFarm",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DeviceFarm"
-      ]
+      "label": "@swiftpkg_soto//:DeviceFarm"
     },
     {
       "identity": "soto",
       "name": "DirectConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DirectConnect"
-      ]
+      "label": "@swiftpkg_soto//:DirectConnect"
     },
     {
       "identity": "soto",
       "name": "DocDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DocDB"
-      ]
+      "label": "@swiftpkg_soto//:DocDB"
     },
     {
       "identity": "soto",
       "name": "DynamoDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DynamoDB"
-      ]
+      "label": "@swiftpkg_soto//:DynamoDB"
     },
     {
       "identity": "soto",
       "name": "DynamoDBStreams",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_DynamoDBStreams"
-      ]
+      "label": "@swiftpkg_soto//:DynamoDBStreams"
     },
     {
       "identity": "soto",
       "name": "EBS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EBS"
-      ]
+      "label": "@swiftpkg_soto//:EBS"
     },
     {
       "identity": "soto",
       "name": "EC2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EC2"
-      ]
+      "label": "@swiftpkg_soto//:EC2"
     },
     {
       "identity": "soto",
       "name": "EC2InstanceConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EC2InstanceConnect"
-      ]
+      "label": "@swiftpkg_soto//:EC2InstanceConnect"
     },
     {
       "identity": "soto",
       "name": "ECR",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ECR"
-      ]
+      "label": "@swiftpkg_soto//:ECR"
     },
     {
       "identity": "soto",
       "name": "ECS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ECS"
-      ]
+      "label": "@swiftpkg_soto//:ECS"
     },
     {
       "identity": "soto",
       "name": "EFS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EFS"
-      ]
+      "label": "@swiftpkg_soto//:EFS"
     },
     {
       "identity": "soto",
       "name": "EKS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EKS"
-      ]
+      "label": "@swiftpkg_soto//:EKS"
     },
     {
       "identity": "soto",
       "name": "ELB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ELB"
-      ]
+      "label": "@swiftpkg_soto//:ELB"
     },
     {
       "identity": "soto",
       "name": "ELBV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ELBV2"
-      ]
+      "label": "@swiftpkg_soto//:ELBV2"
     },
     {
       "identity": "soto",
       "name": "EMR",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EMR"
-      ]
+      "label": "@swiftpkg_soto//:EMR"
     },
     {
       "identity": "soto",
       "name": "ElastiCache",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElastiCache"
-      ]
+      "label": "@swiftpkg_soto//:ElastiCache"
     },
     {
       "identity": "soto",
       "name": "ElasticBeanstalk",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticBeanstalk"
-      ]
+      "label": "@swiftpkg_soto//:ElasticBeanstalk"
     },
     {
       "identity": "soto",
       "name": "ElasticInference",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticInference"
-      ]
+      "label": "@swiftpkg_soto//:ElasticInference"
     },
     {
       "identity": "soto",
       "name": "ElasticTranscoder",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticTranscoder"
-      ]
+      "label": "@swiftpkg_soto//:ElasticTranscoder"
     },
     {
       "identity": "soto",
       "name": "ElasticsearchService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ElasticsearchService"
-      ]
+      "label": "@swiftpkg_soto//:ElasticsearchService"
     },
     {
       "identity": "soto",
       "name": "EventBridge",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_EventBridge"
-      ]
+      "label": "@swiftpkg_soto//:EventBridge"
     },
     {
       "identity": "soto",
       "name": "FMS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FMS"
-      ]
+      "label": "@swiftpkg_soto//:FMS"
     },
     {
       "identity": "soto",
       "name": "FSx",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FSx"
-      ]
+      "label": "@swiftpkg_soto//:FSx"
     },
     {
       "identity": "soto",
       "name": "Firehose",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Firehose"
-      ]
+      "label": "@swiftpkg_soto//:Firehose"
     },
     {
       "identity": "soto",
       "name": "ForecastQueryService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ForecastQueryService"
-      ]
+      "label": "@swiftpkg_soto//:ForecastQueryService"
     },
     {
       "identity": "soto",
       "name": "ForecastService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ForecastService"
-      ]
+      "label": "@swiftpkg_soto//:ForecastService"
     },
     {
       "identity": "soto",
       "name": "FraudDetector",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_FraudDetector"
-      ]
+      "label": "@swiftpkg_soto//:FraudDetector"
     },
     {
       "identity": "soto",
       "name": "GameLift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GameLift"
-      ]
+      "label": "@swiftpkg_soto//:GameLift"
     },
     {
       "identity": "soto",
       "name": "Glacier",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Glacier"
-      ]
+      "label": "@swiftpkg_soto//:Glacier"
     },
     {
       "identity": "soto",
       "name": "GlobalAccelerator",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GlobalAccelerator"
-      ]
+      "label": "@swiftpkg_soto//:GlobalAccelerator"
     },
     {
       "identity": "soto",
       "name": "Glue",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Glue"
-      ]
+      "label": "@swiftpkg_soto//:Glue"
     },
     {
       "identity": "soto",
       "name": "Greengrass",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Greengrass"
-      ]
+      "label": "@swiftpkg_soto//:Greengrass"
     },
     {
       "identity": "soto",
       "name": "GroundStation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GroundStation"
-      ]
+      "label": "@swiftpkg_soto//:GroundStation"
     },
     {
       "identity": "soto",
       "name": "GuardDuty",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_GuardDuty"
-      ]
+      "label": "@swiftpkg_soto//:GuardDuty"
     },
     {
       "identity": "soto",
       "name": "Health",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Health"
-      ]
+      "label": "@swiftpkg_soto//:Health"
     },
     {
       "identity": "soto",
       "name": "Honeycode",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Honeycode"
-      ]
+      "label": "@swiftpkg_soto//:Honeycode"
     },
     {
       "identity": "soto",
       "name": "IAM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IAM"
-      ]
+      "label": "@swiftpkg_soto//:IAM"
     },
     {
       "identity": "soto",
       "name": "IVS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IVS"
-      ]
+      "label": "@swiftpkg_soto//:IVS"
     },
     {
       "identity": "soto",
       "name": "IdentityStore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IdentityStore"
-      ]
+      "label": "@swiftpkg_soto//:IdentityStore"
     },
     {
       "identity": "soto",
       "name": "Imagebuilder",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Imagebuilder"
-      ]
+      "label": "@swiftpkg_soto//:Imagebuilder"
     },
     {
       "identity": "soto",
       "name": "ImportExport",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ImportExport"
-      ]
+      "label": "@swiftpkg_soto//:ImportExport"
     },
     {
       "identity": "soto",
       "name": "Inspector",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Inspector"
-      ]
+      "label": "@swiftpkg_soto//:Inspector"
     },
     {
       "identity": "soto",
       "name": "IoT",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT"
-      ]
+      "label": "@swiftpkg_soto//:IoT"
     },
     {
       "identity": "soto",
       "name": "IoT1ClickDevicesService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT1ClickDevicesService"
-      ]
+      "label": "@swiftpkg_soto//:IoT1ClickDevicesService"
     },
     {
       "identity": "soto",
       "name": "IoT1ClickProjects",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoT1ClickProjects"
-      ]
+      "label": "@swiftpkg_soto//:IoT1ClickProjects"
     },
     {
       "identity": "soto",
       "name": "IoTAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:IoTAnalytics"
     },
     {
       "identity": "soto",
       "name": "IoTDataPlane",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTDataPlane"
-      ]
+      "label": "@swiftpkg_soto//:IoTDataPlane"
     },
     {
       "identity": "soto",
       "name": "IoTEvents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTEvents"
-      ]
+      "label": "@swiftpkg_soto//:IoTEvents"
     },
     {
       "identity": "soto",
       "name": "IoTEventsData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTEventsData"
-      ]
+      "label": "@swiftpkg_soto//:IoTEventsData"
     },
     {
       "identity": "soto",
       "name": "IoTJobsDataPlane",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTJobsDataPlane"
-      ]
+      "label": "@swiftpkg_soto//:IoTJobsDataPlane"
     },
     {
       "identity": "soto",
       "name": "IoTSecureTunneling",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTSecureTunneling"
-      ]
+      "label": "@swiftpkg_soto//:IoTSecureTunneling"
     },
     {
       "identity": "soto",
       "name": "IoTSiteWise",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTSiteWise"
-      ]
+      "label": "@swiftpkg_soto//:IoTSiteWise"
     },
     {
       "identity": "soto",
       "name": "IoTThingsGraph",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_IoTThingsGraph"
-      ]
+      "label": "@swiftpkg_soto//:IoTThingsGraph"
     },
     {
       "identity": "soto",
       "name": "KMS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KMS"
-      ]
+      "label": "@swiftpkg_soto//:KMS"
     },
     {
       "identity": "soto",
       "name": "Kafka",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kafka"
-      ]
+      "label": "@swiftpkg_soto//:Kafka"
     },
     {
       "identity": "soto",
       "name": "Kendra",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kendra"
-      ]
+      "label": "@swiftpkg_soto//:Kendra"
     },
     {
       "identity": "soto",
       "name": "Kinesis",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Kinesis"
-      ]
+      "label": "@swiftpkg_soto//:Kinesis"
     },
     {
       "identity": "soto",
       "name": "KinesisAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:KinesisAnalytics"
     },
     {
       "identity": "soto",
       "name": "KinesisAnalyticsV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisAnalyticsV2"
-      ]
+      "label": "@swiftpkg_soto//:KinesisAnalyticsV2"
     },
     {
       "identity": "soto",
       "name": "KinesisVideo",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideo"
-      ]
+      "label": "@swiftpkg_soto//:KinesisVideo"
     },
     {
       "identity": "soto",
       "name": "KinesisVideoArchivedMedia",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoArchivedMedia"
-      ]
+      "label": "@swiftpkg_soto//:KinesisVideoArchivedMedia"
     },
     {
       "identity": "soto",
       "name": "KinesisVideoMedia",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoMedia"
-      ]
+      "label": "@swiftpkg_soto//:KinesisVideoMedia"
     },
     {
       "identity": "soto",
       "name": "KinesisVideoSignalingChannels",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_KinesisVideoSignalingChannels"
-      ]
+      "label": "@swiftpkg_soto//:KinesisVideoSignalingChannels"
     },
     {
       "identity": "soto",
       "name": "LakeFormation",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LakeFormation"
-      ]
+      "label": "@swiftpkg_soto//:LakeFormation"
     },
     {
       "identity": "soto",
       "name": "Lambda",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Lambda"
-      ]
+      "label": "@swiftpkg_soto//:Lambda"
     },
     {
       "identity": "soto",
       "name": "LexModelBuildingService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LexModelBuildingService"
-      ]
+      "label": "@swiftpkg_soto//:LexModelBuildingService"
     },
     {
       "identity": "soto",
       "name": "LexRuntimeService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LexRuntimeService"
-      ]
+      "label": "@swiftpkg_soto//:LexRuntimeService"
     },
     {
       "identity": "soto",
       "name": "LicenseManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_LicenseManager"
-      ]
+      "label": "@swiftpkg_soto//:LicenseManager"
     },
     {
       "identity": "soto",
       "name": "Lightsail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Lightsail"
-      ]
+      "label": "@swiftpkg_soto//:Lightsail"
     },
     {
       "identity": "soto",
       "name": "MQ",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MQ"
-      ]
+      "label": "@swiftpkg_soto//:MQ"
     },
     {
       "identity": "soto",
       "name": "MTurk",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MTurk"
-      ]
+      "label": "@swiftpkg_soto//:MTurk"
     },
     {
       "identity": "soto",
       "name": "MachineLearning",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MachineLearning"
-      ]
+      "label": "@swiftpkg_soto//:MachineLearning"
     },
     {
       "identity": "soto",
       "name": "Macie",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Macie"
-      ]
+      "label": "@swiftpkg_soto//:Macie"
     },
     {
       "identity": "soto",
       "name": "Macie2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Macie2"
-      ]
+      "label": "@swiftpkg_soto//:Macie2"
     },
     {
       "identity": "soto",
       "name": "ManagedBlockchain",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ManagedBlockchain"
-      ]
+      "label": "@swiftpkg_soto//:ManagedBlockchain"
     },
     {
       "identity": "soto",
       "name": "MarketplaceCatalog",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceCatalog"
-      ]
+      "label": "@swiftpkg_soto//:MarketplaceCatalog"
     },
     {
       "identity": "soto",
       "name": "MarketplaceCommerceAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceCommerceAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:MarketplaceCommerceAnalytics"
     },
     {
       "identity": "soto",
       "name": "MarketplaceEntitlementService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceEntitlementService"
-      ]
+      "label": "@swiftpkg_soto//:MarketplaceEntitlementService"
     },
     {
       "identity": "soto",
       "name": "MarketplaceMetering",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MarketplaceMetering"
-      ]
+      "label": "@swiftpkg_soto//:MarketplaceMetering"
     },
     {
       "identity": "soto",
       "name": "MediaConnect",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaConnect"
-      ]
+      "label": "@swiftpkg_soto//:MediaConnect"
     },
     {
       "identity": "soto",
       "name": "MediaConvert",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaConvert"
-      ]
+      "label": "@swiftpkg_soto//:MediaConvert"
     },
     {
       "identity": "soto",
       "name": "MediaLive",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaLive"
-      ]
+      "label": "@swiftpkg_soto//:MediaLive"
     },
     {
       "identity": "soto",
       "name": "MediaPackage",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaPackage"
-      ]
+      "label": "@swiftpkg_soto//:MediaPackage"
     },
     {
       "identity": "soto",
       "name": "MediaPackageVod",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaPackageVod"
-      ]
+      "label": "@swiftpkg_soto//:MediaPackageVod"
     },
     {
       "identity": "soto",
       "name": "MediaStore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaStore"
-      ]
+      "label": "@swiftpkg_soto//:MediaStore"
     },
     {
       "identity": "soto",
       "name": "MediaStoreData",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaStoreData"
-      ]
+      "label": "@swiftpkg_soto//:MediaStoreData"
     },
     {
       "identity": "soto",
       "name": "MediaTailor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MediaTailor"
-      ]
+      "label": "@swiftpkg_soto//:MediaTailor"
     },
     {
       "identity": "soto",
       "name": "MigrationHub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MigrationHub"
-      ]
+      "label": "@swiftpkg_soto//:MigrationHub"
     },
     {
       "identity": "soto",
       "name": "MigrationHubConfig",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MigrationHubConfig"
-      ]
+      "label": "@swiftpkg_soto//:MigrationHubConfig"
     },
     {
       "identity": "soto",
       "name": "Mobile",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Mobile"
-      ]
+      "label": "@swiftpkg_soto//:Mobile"
     },
     {
       "identity": "soto",
       "name": "MobileAnalytics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_MobileAnalytics"
-      ]
+      "label": "@swiftpkg_soto//:MobileAnalytics"
     },
     {
       "identity": "soto",
       "name": "Neptune",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Neptune"
-      ]
+      "label": "@swiftpkg_soto//:Neptune"
     },
     {
       "identity": "soto",
       "name": "NetworkManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_NetworkManager"
-      ]
+      "label": "@swiftpkg_soto//:NetworkManager"
     },
     {
       "identity": "soto",
       "name": "OpsWorks",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_OpsWorks"
-      ]
+      "label": "@swiftpkg_soto//:OpsWorks"
     },
     {
       "identity": "soto",
       "name": "OpsWorksCM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_OpsWorksCM"
-      ]
+      "label": "@swiftpkg_soto//:OpsWorksCM"
     },
     {
       "identity": "soto",
       "name": "Organizations",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Organizations"
-      ]
+      "label": "@swiftpkg_soto//:Organizations"
     },
     {
       "identity": "soto",
       "name": "Outposts",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Outposts"
-      ]
+      "label": "@swiftpkg_soto//:Outposts"
     },
     {
       "identity": "soto",
       "name": "PI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PI"
-      ]
+      "label": "@swiftpkg_soto//:PI"
     },
     {
       "identity": "soto",
       "name": "Personalize",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Personalize"
-      ]
+      "label": "@swiftpkg_soto//:Personalize"
     },
     {
       "identity": "soto",
       "name": "PersonalizeEvents",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PersonalizeEvents"
-      ]
+      "label": "@swiftpkg_soto//:PersonalizeEvents"
     },
     {
       "identity": "soto",
       "name": "PersonalizeRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PersonalizeRuntime"
-      ]
+      "label": "@swiftpkg_soto//:PersonalizeRuntime"
     },
     {
       "identity": "soto",
       "name": "Pinpoint",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Pinpoint"
-      ]
+      "label": "@swiftpkg_soto//:Pinpoint"
     },
     {
       "identity": "soto",
       "name": "PinpointEmail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PinpointEmail"
-      ]
+      "label": "@swiftpkg_soto//:PinpointEmail"
     },
     {
       "identity": "soto",
       "name": "PinpointSMSVoice",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_PinpointSMSVoice"
-      ]
+      "label": "@swiftpkg_soto//:PinpointSMSVoice"
     },
     {
       "identity": "soto",
       "name": "Polly",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Polly"
-      ]
+      "label": "@swiftpkg_soto//:Polly"
     },
     {
       "identity": "soto",
       "name": "Pricing",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Pricing"
-      ]
+      "label": "@swiftpkg_soto//:Pricing"
     },
     {
       "identity": "soto",
       "name": "QLDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QLDB"
-      ]
+      "label": "@swiftpkg_soto//:QLDB"
     },
     {
       "identity": "soto",
       "name": "QLDBSession",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QLDBSession"
-      ]
+      "label": "@swiftpkg_soto//:QLDBSession"
     },
     {
       "identity": "soto",
       "name": "QuickSight",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_QuickSight"
-      ]
+      "label": "@swiftpkg_soto//:QuickSight"
     },
     {
       "identity": "soto",
       "name": "RAM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RAM"
-      ]
+      "label": "@swiftpkg_soto//:RAM"
     },
     {
       "identity": "soto",
       "name": "RDS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RDS"
-      ]
+      "label": "@swiftpkg_soto//:RDS"
     },
     {
       "identity": "soto",
       "name": "RDSDataService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RDSDataService"
-      ]
+      "label": "@swiftpkg_soto//:RDSDataService"
     },
     {
       "identity": "soto",
       "name": "Redshift",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Redshift"
-      ]
+      "label": "@swiftpkg_soto//:Redshift"
     },
     {
       "identity": "soto",
       "name": "RedshiftDataAPIService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RedshiftDataAPIService"
-      ]
+      "label": "@swiftpkg_soto//:RedshiftDataAPIService"
     },
     {
       "identity": "soto",
       "name": "Rekognition",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Rekognition"
-      ]
+      "label": "@swiftpkg_soto//:Rekognition"
     },
     {
       "identity": "soto",
       "name": "ResourceGroups",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ResourceGroups"
-      ]
+      "label": "@swiftpkg_soto//:ResourceGroups"
     },
     {
       "identity": "soto",
       "name": "ResourceGroupsTaggingAPI",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ResourceGroupsTaggingAPI"
-      ]
+      "label": "@swiftpkg_soto//:ResourceGroupsTaggingAPI"
     },
     {
       "identity": "soto",
       "name": "RoboMaker",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_RoboMaker"
-      ]
+      "label": "@swiftpkg_soto//:RoboMaker"
     },
     {
       "identity": "soto",
       "name": "Route53",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53"
-      ]
+      "label": "@swiftpkg_soto//:Route53"
     },
     {
       "identity": "soto",
       "name": "Route53Domains",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53Domains"
-      ]
+      "label": "@swiftpkg_soto//:Route53Domains"
     },
     {
       "identity": "soto",
       "name": "Route53Resolver",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Route53Resolver"
-      ]
+      "label": "@swiftpkg_soto//:Route53Resolver"
     },
     {
       "identity": "soto",
       "name": "S3",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_S3"
-      ]
+      "label": "@swiftpkg_soto//:S3"
     },
     {
       "identity": "soto",
       "name": "S3Control",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_S3Control"
-      ]
+      "label": "@swiftpkg_soto//:S3Control"
     },
     {
       "identity": "soto",
       "name": "SES",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SES"
-      ]
+      "label": "@swiftpkg_soto//:SES"
     },
     {
       "identity": "soto",
       "name": "SESV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SESV2"
-      ]
+      "label": "@swiftpkg_soto//:SESV2"
     },
     {
       "identity": "soto",
       "name": "SFN",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SFN"
-      ]
+      "label": "@swiftpkg_soto//:SFN"
     },
     {
       "identity": "soto",
       "name": "SMS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SMS"
-      ]
+      "label": "@swiftpkg_soto//:SMS"
     },
     {
       "identity": "soto",
       "name": "SNS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SNS"
-      ]
+      "label": "@swiftpkg_soto//:SNS"
     },
     {
       "identity": "soto",
       "name": "SQS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SQS"
-      ]
+      "label": "@swiftpkg_soto//:SQS"
     },
     {
       "identity": "soto",
       "name": "SSM",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSM"
-      ]
+      "label": "@swiftpkg_soto//:SSM"
     },
     {
       "identity": "soto",
       "name": "SSO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSO"
-      ]
+      "label": "@swiftpkg_soto//:SSO"
     },
     {
       "identity": "soto",
       "name": "SSOAdmin",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSOAdmin"
-      ]
+      "label": "@swiftpkg_soto//:SSOAdmin"
     },
     {
       "identity": "soto",
       "name": "SSOOIDC",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SSOOIDC"
-      ]
+      "label": "@swiftpkg_soto//:SSOOIDC"
     },
     {
       "identity": "soto",
       "name": "STS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_STS"
-      ]
+      "label": "@swiftpkg_soto//:STS"
     },
     {
       "identity": "soto",
       "name": "SWF",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SWF"
-      ]
+      "label": "@swiftpkg_soto//:SWF"
     },
     {
       "identity": "soto",
       "name": "SageMaker",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SageMaker"
-      ]
+      "label": "@swiftpkg_soto//:SageMaker"
     },
     {
       "identity": "soto",
       "name": "SageMakerRuntime",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SageMakerRuntime"
-      ]
+      "label": "@swiftpkg_soto//:SageMakerRuntime"
     },
     {
       "identity": "soto",
       "name": "SavingsPlans",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SavingsPlans"
-      ]
+      "label": "@swiftpkg_soto//:SavingsPlans"
     },
     {
       "identity": "soto",
       "name": "Schemas",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Schemas"
-      ]
+      "label": "@swiftpkg_soto//:Schemas"
     },
     {
       "identity": "soto",
       "name": "SecretsManager",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SecretsManager"
-      ]
+      "label": "@swiftpkg_soto//:SecretsManager"
     },
     {
       "identity": "soto",
       "name": "SecurityHub",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SecurityHub"
-      ]
+      "label": "@swiftpkg_soto//:SecurityHub"
     },
     {
       "identity": "soto",
       "name": "ServerlessApplicationRepository",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServerlessApplicationRepository"
-      ]
+      "label": "@swiftpkg_soto//:ServerlessApplicationRepository"
     },
     {
       "identity": "soto",
       "name": "ServiceCatalog",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceCatalog"
-      ]
+      "label": "@swiftpkg_soto//:ServiceCatalog"
     },
     {
       "identity": "soto",
       "name": "ServiceDiscovery",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceDiscovery"
-      ]
+      "label": "@swiftpkg_soto//:ServiceDiscovery"
     },
     {
       "identity": "soto",
       "name": "ServiceQuotas",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_ServiceQuotas"
-      ]
+      "label": "@swiftpkg_soto//:ServiceQuotas"
     },
     {
       "identity": "soto",
       "name": "Shield",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Shield"
-      ]
+      "label": "@swiftpkg_soto//:Shield"
     },
     {
       "identity": "soto",
       "name": "Signer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Signer"
-      ]
+      "label": "@swiftpkg_soto//:Signer"
     },
     {
       "identity": "soto",
       "name": "SimpleDB",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_SimpleDB"
-      ]
+      "label": "@swiftpkg_soto//:SimpleDB"
     },
     {
       "identity": "soto",
       "name": "Snowball",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Snowball"
-      ]
+      "label": "@swiftpkg_soto//:Snowball"
     },
     {
       "identity": "soto",
       "name": "StorageGateway",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_StorageGateway"
-      ]
+      "label": "@swiftpkg_soto//:StorageGateway"
     },
     {
       "identity": "soto",
       "name": "Support",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Support"
-      ]
+      "label": "@swiftpkg_soto//:Support"
     },
     {
       "identity": "soto",
       "name": "Synthetics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Synthetics"
-      ]
+      "label": "@swiftpkg_soto//:Synthetics"
     },
     {
       "identity": "soto",
       "name": "Textract",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Textract"
-      ]
+      "label": "@swiftpkg_soto//:Textract"
     },
     {
       "identity": "soto",
       "name": "TranscribeService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_TranscribeService"
-      ]
+      "label": "@swiftpkg_soto//:TranscribeService"
     },
     {
       "identity": "soto",
       "name": "TranscribeStreamingService",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_TranscribeStreamingService"
-      ]
+      "label": "@swiftpkg_soto//:TranscribeStreamingService"
     },
     {
       "identity": "soto",
       "name": "Transfer",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Transfer"
-      ]
+      "label": "@swiftpkg_soto//:Transfer"
     },
     {
       "identity": "soto",
       "name": "Translate",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_Translate"
-      ]
+      "label": "@swiftpkg_soto//:Translate"
     },
     {
       "identity": "soto",
       "name": "WAF",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAF"
-      ]
+      "label": "@swiftpkg_soto//:WAF"
     },
     {
       "identity": "soto",
       "name": "WAFRegional",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAFRegional"
-      ]
+      "label": "@swiftpkg_soto//:WAFRegional"
     },
     {
       "identity": "soto",
       "name": "WAFV2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WAFV2"
-      ]
+      "label": "@swiftpkg_soto//:WAFV2"
     },
     {
       "identity": "soto",
       "name": "WorkDocs",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkDocs"
-      ]
+      "label": "@swiftpkg_soto//:WorkDocs"
     },
     {
       "identity": "soto",
       "name": "WorkLink",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkLink"
-      ]
+      "label": "@swiftpkg_soto//:WorkLink"
     },
     {
       "identity": "soto",
       "name": "WorkMail",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkMail"
-      ]
+      "label": "@swiftpkg_soto//:WorkMail"
     },
     {
       "identity": "soto",
       "name": "WorkMailMessageFlow",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkMailMessageFlow"
-      ]
+      "label": "@swiftpkg_soto//:WorkMailMessageFlow"
     },
     {
       "identity": "soto",
       "name": "WorkSpaces",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_WorkSpaces"
-      ]
+      "label": "@swiftpkg_soto//:WorkSpaces"
     },
     {
       "identity": "soto",
       "name": "XRay",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_soto//:Sources_AWSSDKSwift_Services_XRay"
-      ]
+      "label": "@swiftpkg_soto//:XRay"
     },
     {
       "identity": "spectre",
       "name": "Spectre",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_spectre//:Sources_Spectre"
-      ]
+      "label": "@swiftpkg_spectre//:Spectre"
     },
     {
       "identity": "sql-kit",
       "name": "SQLKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sql_kit//:Sources_SQLKit"
-      ]
+      "label": "@swiftpkg_sql_kit//:SQLKit"
     },
     {
       "identity": "sql-kit",
       "name": "SQLKitBenchmark",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_sql_kit//:Sources_SQLKitBenchmark"
-      ]
+      "label": "@swiftpkg_sql_kit//:SQLKitBenchmark"
     },
     {
       "identity": "swift-algorithms",
       "name": "Algorithms",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_algorithms//:Sources_Algorithms"
-      ]
+      "label": "@swiftpkg_swift_algorithms//:Algorithms"
     },
     {
       "identity": "swift-argument-parser",
       "name": "ArgumentParser",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_argument_parser//:Sources_ArgumentParser"
-      ]
+      "label": "@swiftpkg_swift_argument_parser//:ArgumentParser"
     },
     {
       "identity": "swift-argument-parser",
       "name": "GenerateManual",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_swift_argument_parser//:Plugins_GenerateManual"
-      ]
+      "label": "@swiftpkg_swift_argument_parser//:GenerateManual"
     },
     {
       "identity": "swift-atomics",
       "name": "Atomics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_atomics//:Sources_Atomics"
-      ]
+      "label": "@swiftpkg_swift_atomics//:Atomics"
     },
     {
       "identity": "swift-backtrace",
       "name": "Backtrace",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_backtrace//:Sources_Backtrace"
-      ]
+      "label": "@swiftpkg_swift_backtrace//:Backtrace"
     },
     {
       "identity": "swift-collections",
       "name": "Collections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_Collections"
-      ]
+      "label": "@swiftpkg_swift_collections//:Collections"
     },
     {
       "identity": "swift-collections",
       "name": "DequeModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_DequeModule"
-      ]
+      "label": "@swiftpkg_swift_collections//:DequeModule"
     },
     {
       "identity": "swift-collections",
       "name": "OrderedCollections",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_collections//:Sources_OrderedCollections"
-      ]
+      "label": "@swiftpkg_swift_collections//:OrderedCollections"
     },
     {
       "identity": "swift-crypto",
       "name": "Crypto",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_crypto//:Sources_Crypto"
-      ]
+      "label": "@swiftpkg_swift_crypto//:Crypto"
     },
     {
       "identity": "swift-crypto",
       "name": "_CryptoExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_crypto//:Sources__CryptoExtras"
-      ]
+      "label": "@swiftpkg_swift_crypto//:_CryptoExtras"
     },
     {
       "identity": "swift-log",
       "name": "Logging",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_log//:Sources_Logging"
-      ]
+      "label": "@swiftpkg_swift_log//:Logging"
     },
     {
       "identity": "swift-metrics",
       "name": "CoreMetrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_CoreMetrics"
-      ]
+      "label": "@swiftpkg_swift_metrics//:CoreMetrics"
     },
     {
       "identity": "swift-metrics",
       "name": "Metrics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_Metrics"
-      ]
+      "label": "@swiftpkg_swift_metrics//:Metrics"
     },
     {
       "identity": "swift-metrics",
       "name": "MetricsTestKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_metrics//:Sources_MetricsTestKit"
-      ]
+      "label": "@swiftpkg_swift_metrics//:MetricsTestKit"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOExtras",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOExtras"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOExtras"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOHTTPCompression",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOHTTPCompression"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOHTTPCompression"
     },
     {
       "identity": "swift-nio-extras",
       "name": "NIOSOCKS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_extras//:Sources_NIOSOCKS"
-      ]
+      "label": "@swiftpkg_swift_nio_extras//:NIOSOCKS"
     },
     {
       "identity": "swift-nio-http2",
       "name": "NIOHTTP2",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_http2//:Sources_NIOHTTP2"
-      ]
+      "label": "@swiftpkg_swift_nio_http2//:NIOHTTP2"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOSSL",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOSSL"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSL"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOSSLHTTP1Client",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOSSLHTTP1Client"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOSSLHTTP1Client"
     },
     {
       "identity": "swift-nio-ssl",
       "name": "NIOTLSServer",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_nio_ssl//:Sources_NIOTLSServer"
-      ]
+      "label": "@swiftpkg_swift_nio_ssl//:NIOTLSServer"
     },
     {
       "identity": "swift-nio-transport-services",
       "name": "NIOTransportServices",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio_transport_services//:Sources_NIOTransportServices"
-      ]
+      "label": "@swiftpkg_swift_nio_transport_services//:NIOTransportServices"
     },
     {
       "identity": "swift-nio",
       "name": "NIO",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIO"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIO"
     },
     {
       "identity": "swift-nio",
       "name": "NIOConcurrencyHelpers",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOConcurrencyHelpers"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOConcurrencyHelpers"
     },
     {
       "identity": "swift-nio",
       "name": "NIOCore",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOCore"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOCore"
     },
     {
       "identity": "swift-nio",
       "name": "NIOEmbedded",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOEmbedded"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOEmbedded"
     },
     {
       "identity": "swift-nio",
       "name": "NIOFoundationCompat",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOFoundationCompat"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOFoundationCompat"
     },
     {
       "identity": "swift-nio",
       "name": "NIOHTTP1",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOHTTP1"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOHTTP1"
     },
     {
       "identity": "swift-nio",
       "name": "NIOPosix",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOPosix"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOPosix"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTLS",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTLS"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTLS"
     },
     {
       "identity": "swift-nio",
       "name": "NIOTestUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOTestUtils"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOTestUtils"
     },
     {
       "identity": "swift-nio",
       "name": "NIOWebSocket",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources_NIOWebSocket"
-      ]
+      "label": "@swiftpkg_swift_nio//:NIOWebSocket"
     },
     {
       "identity": "swift-nio",
       "name": "_NIOConcurrency",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_nio//:Sources__NIOConcurrency"
-      ]
+      "label": "@swiftpkg_swift_nio//:_NIOConcurrency"
     },
     {
       "identity": "swift-numerics",
       "name": "ComplexModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_numerics//:Sources_ComplexModule"
-      ]
+      "label": "@swiftpkg_swift_numerics//:ComplexModule"
     },
     {
       "identity": "swift-numerics",
       "name": "Numerics",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_numerics//:Sources_Numerics"
-      ]
+      "label": "@swiftpkg_swift_numerics//:Numerics"
     },
     {
       "identity": "swift-numerics",
       "name": "RealModule",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_numerics//:Sources_RealModule"
-      ]
+      "label": "@swiftpkg_swift_numerics//:RealModule"
     },
     {
       "identity": "swift-protobuf",
       "name": "SwiftProtobuf",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Sources_SwiftProtobuf"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobuf"
     },
     {
       "identity": "swift-protobuf",
       "name": "SwiftProtobufPlugin",
       "type": "plugin",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Plugins_SwiftProtobufPlugin"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPlugin"
     },
     {
       "identity": "swift-protobuf",
       "name": "SwiftProtobufPluginLibrary",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Sources_SwiftProtobufPluginLibrary"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:SwiftProtobufPluginLibrary"
     },
     {
       "identity": "swift-protobuf",
       "name": "protoc-gen-swift",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_swift_protobuf//:Sources_protoc-gen-swift"
-      ]
+      "label": "@swiftpkg_swift_protobuf//:protoc-gen-swift"
     },
     {
       "identity": "vapor",
       "name": "Vapor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_vapor//:Sources_Vapor"
-      ]
+      "label": "@swiftpkg_vapor//:Vapor"
     },
     {
       "identity": "vapor",
       "name": "XCTVapor",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_vapor//:Sources_XCTVapor"
-      ]
+      "label": "@swiftpkg_vapor//:XCTVapor"
     },
     {
       "identity": "websocket-kit",
       "name": "WebSocketKit",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_websocket_kit//:Sources_WebSocketKit"
-      ]
+      "label": "@swiftpkg_websocket_kit//:WebSocketKit"
     },
     {
       "identity": "xclogparser",
       "name": "XCLogParser",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_xclogparser//:Sources_XCLogParser"
-      ]
+      "label": "@swiftpkg_xclogparser//:XCLogParser"
     },
     {
       "identity": "xclogparser",
       "name": "xclogparser",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_xclogparser//:Sources_XCLogParserApp"
-      ]
+      "label": "@swiftpkg_xclogparser//:xclogparser"
     },
     {
       "identity": "xcmetrics",
       "name": "XCMetrics",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_xcmetrics//:Sources_XCMetricsApp"
-      ]
+      "label": "@swiftpkg_xcmetrics//:XCMetrics"
     },
     {
       "identity": "xcmetrics",
       "name": "XCMetricsBackend",
       "type": "executable",
-      "target_labels": [
-        "@swiftpkg_xcmetrics//:Sources_XCMetricsBackend"
-      ]
+      "label": "@swiftpkg_xcmetrics//:XCMetricsBackend"
     },
     {
       "identity": "xcmetrics",
       "name": "XCMetricsClient",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_xcmetrics//:Sources_XCMetricsClient"
-      ]
+      "label": "@swiftpkg_xcmetrics//:XCMetricsClient"
     },
     {
       "identity": "xcmetrics",
       "name": "XCMetricsPlugins",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_xcmetrics//:Sources_XCMetricsPlugins"
-      ]
+      "label": "@swiftpkg_xcmetrics//:XCMetricsPlugins"
     },
     {
       "identity": "xcmetrics",
       "name": "XCMetricsUtils",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_xcmetrics//:Sources_XCMetricsUtils"
-      ]
+      "label": "@swiftpkg_xcmetrics//:XCMetricsUtils"
     },
     {
       "identity": "yams",
       "name": "Yams",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_yams//:Sources_Yams"
-      ]
+      "label": "@swiftpkg_yams//:Yams"
     }
   ],
   "packages": [

--- a/gazelle/internal/reslog/rule_resolution_summary.go
+++ b/gazelle/internal/reslog/rule_resolution_summary.go
@@ -37,17 +37,14 @@ func moduleLabelCompare(a, b ModuleLabel) int {
 type Product struct {
 	Identity string
 	Name     string
-	Labels   []string
+	Label    string
 }
 
 func newProductFromSwiftProduct(p *swift.Product) Product {
 	prd := Product{
 		Identity: p.Identity,
 		Name:     p.Name,
-		Labels:   make([]string, len(p.TargetLabels)),
-	}
-	for idx, l := range p.TargetLabels {
-		prd.Labels[idx] = l.String()
+		Label:    p.Label.String(),
 	}
 	return prd
 }

--- a/gazelle/internal/reslog/rule_resolution_test.go
+++ b/gazelle/internal/reslog/rule_resolution_test.go
@@ -25,7 +25,6 @@ func TestRuleResolution(t *testing.T) {
 		"LocalA",
 		"LocalB",
 		"ExternalA",
-		"ExternalB",
 		"Custom",
 		"Unresolved",
 	}
@@ -43,10 +42,7 @@ func TestRuleResolution(t *testing.T) {
 				"awesome-repo",
 				"AwesomeProduct",
 				swift.LibraryProductType,
-				[]*label.Label{
-					newLabel("swiftpkg_awesome_repo", "path/to", "ExternalA"),
-					newLabel("swiftpkg_awesome_repo", "path/to", "ExternalB"),
-				},
+				newLabel("swiftpkg_awesome_repo", "path/to", "ExternalA"),
 			),
 		},
 		Unresolved: []string{"Custom", "Unresolved"},
@@ -67,7 +63,6 @@ func TestRuleResolution(t *testing.T) {
 		"//path/to:LocalA",
 		"//path/to:LocalB",
 		"@swiftpkg_awesome_repo//path/to:ExternalA",
-		"@swiftpkg_awesome_repo//path/to:ExternalB",
 		"@com_github_example_custom//:Custom",
 	)
 
@@ -77,7 +72,6 @@ func TestRuleResolution(t *testing.T) {
 		Imports: []string{
 			"Custom",
 			"ExternalA",
-			"ExternalB",
 			"LocalA",
 			"LocalB",
 			"UIKit",
@@ -91,10 +85,7 @@ func TestRuleResolution(t *testing.T) {
 		ExtRes: reslog.ExternalResolutionSummary{
 			Modules: []string{"ExternalA", "ExternalB"},
 			Products: []reslog.Product{
-				{"awesome-repo", "AwesomeProduct", []string{
-					"@swiftpkg_awesome_repo//path/to:ExternalA",
-					"@swiftpkg_awesome_repo//path/to:ExternalB",
-				}},
+				{"awesome-repo", "AwesomeProduct", "@swiftpkg_awesome_repo//path/to:ExternalA"},
 			},
 			Unresolved: []string{"Custom", "Unresolved"},
 		},
@@ -107,7 +98,6 @@ func TestRuleResolution(t *testing.T) {
 			"//path/to:LocalB",
 			"@com_github_example_custom//:Custom",
 			"@swiftpkg_awesome_repo//path/to:ExternalA",
-			"@swiftpkg_awesome_repo//path/to:ExternalB",
 		},
 	}
 	assert.Equal(t, expected, rr.Summary())

--- a/gazelle/internal/swift/bazel_label.go
+++ b/gazelle/internal/swift/bazel_label.go
@@ -1,29 +1,18 @@
 package swift
 
 import (
-	"path"
-	"strings"
-
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/cgrindel/rules_swift_package_manager/gazelle/internal/swiftpkg"
 )
 
 const modulemapLabelNameSuffix = "_modulemap"
+const targetLabelNameSuffix = ".rspm"
 
 // BazelLabelFromTarget creates a Bazel label from a Swift target.
 // The logic in this function must stay in sync with
 // pkginfo_targets.bazel_label_name_from_parts() in the Starlark code.
 func BazelLabelFromTarget(repoName string, target *swiftpkg.Target) *label.Label {
-	var name string
-	basename := path.Base(target.Path)
-	dirname := path.Dir(target.Path)
-	if basename == target.Name && dirname != "." {
-		name = target.Path
-	} else {
-		name = path.Join(target.Path, target.Name)
-	}
-	name = strings.ReplaceAll(name, "/", "_")
-	lbl := label.New(repoName, "", name)
+	lbl := label.New(repoName, "", target.Name+targetLabelNameSuffix)
 	return &lbl
 }
 

--- a/gazelle/internal/swift/bazel_label_test.go
+++ b/gazelle/internal/swift/bazel_label_test.go
@@ -22,14 +22,14 @@ func TestBazelLabelFromTarget(t *testing.T) {
 			repoName:   "example_cool_repo",
 			targetName: "Foo",
 			targetPath: "Sources/Foo",
-			exp:        "@example_cool_repo//:Sources_Foo",
+			exp:        "@example_cool_repo//:Foo.rspm",
 		},
 		{
 			msg:        "simple path",
 			repoName:   "example_cool_repo",
 			targetName: "simple_path",
 			targetPath: "simple_path",
-			exp:        "@example_cool_repo//:simple_path_simple_path",
+			exp:        "@example_cool_repo//:simple_path.rspm",
 		},
 	}
 	for _, tt := range tests {

--- a/gazelle/internal/swift/dependency_index_test.go
+++ b/gazelle/internal/swift/dependency_index_test.go
@@ -74,7 +74,7 @@ func TestDependencyIndex(t *testing.T) {
 		awesomeRepoId,
 		fooPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{fooM.Label},
+		fooM.Label,
 	)
 	// Product: Bar
 	// Label: BarM
@@ -83,7 +83,7 @@ func TestDependencyIndex(t *testing.T) {
 		awesomeRepoId,
 		barPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{barM.Label},
+		barM.Label,
 	)
 	// Product: Baz
 	// Label: BazM
@@ -92,7 +92,7 @@ func TestDependencyIndex(t *testing.T) {
 		awesomeRepoId,
 		bazPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{bazM.Label, fooM.Label},
+		bazM.Label,
 	)
 	// Product: Other
 	// Label: OtherM
@@ -101,7 +101,7 @@ func TestDependencyIndex(t *testing.T) {
 		awesomeRepoId,
 		otherPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{otherM.Label},
+		otherM.Label,
 	)
 
 	// Looks similar to Foo in awesome-repo.
@@ -125,7 +125,7 @@ func TestDependencyIndex(t *testing.T) {
 		anotherRepoID,
 		fooPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{anotherFooM.Label},
+		anotherFooM.Label,
 	)
 
 	directIdentities := []string{awesomeRepoId}

--- a/gazelle/internal/swift/product_index_test.go
+++ b/gazelle/internal/swift/product_index_test.go
@@ -9,21 +9,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var farmPoultryChickenLabel = label.New("farm", "poultry", "Chicken")
-var farmPoultryHenLabel = label.New("farm", "poultry", "Hen")
+var farmPoultryLabel = label.New("farm", "poultry", "Poultry")
 var zooPoultryLabel = label.New("zoo", "", "Poultry")
 
 var poultryP = swift.NewProduct(
 	"farm",
 	"Poultry",
 	swift.LibraryProductType,
-	[]*label.Label{&farmPoultryChickenLabel, &farmPoultryHenLabel},
+	&farmPoultryLabel,
 )
 var anotherPoultryP = swift.NewProduct(
 	"zoo",
 	"Poultry",
 	swift.LibraryProductType,
-	[]*label.Label{&zooPoultryLabel},
+	&zooPoultryLabel,
 )
 var productIndex = make(swift.ProductIndex)
 

--- a/gazelle/internal/swift/product_test.go
+++ b/gazelle/internal/swift/product_test.go
@@ -26,25 +26,24 @@ func TestProducts(t *testing.T) {
 	awesomeRepoId := "awesome-repo"
 	fooPrdName := "Foo"
 	barPrdName := "Bar"
-	fooCoreLabel := label.New("swiftpkg_awesome_repo", "", "Sources_FooCore")
-	fooLabel := label.New("swiftpkg_awesome_repo", "", "Sources_Foo")
-	barLabel := label.New("swiftpkg_awesome_repo", "", "Sources_Bar")
+	fooLabel := label.New("swiftpkg_awesome_repo", "", "Foo")
+	barLabel := label.New("swiftpkg_awesome_repo", "", "Bar")
 	fooPrd := swift.NewProduct(
 		awesomeRepoId,
 		fooPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{&fooCoreLabel, &fooLabel},
+		&fooLabel,
 	)
 	barPrd := swift.NewProduct(
 		awesomeRepoId,
 		barPrdName,
 		swift.LibraryProductType,
-		[]*label.Label{&fooCoreLabel, &barLabel},
+		&barLabel,
 	)
 	products := swift.Products{fooPrd, barPrd}
 
 	t.Run("labels", func(t *testing.T) {
-		expected := mapset.NewSet[*label.Label](&barLabel, &fooLabel, &fooCoreLabel)
+		expected := mapset.NewSet[*label.Label](&fooLabel, &barLabel)
 		assert.Equal(t, expected, products.Labels())
 	})
 }

--- a/swiftpkg/internal/deps_indexes.bzl
+++ b/swiftpkg/internal/deps_indexes.bzl
@@ -119,18 +119,15 @@ def _new_product_from_dict(prd_dict):
         identity = prd_dict["identity"],
         name = prd_dict["name"],
         type = prd_dict["type"],
-        target_labels = [
-            bazel_labels.parse(lbl_str)
-            for lbl_str in prd_dict["target_labels"]
-        ],
+        label = bazel_labels.parse(prd_dict["label"]),
     )
 
-def _new_product(identity, name, type, target_labels):
+def _new_product(identity, name, type, label):
     return struct(
         identity = identity,
         name = name,
         type = type,
-        target_labels = target_labels,
+        label = label,
     )
 
 def _new_package(identity, name, remote_pkg = None, local_pkg = None):
@@ -261,8 +258,7 @@ def _modules_for_product(deps_index, product):
         A `list` of the modules associated with the product.
     """
     return lists.flatten(lists.compact([
-        _get_module(deps_index, label)
-        for label in product.target_labels
+        _get_module(deps_index, product.label),
     ]))
 
 def _resolve_module(
@@ -344,10 +340,7 @@ def _resolve_product(
         preferred_repo_name = bazel_repo_names.normalize(preferred_repo_name)
         product = lists.find(
             products,
-            lambda p: lists.contains(
-                p.target_labels,
-                lambda tl: tl.repository_name == preferred_repo_name,
-            ),
+            lambda p: p.label.repository_name == preferred_repo_name,
         )
         if product != None:
             return product
@@ -362,10 +355,7 @@ def _resolve_product(
         products = [
             p
             for p in products
-            if lists.contains(
-                p.target_labels,
-                lambda tl: sets.contains(repo_names, tl.repository_name),
-            )
+            if sets.contains(repo_names, p.label.repository_name)
         ]
 
     if len(products) == 0:

--- a/swiftpkg/internal/pkginfo_targets.bzl
+++ b/swiftpkg/internal/pkginfo_targets.bzl
@@ -74,7 +74,7 @@ def _join_path_from_parts(target_path, path):
     return paths.join(target_path, path)
 
 def _join_path(target, path):
-    """Joins the provide path with that target.path. 
+    """Joins the provide path with that target.path.
 
     If the target path is `.`, then the path input is returned without
     modification.
@@ -88,31 +88,19 @@ def _join_path(target, path):
     """
     return _join_path_from_parts(target.path, path)
 
-def _bazel_label_name_from_parts(target_path, target_name):
-    """Create a Bazel label name from a target path and name.
+def _bazel_label_name_from_parts(target_name):
+    """Create a Bazel label name from a target name.
 
     The logic in this function must stay in sync with BazelLabelFromTarget() in
     bazel_label.go.
 
     Args:
-        target_path: The target's path as a `string`.
         target_name: The target's name as a `string`.
 
     Returns:
         A Bazel label name as a `string`.
     """
-    basename = paths.basename(target_path)
-    dirname = paths.dirname(target_path)
-
-    # We are trying to construct the shortest, unique target name. We need to
-    # be sure that a target label does not conflict with a product label with
-    # the same name.
-    if basename == target_name and dirname != "":
-        name = target_path
-    else:
-        name = _join_path_from_parts(target_path, target_name)
-
-    return name.replace("/", "_")
+    return target_name + ".rspm"
 
 def _bazel_label_name(target):
     """Returns the name of the Bazel label for the specified target.
@@ -123,7 +111,7 @@ def _bazel_label_name(target):
     Returns:
         A `string` representing the Bazel label name.
     """
-    return _bazel_label_name_from_parts(target.path, target.name)
+    return _bazel_label_name_from_parts(target.name)
 
 def _modulemap_label_name(target_name):
     """Returns the name of the related `generate_modulemap` target.
@@ -227,11 +215,10 @@ def make_pkginfo_targets(bazel_labels):
         A `struct` representing the `pkginfo_targets` module.
     """
 
-    def _bazel_label_from_parts(target_path, target_name, repo_name = None):
+    def _bazel_label_from_parts(target_name, repo_name = None):
         """Create a Bazel label string from a target information.
 
         Args:
-            target_path: The target's path as a `string`.
             target_name: The target's name as a `string`.
             repo_name: The name of the repository as a `string`. This must be
                 provided if the module is being used outside of a BUILD thread.
@@ -243,7 +230,7 @@ def make_pkginfo_targets(bazel_labels):
         return bazel_labels.new(
             repository_name = repo_name,
             package = "",
-            name = _bazel_label_name_from_parts(target_path, target_name),
+            name = _bazel_label_name_from_parts(target_name),
         )
 
     def _bazel_label(target, repo_name = None):

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -200,7 +200,6 @@ def _new_target_from_json_maps(
     target_name = dump_map["name"]
     target_path = desc_map["path"]
     target_label = pkginfo_targets.bazel_label_from_parts(
-        target_path = target_path,
         target_name = target_name,
         repo_name = repo_name,
     )
@@ -1077,7 +1076,6 @@ def _new_target(
         fail("Need to specify `label` or `repo_name`.")
     if label == None:
         label = pkginfo_targets.bazel_label_from_parts(
-            target_path = path,
             target_name = name,
             repo_name = repo_name,
         )

--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -98,7 +98,7 @@ def _gen_build_files(repository_ctx, pkg_ctx):
         bld_files.append(bld_file)
 
     # Create Bazel declarations for the targets
-    bld_files.append(swiftpkg_build_files.new_for_products(pkg_info, pkg_ctx.repo_name))
+    bld_files.append(swiftpkg_build_files.new_for_products(pkg_ctx))
 
     # Write the build file
     root_bld_file = build_files.merge(*bld_files)

--- a/swiftpkg/tests/deps_indexes_tests.bzl
+++ b/swiftpkg/tests/deps_indexes_tests.bzl
@@ -426,26 +426,19 @@ _deps_index_json = """
             "identity": "swift-argument-parser",
             "name": "ArgumentParser",
             "type": "library",
-            "target_labels": [
-                "@apple_swift_argument_parser//Sources/ArgumentParser"
-            ]
+            "label": "@apple_swift_argument_parser//ArgumentParser"
         },
         {
             "identity": "example-cool-repo",
             "name": "Foo",
             "type": "library",
-            "target_labels": [
-                "@example_cool_repo//:Foo",
-                "@example_cool_repo//:Bar"
-            ]
+            "label": "@example_cool_repo//:Foo"
         },
         {
             "identity": "example-another-repo",
             "name": "Foo",
             "type": "library",
-            "target_labels": [
-                "@example_another_repo//Sources/Foo"
-            ]
+            "label": "@example_another_repo//Sources/Foo"
         }
     ],
     "packages": [

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -116,19 +116,13 @@ _deps_index_json = """\
       "identity": "example-swift-package",
       "name": "AwesomeProduct",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_example_swift_package//:AwesomePackage",
-        "@swiftpkg_example_swift_package//:Source/Baz"
-      ]
+      "label": "@swiftpkg_example_swift_package//:AwesomePackage"
     },
     {
       "identity": "example-swift-package",
       "name": "Baz",
       "type": "library",
-      "target_labels": [
-        "@swiftpkg_example_swift_package//:Source/Baz",
-        "@swiftpkg_example_swift_package//:Source/MoreBaz"
-      ]
+      "label": "@swiftpkg_example_swift_package//:Source/Baz"
     }
   ]
 }
@@ -168,9 +162,6 @@ def _bzl_select_list_test(ctx):
                         bazel_labels.normalize(
                             "@swiftpkg_example_swift_package//:AwesomePackage",
                         ),
-                        bazel_labels.normalize(
-                            "@swiftpkg_example_swift_package//:Source/Baz",
-                        ),
                     ],
                 ),
             ],
@@ -184,9 +175,6 @@ def _bzl_select_list_test(ctx):
                     value = [
                         bazel_labels.normalize(
                             "@swiftpkg_example_swift_package//:AwesomePackage",
-                        ),
-                        bazel_labels.normalize(
-                            "@swiftpkg_example_swift_package//:Source/Baz",
                         ),
                     ],
                 ),
@@ -231,9 +219,6 @@ def _bzl_select_list_test(ctx):
                     value = [
                         bazel_labels.normalize(
                             "@swiftpkg_example_swift_package//:AwesomePackage",
-                        ),
-                        bazel_labels.normalize(
-                            "@swiftpkg_example_swift_package//:Source/Baz",
                         ),
                     ],
                     condition = c,

--- a/swiftpkg/tests/pkginfo_targets_tests.bzl
+++ b/swiftpkg/tests/pkginfo_targets_tests.bzl
@@ -87,15 +87,15 @@ def _bazel_label_test(ctx):
     env = unittest.begin(ctx)
 
     actual = pkginfo_targets.bazel_label(_bar_target)
-    expected = bazel_labels.parse("@example_cool_repo//:Sources_Bar")
+    expected = bazel_labels.parse("@example_cool_repo//:Bar.rspm")
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label(_foo_target, "@another_repo")
-    expected = bazel_labels.parse("@another_repo//:Sources_Foo")
+    expected = bazel_labels.parse("@another_repo//:Foo.rspm")
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label(_chocolate_target)
-    expected = bazel_labels.parse("@example_cool_repo//:Sources_Bar_Chocolate")
+    expected = bazel_labels.parse("@example_cool_repo//:Chocolate.rspm")
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
@@ -127,19 +127,19 @@ def _bazel_label_name_test(ctx):
     env = unittest.begin(ctx)
 
     actual = pkginfo_targets.bazel_label_name(_bar_target)
-    expected = "Sources_Bar"
+    expected = "Bar.rspm"
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label_name(_chocolate_target)
-    expected = "Sources_Bar_Chocolate"
+    expected = "Chocolate.rspm"
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label_name(_dot_path_target)
-    expected = "DotPath"
+    expected = "DotPath.rspm"
     asserts.equals(env, expected, actual)
 
     actual = pkginfo_targets.bazel_label_name(_simple_path_target)
-    expected = "simple_path_simple_path"
+    expected = "simple_path.rspm"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)

--- a/swiftpkg/tests/pkginfos_tests.bzl
+++ b/swiftpkg/tests/pkginfos_tests.bzl
@@ -555,7 +555,7 @@ _swift_arg_parser_deps_index_json = """
             "name": "MySwiftPackage",
             "c99name": "MySwiftPackage",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Sources_MySwiftPackage",
+            "label": "@swiftpkg_mypackage//:MySwiftPackage.rspm",
             "package_identity": "mypackage",
             "product_memberships": [
                 "printstuff"
@@ -567,9 +567,7 @@ _swift_arg_parser_deps_index_json = """
             "identity": "mypackage",
             "name": "printstuff",
             "type": "executable",
-            "target_labels": [
-                "@swiftpkg_mypackage//:Sources_MySwiftPackage"
-            ]
+            "label": "@swiftpkg_mypackage//:MySwiftPackage"
         }
     ]
 }
@@ -760,7 +758,7 @@ _clang_deps_index_json = """
             "name": "libbar",
             "c99name": "libbar",
             "src_type": "clang",
-            "label": "@swiftpkg_libbar//:libbar",
+            "label": "@swiftpkg_libbar//:libbar.rspm",
             "package_identity": "mypackage",
             "product_memberships": [
                 "libbar"
@@ -772,9 +770,7 @@ _clang_deps_index_json = """
             "identity": "libbar",
             "name": "libbar",
             "type": "library",
-            "target_labels": [
-                "@swiftpkg_libbar//:libbar"
-            ]
+            "label": "@swiftpkg_libbar//:libbar"
         }
     ]
 }

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -56,6 +56,15 @@ _pkg_info = pkginfos.new(
             targets = ["RegularSwiftTargetAsLibrary"],
         ),
         pkginfos.new_product(
+            name = "ObjcLibraryWithModulemap",
+            type = pkginfos.new_product_type(
+                library = pkginfos.new_library_type(
+                    library_type_kinds.automatic,
+                ),
+            ),
+            targets = ["ObjcLibraryWithModulemap"],
+        ),
+        pkginfos.new_product(
             name = "swiftexec",
             type = pkginfos.new_product_type(executable = True),
             targets = ["SwiftExecutableTarget"],
@@ -459,7 +468,7 @@ _deps_index_json = """
             "name": "RegularTargetForExec",
             "c99name": "RegularTargetForExec",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Source_RegularTargetForExec",
+            "label": "@swiftpkg_mypackage//:RegularTargetForExec.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -467,7 +476,7 @@ _deps_index_json = """
             "name": "RegularSwiftTargetAsLibrary",
             "c99name": "RegularSwiftTargetAsLibrary",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary",
+            "label": "@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -475,7 +484,7 @@ _deps_index_json = """
             "name": "RegularSwiftTargetAsLibraryTests",
             "c99name": "RegularSwiftTargetAsLibraryTests",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibraryTests",
+            "label": "@swiftpkg_mypackage//:RegularSwiftTargetAsLibraryTests.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -483,7 +492,7 @@ _deps_index_json = """
             "name": "SwiftExecutableTarget",
             "c99name": "SwiftExecutableTarget",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Source_SwiftLibraryTarget",
+            "label": "@swiftpkg_mypackage//:SwiftLibraryTarget.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -491,7 +500,7 @@ _deps_index_json = """
             "name": "ClangLibrary",
             "c99name": "ClangLibrary",
             "src_type": "clang",
-            "label": "@swiftpkg_mypackage//:ClangLibrary",
+            "label": "@swiftpkg_mypackage//:ClangLibrary.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -499,7 +508,7 @@ _deps_index_json = """
             "name": "ObjcLibrary",
             "c99name": "ObjcLibrary",
             "src_type": "objc",
-            "label": "@swiftpkg_mypackage//:ObjcLibrary",
+            "label": "@swiftpkg_mypackage//:ObjcLibrary.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -507,7 +516,7 @@ _deps_index_json = """
             "name": "ObjcLibraryDep",
             "c99name": "ObjcLibraryDep",
             "src_type": "objc",
-            "label": "@swiftpkg_mypackage//:ObjcLibraryDep",
+            "label": "@swiftpkg_mypackage//:ObjcLibraryDep.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -515,7 +524,7 @@ _deps_index_json = """
             "name": "ObjcLibraryWithModulemap",
             "c99name": "ObjcLibraryWithModulemap",
             "src_type": "objc",
-            "label": "@swiftpkg_mypackage//:ObjcLibraryWithModulemap",
+            "label": "@swiftpkg_mypackage//:ObjcLibraryWithModulemap.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -523,7 +532,7 @@ _deps_index_json = """
             "name": "SwiftLibraryWithConditionalDep",
             "c99name": "SwiftLibraryWithConditionalDep",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Source_SwiftLibraryWithConditionalDep",
+            "label": "@swiftpkg_mypackage//:SwiftLibraryWithConditionalDep.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -531,7 +540,7 @@ _deps_index_json = """
             "name": "ClangLibraryWithConditionalDep",
             "c99name": "ClangLibraryWithConditionalDep",
             "src_type": "clang",
-            "label": "@swiftpkg_mypackage//:ClangLibraryWithConditionalDep",
+            "label": "@swiftpkg_mypackage//:ClangLibraryWithConditionalDep.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         },
@@ -539,7 +548,7 @@ _deps_index_json = """
             "name": "SwiftForObjcTarget",
             "c99name": "SwiftForObjcTarget",
             "src_type": "swift",
-            "label": "@swiftpkg_mypackage//:Source_SwiftForObjcTarget",
+            "label": "@swiftpkg_mypackage//:SwiftForObjcTarget.rspm",
             "package_identity": "mypackage",
             "product_memberships": []
         }
@@ -567,14 +576,14 @@ def _target_generation_test(ctx):
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
-    name = "Source_RegularSwiftTargetAsLibrary",
+    name = "RegularSwiftTargetAsLibrary.rspm",
     always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
     deps = [],
     module_name = "RegularSwiftTargetAsLibrary",
     srcs = ["Source/RegularSwiftTargetAsLibrary/RegularSwiftTargetAsLibrary.swift"],
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -588,14 +597,14 @@ swift_library(
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
-    name = "Source_RegularTargetForExec",
+    name = "RegularTargetForExec.rspm",
     always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
-    deps = ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
+    deps = ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
     module_name = "RegularTargetForExec",
     srcs = ["Source/RegularTargetForExec/main.swift"],
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -606,12 +615,12 @@ swift_library(
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
-    name = "Tests_RegularSwiftTargetAsLibraryTests",
+    name = "RegularSwiftTargetAsLibraryTests.rspm",
     defines = ["SWIFT_PACKAGE"],
-    deps = ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
+    deps = ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
     module_name = "RegularSwiftTargetAsLibraryTests",
     srcs = ["Tests/RegularSwiftTargetAsLibraryTests/RegularSwiftTargetAsLibraryTests.swift"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -622,7 +631,7 @@ swift_test(
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 
 swift_binary(
-    name = "Source_SwiftExecutableTarget",
+    name = "SwiftExecutableTarget.rspm",
     copts = [
         "-enable-experimental-feature",
         "BuiltinModule",
@@ -638,7 +647,7 @@ swift_binary(
     deps = [],
     module_name = "SwiftExecutableTarget",
     srcs = ["Source/SwiftExecutableTarget/main.swift"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -648,7 +657,7 @@ swift_binary(
             exp = """\
 
 cc_library(
-    name = "ClangLibrary",
+    name = "ClangLibrary.rspm",
     copts = [
         "-fblocks",
         "-fobjc-arc",
@@ -672,7 +681,7 @@ cc_library(
     ],
     tags = ["swift_module=ClangLibrary"],
     textual_hdrs = ["src/foo.cc"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -683,16 +692,16 @@ cc_library(
 load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "generate_modulemap")
 
 generate_modulemap(
-    name = "ObjcLibrary_modulemap",
-    deps = ["@swiftpkg_mypackage//:ObjcLibraryDep_modulemap"],
+    name = "ObjcLibrary.rspm_modulemap",
+    deps = ["@swiftpkg_mypackage//:ObjcLibraryDep.rspm_modulemap"],
     hdrs = ["include/external.h"],
     module_name = "ObjcLibrary",
     noop = False,
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 objc_library(
-    name = "ObjcLibrary",
+    name = "ObjcLibrary.rspm",
     copts = [
         "-fblocks",
         "-fobjc-arc",
@@ -702,8 +711,8 @@ objc_library(
     ],
     defines = ["SWIFT_PACKAGE=1"],
     deps = [
-        "@swiftpkg_mypackage//:ObjcLibraryDep",
-        "@swiftpkg_mypackage//:ObjcLibraryDep_modulemap",
+        "@swiftpkg_mypackage//:ObjcLibraryDep.rspm",
+        "@swiftpkg_mypackage//:ObjcLibraryDep.rspm_modulemap",
     ],
     enable_modules = True,
     hdrs = ["include/external.h"],
@@ -731,7 +740,7 @@ objc_library(
     ],
     tags = ["swift_module=ObjcLibrary"],
     textual_hdrs = ["src/foo.m"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -742,16 +751,16 @@ objc_library(
 load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "generate_modulemap")
 
 generate_modulemap(
-    name = "ObjcLibraryWithModulemap_modulemap",
-    deps = ["@swiftpkg_mypackage//:ObjcLibraryDep_modulemap"],
+    name = "ObjcLibraryWithModulemap.rspm_modulemap",
+    deps = ["@swiftpkg_mypackage//:ObjcLibraryDep.rspm_modulemap"],
     hdrs = ["include/external.h"],
     module_name = "ObjcLibraryWithModulemap",
     noop = True,
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 objc_library(
-    name = "ObjcLibraryWithModulemap",
+    name = "ObjcLibraryWithModulemap.rspm",
     copts = [
         "-fblocks",
         "-fobjc-arc",
@@ -761,8 +770,8 @@ objc_library(
     ],
     defines = ["SWIFT_PACKAGE=1"],
     deps = [
-        "@swiftpkg_mypackage//:ObjcLibraryDep",
-        "@swiftpkg_mypackage//:ObjcLibraryDep_modulemap",
+        "@swiftpkg_mypackage//:ObjcLibraryDep.rspm",
+        "@swiftpkg_mypackage//:ObjcLibraryDep.rspm_modulemap",
     ],
     enable_modules = True,
     hdrs = ["include/external.h"],
@@ -790,7 +799,7 @@ objc_library(
     ],
     tags = ["swift_module=ObjcLibraryWithModulemap"],
     textual_hdrs = ["src/foo.m"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -801,18 +810,18 @@ objc_library(
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
-    name = "Source_SwiftLibraryWithConditionalDep",
+    name = "SwiftLibraryWithConditionalDep.rspm",
     always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
-    deps = ["@swiftpkg_mypackage//:ClangLibrary"] + select({
-        "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
-        "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
+    deps = ["@swiftpkg_mypackage//:ClangLibrary.rspm"] + select({
+        "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
+        "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
         "//conditions:default": [],
     }),
     module_name = "SwiftLibraryWithConditionalDep",
     srcs = ["Source/SwiftLibraryWithConditionalDep/SwiftLibraryWithConditionalDep.swift"],
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -822,7 +831,7 @@ swift_library(
             exp = """\
 
 cc_library(
-    name = "ClangLibraryWithConditionalDep",
+    name = "ClangLibraryWithConditionalDep.rspm",
     copts = [
         "-fblocks",
         "-fobjc-arc",
@@ -832,8 +841,8 @@ cc_library(
     ],
     defines = ["SWIFT_PACKAGE=1"],
     deps = select({
-        "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:ClangLibrary"],
-        "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:ClangLibrary"],
+        "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:ClangLibrary.rspm"],
+        "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:ClangLibrary.rspm"],
         "//conditions:default": [],
     }),
     hdrs = ["include/external.h"],
@@ -844,7 +853,7 @@ cc_library(
     ],
     tags = ["swift_module=ClangLibraryWithConditionalDep"],
     textual_hdrs = ["src/foo.cc"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -856,26 +865,26 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "generate_modulemap")
 
 generate_modulemap(
-    name = "Source_SwiftForObjcTarget_modulemap",
-    deps = ["@swiftpkg_mypackage//:ObjcLibraryDep_modulemap"],
-    hdrs = [":Source_SwiftForObjcTarget"],
+    name = "SwiftForObjcTarget.rspm_modulemap",
+    deps = ["@swiftpkg_mypackage//:ObjcLibraryDep.rspm_modulemap"],
+    hdrs = [":SwiftForObjcTarget.rspm"],
     module_name = "SwiftForObjcTarget",
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 swift_library(
-    name = "Source_SwiftForObjcTarget",
+    name = "SwiftForObjcTarget.rspm",
     always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
     deps = [
-        "@swiftpkg_mypackage//:ObjcLibraryDep",
-        "@swiftpkg_mypackage//:ObjcLibraryDep_modulemap",
+        "@swiftpkg_mypackage//:ObjcLibraryDep.rspm",
+        "@swiftpkg_mypackage//:ObjcLibraryDep.rspm_modulemap",
     ],
     generates_header = True,
     module_name = "SwiftForObjcTarget",
     srcs = ["Source/SwiftForObjcTarget/SwiftForObjcTarget.swift"],
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -888,36 +897,36 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "resource_bundle_accessor", "resource_bundle_infoplist")
 
 apple_resource_bundle(
-    name = "Source_SwiftLibraryWithFilePathResource_resource_bundle",
+    name = "SwiftLibraryWithFilePathResource.rspm_resource_bundle",
     bundle_name = "SwiftLibraryWithFilePathResource_SwiftLibraryWithFilePathResource",
-    infoplists = [":Source_SwiftLibraryWithFilePathResource_resource_bundle_infoplist"],
+    infoplists = [":SwiftLibraryWithFilePathResource.rspm_resource_bundle_infoplist"],
     resources = ["Source/SwiftLibraryWithFilePathResource/Resources/chicken.json"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 resource_bundle_accessor(
-    name = "Source_SwiftLibraryWithFilePathResource_resource_bundle_accessor",
+    name = "SwiftLibraryWithFilePathResource.rspm_resource_bundle_accessor",
     bundle_name = "SwiftLibraryWithFilePathResource_SwiftLibraryWithFilePathResource",
 )
 
 resource_bundle_infoplist(
-    name = "Source_SwiftLibraryWithFilePathResource_resource_bundle_infoplist",
+    name = "SwiftLibraryWithFilePathResource.rspm_resource_bundle_infoplist",
     region = "en",
 )
 
 swift_library(
-    name = "Source_SwiftLibraryWithFilePathResource",
+    name = "SwiftLibraryWithFilePathResource.rspm",
     always_include_developer_search_paths = True,
-    data = [":Source_SwiftLibraryWithFilePathResource_resource_bundle"],
+    data = [":SwiftLibraryWithFilePathResource.rspm_resource_bundle"],
     defines = ["SWIFT_PACKAGE"],
     deps = [],
     module_name = "SwiftLibraryWithFilePathResource",
     srcs = [
         "Source/SwiftLibraryWithFilePathResource/SwiftLibraryWithFilePathResource.swift",
-        ":Source_SwiftLibraryWithFilePathResource_resource_bundle_accessor",
+        ":SwiftLibraryWithFilePathResource.rspm_resource_bundle_accessor",
     ],
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),
@@ -929,33 +938,33 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
 load("@rules_swift_package_manager//swiftpkg:build_defs.bzl", "generate_modulemap", "objc_resource_bundle_accessor_hdr", "objc_resource_bundle_accessor_impl", "resource_bundle_infoplist")
 
 apple_resource_bundle(
-    name = "ObjcLibraryWithResources_resource_bundle",
+    name = "ObjcLibraryWithResources.rspm_resource_bundle",
     bundle_name = "ObjcLibraryWithResources_ObjcLibraryWithResources",
-    infoplists = [":ObjcLibraryWithResources_resource_bundle_infoplist"],
+    infoplists = [":ObjcLibraryWithResources.rspm_resource_bundle_infoplist"],
     resources = ["Source/ObjcLibraryWithResources/Resources/chicken.json"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 generate_modulemap(
-    name = "ObjcLibraryWithResources_modulemap",
+    name = "ObjcLibraryWithResources.rspm_modulemap",
     deps = [],
     hdrs = ["include/external.h"],
     module_name = "ObjcLibraryWithResources",
     noop = False,
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 objc_library(
-    name = "ObjcLibraryWithResources",
+    name = "ObjcLibraryWithResources.rspm",
     copts = [
         "-fblocks",
         "-fobjc-arc",
         "-fPIC",
         "-fmodule-name=ObjcLibraryWithResources",
-        "-include$(location :ObjcLibraryWithResources_objc_resource_bundle_accessor_hdr)",
+        "-include$(location :ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_hdr)",
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage/src",
     ],
-    data = [":ObjcLibraryWithResources_resource_bundle"],
+    data = [":ObjcLibraryWithResources.rspm_resource_bundle"],
     defines = ["SWIFT_PACKAGE=1"],
     enable_modules = True,
     hdrs = ["include/external.h"],
@@ -980,27 +989,27 @@ objc_library(
     srcs = [
         "src/foo.h",
         "src/foo.m",
-        ":ObjcLibraryWithResources_objc_resource_bundle_accessor_hdr",
-        ":ObjcLibraryWithResources_objc_resource_bundle_accessor_impl",
+        ":ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_hdr",
+        ":ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_impl",
     ],
     tags = ["swift_module=ObjcLibraryWithResources"],
     textual_hdrs = ["src/foo.m"],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 
 objc_resource_bundle_accessor_hdr(
-    name = "ObjcLibraryWithResources_objc_resource_bundle_accessor_hdr",
+    name = "ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_hdr",
     module_name = "ObjcLibraryWithResources",
 )
 
 objc_resource_bundle_accessor_impl(
-    name = "ObjcLibraryWithResources_objc_resource_bundle_accessor_impl",
+    name = "ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_impl",
     bundle_name = "ObjcLibraryWithResources_ObjcLibraryWithResources",
     module_name = "ObjcLibraryWithResources",
 )
 
 resource_bundle_infoplist(
-    name = "ObjcLibraryWithResources_resource_bundle_infoplist",
+    name = "ObjcLibraryWithResources.rspm_resource_bundle_infoplist",
     region = "en",
 )
 """,
@@ -1047,7 +1056,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 
 swift_binary(
     name = "oldstyleexec",
-    deps = ["@swiftpkg_mypackage//:Source_RegularTargetForExec"],
+    deps = ["@swiftpkg_mypackage//:RegularTargetForExec.rspm"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -1056,11 +1065,27 @@ swift_binary(
             msg = "Swift library product",
             name = "RegularSwiftTargetAsLibrary",
             exp = """\
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
 
-build_test(
-    name = "RegularSwiftTargetAsLibraryBuildTest",
-    targets = ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
+swift_library_group(
+    name = "RegularSwiftTargetAsLibrary",
+    deps = ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
+    visibility = ["//visibility:public"],
+)
+""",
+        ),
+        struct(
+            msg = "ObjC library with modulemap product",
+            name = "ObjcLibraryWithModulemap",
+            exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+
+swift_library_group(
+    name = "ObjcLibraryWithModulemap",
+    deps = [
+        "@swiftpkg_mypackage//:ObjcLibraryWithModulemap.rspm",
+        "@swiftpkg_mypackage//:ObjcLibraryWithModulemap.rspm_modulemap",
+    ],
     visibility = ["//visibility:public"],
 )
 """,
@@ -1072,7 +1097,7 @@ build_test(
 
 alias(
     name = "swiftexec",
-    actual = "@swiftpkg_mypackage//:Source_SwiftExecutableTarget",
+    actual = "@swiftpkg_mypackage//:SwiftExecutableTarget.rspm",
     visibility = ["//visibility:public"],
 )
 """,
@@ -1082,9 +1107,8 @@ alias(
         product = lists.find(_pkg_info.products, lambda p: p.name == t.name)
         actual = scg.to_starlark(
             swiftpkg_build_files.new_for_product(
-                pkg_info = _pkg_ctx.pkg_info,
+                pkg_ctx = _pkg_ctx,
                 product = product,
-                repo_name = _pkg_ctx.repo_name,
             ),
         )
         asserts.equals(env, t.exp, actual, t.msg)


### PR DESCRIPTION
This also changes the names of targets to have a `.rpm` suffix, and visibility limited to their own repo (you need to depend on the library product, not the underlying targets).
