### PR TITLE
fix: Added Obj-C support check in generated bundle header files

### DIFF
--- a/swiftpkg/internal/ObjcResourceBundleAccessor.h.tmpl
+++ b/swiftpkg/internal/ObjcResourceBundleAccessor.h.tmpl
@@ -1,3 +1,4 @@
+#ifdef __OBJC__
 #import <Foundation/Foundation.h>
 
 #if __cplusplus
@@ -10,4 +11,5 @@ NSBundle* {MODULE_NAME}_SWIFTPM_MODULE_BUNDLE(void);
 
 #if __cplusplus
 }
+#endif
 #endif


### PR DESCRIPTION
This commit adds check for presence of ObjC support in currently used compiler. If not, skips SWIFTPM_MODULE_BUNDLE macros altogether.

fixes https://github.com/cgrindel/rules_swift_package_manager/issues/998