### PR TITLE
docs: update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ time.
 Add the following to the `BUILD.bazel` file at the root of your workspace.
 
 ```bzl
-load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@rules_swift_package_manager//swiftpkg:defs.bzl", "swift_update_packages")
 
 # Ignore the `.build` folder that is created by running Swift package manager


### PR DESCRIPTION
`bazel_gazelle`  now `gazelle`  

From registry: `bazel_dep(name = "gazelle", version = "0.35.0")`   https://registry.bazel.build/modules/gazelle