### PR TITLE
fix: ensure Bazel version in .bazelverion matches BCR presubmit config

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.0.2
+      - 7.1.1
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
BCR presubmit fails if these values are not the same.
