### PR TITLE
fix: support xcframeworks that use archive files (XXX.a)

### DIFF
--- a/examples/resources_example/MODULE.bazel
+++ b/examples/resources_example/MODULE.bazel
@@ -53,6 +53,7 @@ use_repo(
     "swiftpkg_app_lovin_sdk",
     "swiftpkg_googlesignin_ios",
     "swiftpkg_package_with_resources",
+    "swiftpkg_recaptcha_enterprise_mobile_sdk",
     "swiftpkg_sdwebimageswiftui",
 )
 # swift_deps END

--- a/examples/resources_example/Sources/MyApp/BUILD.bazel
+++ b/examples/resources_example/Sources/MyApp/BUILD.bazel
@@ -14,6 +14,7 @@ swift_library(
         "@swiftpkg_another_package_with_resources//:MoreCoolUI",
         "@swiftpkg_googlesignin_ios//:GoogleSignInSwift",
         "@swiftpkg_package_with_resources//:CoolUI",
+        "@swiftpkg_recaptcha_enterprise_mobile_sdk//:RecaptchaEnterprise",
         "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI",
     ],
 )

--- a/examples/resources_example/Sources/MyApp/MyApp.swift
+++ b/examples/resources_example/Sources/MyApp/MyApp.swift
@@ -1,6 +1,7 @@
 import CoolUI
 import GoogleSignInSwift
 import MoreCoolUI
+import RecaptchaEnterprise
 import SDWebImageSwiftUI
 import SwiftUI
 

--- a/examples/resources_example/swift/Package.resolved
+++ b/examples/resources_example/swift/Package.resolved
@@ -37,6 +37,24 @@
       }
     },
     {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "recaptcha-enterprise-mobile-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
+      "state" : {
+        "revision" : "54f4584f85144cac8288210da556a10b32067081",
+        "version" : "18.4.2"
+      }
+    },
+    {
       "identity" : "sdwebimage",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage",

--- a/examples/resources_example/swift/Package.swift
+++ b/examples/resources_example/swift/Package.swift
@@ -10,5 +10,9 @@ let package = Package(
         .package(path: "../third_party/package_with_resources"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: "3.0.1"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "7.0.0"),
+        .package(
+            url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
+            from: "18.4.2"
+        ),
     ]
 )

--- a/examples/resources_example/swift_deps_index.json
+++ b/examples/resources_example/swift_deps_index.json
@@ -4,6 +4,7 @@
     "app_lovin_sdk",
     "googlesignin-ios",
     "package_with_resources",
+    "recaptcha-enterprise-mobile-sdk",
     "sdwebimageswiftui"
   ],
   "modules": [
@@ -135,6 +136,16 @@
       ]
     },
     {
+      "name": "RecaptchaInterop",
+      "c99name": "RecaptchaInterop",
+      "src_type": "objc",
+      "label": "@swiftpkg_interop_ios_for_google_sdks//:RecaptchaInterop.rspm",
+      "package_identity": "interop-ios-for-google-sdks",
+      "product_memberships": [
+        "RecaptchaInterop"
+      ]
+    },
+    {
       "name": "CoolUI",
       "c99name": "CoolUI",
       "src_type": "swift",
@@ -142,6 +153,26 @@
       "package_identity": "package_with_resources",
       "product_memberships": [
         "CoolUI"
+      ]
+    },
+    {
+      "name": "RecaptchaEnterprise",
+      "c99name": "RecaptchaEnterprise",
+      "src_type": "binary",
+      "label": "@swiftpkg_recaptcha_enterprise_mobile_sdk//:RecaptchaEnterprise.rspm",
+      "package_identity": "recaptcha-enterprise-mobile-sdk",
+      "product_memberships": [
+        "RecaptchaEnterprise"
+      ]
+    },
+    {
+      "name": "recaptcha-enterprise",
+      "c99name": "recaptcha_enterprise",
+      "src_type": "clang",
+      "label": "@swiftpkg_recaptcha_enterprise_mobile_sdk//:recaptcha-enterprise.rspm",
+      "package_identity": "recaptcha-enterprise-mobile-sdk",
+      "product_memberships": [
+        "RecaptchaEnterprise"
       ]
     },
     {
@@ -250,10 +281,22 @@
       "label": "@swiftpkg_gtmappauth//:GTMAppAuth"
     },
     {
+      "identity": "interop-ios-for-google-sdks",
+      "name": "RecaptchaInterop",
+      "type": "library",
+      "label": "@swiftpkg_interop_ios_for_google_sdks//:RecaptchaInterop"
+    },
+    {
       "identity": "package_with_resources",
       "name": "CoolUI",
       "type": "library",
       "label": "@swiftpkg_package_with_resources//:CoolUI"
+    },
+    {
+      "identity": "recaptcha-enterprise-mobile-sdk",
+      "name": "RecaptchaEnterprise",
+      "type": "library",
+      "label": "@swiftpkg_recaptcha_enterprise_mobile_sdk//:RecaptchaEnterprise"
     },
     {
       "identity": "sdwebimageswiftui",
@@ -326,10 +369,28 @@
       }
     },
     {
+      "name": "swiftpkg_interop_ios_for_google_sdks",
+      "identity": "interop-ios-for-google-sdks",
+      "remote": {
+        "commit": "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "remote": "https://github.com/google/interop-ios-for-google-sdks.git",
+        "version": "100.0.0"
+      }
+    },
+    {
       "name": "swiftpkg_package_with_resources",
       "identity": "package_with_resources",
       "local": {
         "path": "third_party/package_with_resources"
+      }
+    },
+    {
+      "name": "swiftpkg_recaptcha_enterprise_mobile_sdk",
+      "identity": "recaptcha-enterprise-mobile-sdk",
+      "remote": {
+        "commit": "54f4584f85144cac8288210da556a10b32067081",
+        "remote": "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
+        "version": "18.4.2"
       }
     },
     {


### PR DESCRIPTION
- Check frameworks that are provided as archive files (XXX.a). 
  - See [xcframwork doc](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle) for more information.
- Add [GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk](https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk) to the `resources_example`. This package provides their frameworks as archive files.

Closes #968.