### PR TITLE
fix: add missing bazel version to BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,9 +2,13 @@ bcr_test_module:
   module_path: ""
   matrix:
     platform: ["macos"]
+    bazel:
+      - 6.x
+      - 7.x
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets:
         - "//bzlmod:e2e_test"


### PR DESCRIPTION
The BCR now requires a Bazel version in the `presubmit.yml`.

Related to https://github.com/bazelbuild/bazel-central-registry/pull/1413.