### PR TITLE
fix: the BCR presubmit Bazel version must match the version specified for rules_bazel_integration_test

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,6 @@ bcr_test_module:
   matrix:
     platform: ["macos"]
     bazel:
-      - 6.x
       - 7.x
   tasks:
     run_tests:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,8 @@ bcr_test_module:
   matrix:
     platform: ["macos"]
     bazel:
-      - 7.x
+      # This needs to exactly match the value used in .bazelversion at the root.
+      - 7.0.0
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Related to https://github.com/bazelbuild/bazel-central-registry/pull/1416.
