### PR TITLE
fix: align BCR Bazel version with .bazelversion

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.0.0
+      - 7.0.2
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Fix failing BCR presubmit.
https://buildkite.com/bazel/bcr-presubmit/builds/3632#018d94f1-6b8d-4a85-81bb-e04afbad359e
