### PR TITLE
chore: enable `always_include_developer_search_paths` for all `swift_library` targets in external Swift packages

### DIFF
--- a/examples/nimble_example/MODULE.bazel.lock
+++ b/examples/nimble_example/MODULE.bazel.lock
@@ -2508,9 +2508,37 @@
         "recordedRepoMappingEntries": []
       }
     },
+    "@@rules_apple~3.2.1//apple:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "N8kVRd5FAdvXx7eSi2BgbUpsnUMZewaoOmBsW+UsKmw=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "xctestrunner": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_apple~3.2.1~non_module_deps~xctestrunner",
+              "urls": [
+                "https://github.com/google/xctestrunner/archive/b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6.tar.gz"
+              ],
+              "strip_prefix": "xctestrunner-b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6",
+              "sha256": "ae3a063c985a8633cb7eb566db21656f8db8eb9a0edb8c182312c7f0db53730d"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_apple~3.2.1",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_go~0.44.0//go:extensions.bzl%go_sdk": {
       "os:osx,arch:x86_64": {
-        "bzlTransitiveDigest": "HOJ7KCV+gzdiDP50kTBrioqp+Vdoj42MzmZF65s69fg=",
+        "bzlTransitiveDigest": "GI6yMOM2hDU7hVAHmfnV90TgIqJguaDlemn2az5C07E=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -2678,7 +2706,33 @@
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~1.3.0",
+            "bazel_features_globals",
+            "bazel_features~1.3.0~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~1.3.0",
+            "bazel_features_version",
+            "bazel_features~1.3.0~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~0.44.0",
+            "bazel_features",
+            "bazel_features~1.3.0"
+          ],
+          [
+            "rules_go~0.44.0",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go~0.44.0",
+            "io_bazel_rules_go",
+            "rules_go~0.44.0"
+          ]
+        ]
       },
       "os:linux,arch:amd64": {
         "bzlTransitiveDigest": "GI6yMOM2hDU7hVAHmfnV90TgIqJguaDlemn2az5C07E=",
@@ -3432,9 +3486,9 @@
     },
     "@@rules_swift_package_manager~override//:extensions.bzl%swift_deps": {
       "general": {
-        "bzlTransitiveDigest": "a13Oc0hXT+L5cvojiIZIfzIFXt+8RemLnU6Rf/kkLXI=",
+        "bzlTransitiveDigest": "vZtOh7Hqv5kuRtMyW/AVHtgik9HENMZMtdkoAIS6qOQ=",
         "accumulatedFileDigests": {
-          "@@//:swift_deps_index.json": "b68d4e851040a2a01a7bc0d5a8fb5a20f23b0ccdddb74484567fb447c9bf5f57"
+          "@@//:swift_deps_index.json": "067537104205b90104f3c55a95a502dd9878812433e3d2b4c9542abd2cd3cb76"
         },
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -3444,7 +3498,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_cwlpreconditiontesting",
               "bazel_package_name": "swiftpkg_cwlpreconditiontesting",
-              "commit": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+              "commit": "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
               "remote": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3464,7 +3518,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_cwlcatchexception",
               "bazel_package_name": "swiftpkg_cwlcatchexception",
-              "commit": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+              "commit": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
               "remote": "https://github.com/mattgallagher/CwlCatchException.git",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3484,7 +3538,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_nimble",
               "bazel_package_name": "swiftpkg_nimble",
-              "commit": "d616f15123bfb36db1b1075153f73cf40605b39d",
+              "commit": "c1f3dd66222d5e7a1a20afc237f7e7bc432c564f",
               "remote": "https://github.com/Quick/Nimble",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3504,7 +3558,7 @@
             "attributes": {
               "name": "rules_swift_package_manager~override~swift_deps~swiftpkg_quick",
               "bazel_package_name": "swiftpkg_quick",
-              "commit": "ef9aaf3f634b3a1ab6f54f1173fe2400b36e7cb8",
+              "commit": "a9e6c24033a25e158384d523a556c0b96c44a839",
               "remote": "https://github.com/Quick/Quick",
               "dependencies_index": "@@//:swift_deps_index.json",
               "init_submodules": false,
@@ -3519,7 +3573,194 @@
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift_package_manager~override",
+            "bazel_skylib",
+            "bazel_skylib~1.5.0"
+          ],
+          [
+            "rules_swift_package_manager~override",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift_package_manager~override",
+            "cgrindel_bazel_starlib",
+            "cgrindel_bazel_starlib~0.19.0"
+          ]
+        ]
+      }
+    },
+    "@@rules_swift~1.16.0//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "JXT9csgB0VHkXU94H+OROIY4q5dpOW0Di+C2YoFqVTM=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_grpc_grpc_swift": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_grpc_grpc_swift",
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_extras",
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_protobuf",
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_ssl",
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_atomics",
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_http2",
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio_transport_services",
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~build_bazel_rules_swift_index_import",
+              "build_file": "@@rules_swift~1.16.0//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_nio",
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_log",
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~com_github_apple_swift_collections",
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift~1.16.0//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "bzlFile": "@@rules_swift~1.16.0//swift/internal:swift_autoconfiguration.bzl",
+            "ruleClassName": "swift_autoconfiguration",
+            "attributes": {
+              "name": "rules_swift~1.16.0~non_module_deps~build_bazel_rules_swift_local_config"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift~1.16.0",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift~1.16.0",
+            "build_bazel_rules_swift",
+            "rules_swift~1.16.0"
+          ]
+        ]
       }
     }
   }

--- a/examples/nimble_example/Package.resolved
+++ b/examples/nimble_example/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "35f9e770f54ce62dd8526470f14c6e137cef3eea",
-        "version" : "2.1.1"
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-        "version" : "2.1.0"
+        "revision" : "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
+        "version" : "2.2.0"
       }
     },
     {

--- a/examples/nimble_example/Sources/NimbleExample/BUILD.bazel
+++ b/examples/nimble_example/Sources/NimbleExample/BUILD.bazel
@@ -14,6 +14,7 @@ swift_library(
     tags = ["manual"],
     deps = [
         "@swiftpkg_nimble//:Sources_Nimble",
+        "@swiftpkg_nimble//:Sources_NimbleObjectiveC",
         "@swiftpkg_quick//:Sources_Quick",
     ],
 )

--- a/examples/nimble_example/swift_deps_index.json
+++ b/examples/nimble_example/swift_deps_index.json
@@ -67,11 +67,31 @@
       ]
     },
     {
+      "name": "NimbleObjectiveC",
+      "c99name": "NimbleObjectiveC",
+      "src_type": "objc",
+      "label": "@swiftpkg_nimble//:Sources_NimbleObjectiveC",
+      "package_identity": "nimble",
+      "product_memberships": [
+        "Nimble"
+      ]
+    },
+    {
       "name": "Quick",
       "c99name": "Quick",
       "src_type": "swift",
       "label": "@swiftpkg_quick//:Sources_Quick",
       "modulemap_label": "@swiftpkg_quick//:Sources_Quick_modulemap",
+      "package_identity": "quick",
+      "product_memberships": [
+        "Quick"
+      ]
+    },
+    {
+      "name": "QuickObjCRuntime",
+      "c99name": "QuickObjCRuntime",
+      "src_type": "objc",
+      "label": "@swiftpkg_quick//:Sources_QuickObjCRuntime",
       "package_identity": "quick",
       "product_memberships": [
         "Quick"
@@ -109,7 +129,8 @@
       "name": "Nimble",
       "type": "library",
       "target_labels": [
-        "@swiftpkg_nimble//:Sources_Nimble"
+        "@swiftpkg_nimble//:Sources_Nimble",
+        "@swiftpkg_nimble//:Sources_NimbleObjectiveC"
       ]
     },
     {
@@ -126,18 +147,18 @@
       "name": "swiftpkg_cwlcatchexception",
       "identity": "cwlcatchexception",
       "remote": {
-        "commit": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+        "commit": "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
         "remote": "https://github.com/mattgallagher/CwlCatchException.git",
-        "version": "2.1.1"
+        "version": "2.1.2"
       }
     },
     {
       "name": "swiftpkg_cwlpreconditiontesting",
       "identity": "cwlpreconditiontesting",
       "remote": {
-        "commit": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+        "commit": "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
         "remote": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "version": "2.1.0"
+        "version": "2.2.0"
       }
     },
     {

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -761,15 +761,12 @@ def _new_swift_src_info_from_sources(
         exclude_paths = []):
     # Check for any @objc directives in the source files
     has_objc_directive = False
-    imports_xctest = False
     for src in sources:
         path = paths.join(target_path, src)
         contents = repository_ctx.read(path)
         if swift_files.has_objc_directive(contents):
             has_objc_directive = True
-        if swift_files.has_import(contents, "XCTest"):
-            imports_xctest = True
-        if has_objc_directive and imports_xctest:
+        if has_objc_directive:
             break
 
     # Find any auto-discoverable resources under the target
@@ -798,17 +795,14 @@ def _new_swift_src_info_from_sources(
 
     return _new_swift_src_info(
         has_objc_directive = has_objc_directive,
-        imports_xctest = imports_xctest,
         discovered_res_files = discovered_res_files,
     )
 
 def _new_swift_src_info(
         has_objc_directive = False,
-        imports_xctest = False,
         discovered_res_files = []):
     return struct(
         has_objc_directive = has_objc_directive,
-        imports_xctest = imports_xctest,
         discovered_res_files = discovered_res_files,
     )
 
@@ -981,7 +975,6 @@ def _new_objc_src_info_from_sources(repository_ctx, pkg_path, sources):
         srcs = srcs,
     )
 
-    # imports_xctest = lists.contains(src_info.other_imports, "XCTest")
     imports_xctest = False
     xctest_srcs = src_info.all_imports.get("XCTest", [])
     if xctest_srcs != []:

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -975,20 +975,13 @@ def _new_objc_src_info_from_sources(repository_ctx, pkg_path, sources):
         srcs = srcs,
     )
 
-    imports_xctest = False
-    xctest_srcs = src_info.all_imports.get("XCTest", [])
-    if xctest_srcs != []:
-        imports_xctest = True
-
     return _new_objc_src_info(
         builtin_frameworks = src_info.frameworks,
-        imports_xctest = imports_xctest,
     )
 
-def _new_objc_src_info(builtin_frameworks = [], imports_xctest = False):
+def _new_objc_src_info(builtin_frameworks = []):
     return struct(
         builtin_frameworks = builtin_frameworks,
-        imports_xctest = imports_xctest,
     )
 
 # MARK: - Target

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -146,6 +146,11 @@ def _swift_library_from_target(target, attrs):
     # built from a leaf node which can provide critical configuration
     # information.
     attrs["tags"] = ["manual"]
+
+    # SPM always includes the developer search paths when compiling Swift
+    # library targets. So, we do too.
+    attrs["always_include_developer_search_paths"] = True
+
     return build_decls.new(
         kind = swift_kinds.library,
         name = pkginfo_targets.bazel_label_name(target),

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -86,11 +86,6 @@ def _swift_target_build_file(pkg_ctx, target):
     if target.swift_src_info.has_objc_directive and is_library_target:
         attrs["generates_header"] = True
 
-    # The rules_swift code links in developer libraries if the rule is marked testonly.
-    # https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/compiling.bzl#L1312-L1319
-    if target.swift_src_info.imports_xctest:
-        attrs["testonly"] = True
-
     if target.swift_settings != None:
         if len(target.swift_settings.defines) > 0:
             defines.extend(lists.flatten([
@@ -629,11 +624,6 @@ def _generate_modulemap_for_swift_target(target, deps):
         "module_name": target.c99name,
         "visibility": ["//visibility:public"],
     }
-
-    # The modulemap target needs to match the testonly state for its related
-    # Swift target.
-    if target.swift_src_info != None and target.swift_src_info.imports_xctest:
-        attrs["testonly"] = True
     decls = [
         build_decls.new(
             kind = swiftpkg_kinds.generate_modulemap,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -345,9 +345,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         attrs["enable_modules"] = True
         attrs["module_name"] = target.c99name
 
-        if target.objc_src_info.imports_xctest:
-            attrs["testonly"] = True
-
         sdk_framework_bzl_selects = []
         for sf in target.objc_src_info.builtin_frameworks:
             platform_conditions = bazel_apple_platforms.for_framework(sf)

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -150,19 +150,6 @@ _pkg_info = pkginfos.new(
             swift_src_info = pkginfos.new_swift_src_info(),
         ),
         pkginfos.new_target(
-            name = "SwiftLibraryUsesXCTest",
-            type = "regular",
-            c99name = "SwiftLibraryUsesXCTest",
-            module_type = "SwiftTarget",
-            path = "Source/SwiftLibraryUsesXCTest",
-            sources = [
-                "SwiftLibraryUsesXCTest.swift",
-            ],
-            dependencies = [],
-            repo_name = _repo_name,
-            swift_src_info = pkginfos.new_swift_src_info(imports_xctest = True),
-        ),
-        pkginfos.new_target(
             name = "ClangLibrary",
             type = "regular",
             c99name = "ClangLibrary",
@@ -649,29 +636,6 @@ swift_binary(
     deps = [],
     module_name = "SwiftExecutableTarget",
     srcs = ["Source/SwiftExecutableTarget/main.swift"],
-    visibility = ["//visibility:public"],
-)
-""",
-        ),
-        struct(
-            msg = "Swift library that uses XCTest should have testonly = True",
-            name = "SwiftLibraryUsesXCTest",
-            file_contents = {
-                "SwiftLibraryUsesXCTest.swift": """\
-import XCTest
-""",
-            },
-            exp = """\
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-
-swift_library(
-    name = "Source_SwiftLibraryUsesXCTest",
-    defines = ["SWIFT_PACKAGE"],
-    deps = [],
-    module_name = "SwiftLibraryUsesXCTest",
-    srcs = ["Source/SwiftLibraryUsesXCTest/SwiftLibraryUsesXCTest.swift"],
-    tags = ["manual"],
-    testonly = True,
     visibility = ["//visibility:public"],
 )
 """,

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -568,6 +568,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "Source_RegularSwiftTargetAsLibrary",
+    always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
     deps = [],
     module_name = "RegularSwiftTargetAsLibrary",
@@ -588,6 +589,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "Source_RegularTargetForExec",
+    always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
     deps = ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
     module_name = "RegularTargetForExec",
@@ -800,6 +802,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "Source_SwiftLibraryWithConditionalDep",
+    always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
     deps = ["@swiftpkg_mypackage//:ClangLibrary"] + select({
         "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:Source_RegularSwiftTargetAsLibrary"],
@@ -862,6 +865,7 @@ generate_modulemap(
 
 swift_library(
     name = "Source_SwiftForObjcTarget",
+    always_include_developer_search_paths = True,
     defines = ["SWIFT_PACKAGE"],
     deps = [
         "@swiftpkg_mypackage//:ObjcLibraryDep",
@@ -903,6 +907,7 @@ resource_bundle_infoplist(
 
 swift_library(
     name = "Source_SwiftLibraryWithFilePathResource",
+    always_include_developer_search_paths = True,
     data = [":Source_SwiftLibraryWithFilePathResource_resource_bundle"],
     defines = ["SWIFT_PACKAGE"],
     deps = [],


### PR DESCRIPTION
Background: SPM always includes the developer search paths for compilation and linking. Now that `rules_swift` supports including these for non-test targets, we will enable this feature.

- Use `always_include_developer_search_paths` for generated `swift_library` targets.
- Remove check for `XCTest` imports. Previously, we would mark targets as `testonly = True` if `XCTest` imports were detected. With the `always_include_developer_search_paths` feature, this is no longer necessary.

Closes #791.