### PR TITLE
fix: don't include directories in resources

### DIFF
--- a/examples/resources_example/MODULE.bazel
+++ b/examples/resources_example/MODULE.bazel
@@ -55,5 +55,6 @@ use_repo(
     "swiftpkg_package_with_resources",
     "swiftpkg_recaptcha_enterprise_mobile_sdk",
     "swiftpkg_sdwebimageswiftui",
+    "swiftpkg_swift_sdk",
 )
 # swift_deps END

--- a/examples/resources_example/Sources/MyApp/BUILD.bazel
+++ b/examples/resources_example/Sources/MyApp/BUILD.bazel
@@ -16,6 +16,7 @@ swift_library(
         "@swiftpkg_package_with_resources//:CoolUI",
         "@swiftpkg_recaptcha_enterprise_mobile_sdk//:RecaptchaEnterprise",
         "@swiftpkg_sdwebimageswiftui//:SDWebImageSwiftUI",
+        "@swiftpkg_swift_sdk//:IterableSDK",
     ],
 )
 

--- a/examples/resources_example/Sources/MyApp/MyApp.swift
+++ b/examples/resources_example/Sources/MyApp/MyApp.swift
@@ -1,5 +1,6 @@
 import CoolUI
 import GoogleSignInSwift
+import IterableSDK
 import MoreCoolUI
 import RecaptchaEnterprise
 import SDWebImageSwiftUI

--- a/examples/resources_example/Tests/MyAppTests/BUILD.bazel
+++ b/examples/resources_example/Tests/MyAppTests/BUILD.bazel
@@ -12,6 +12,7 @@ swift_library(
     deps = [
         "@swiftpkg_app_lovin_sdk//:AppLovinSDK",
         "@swiftpkg_package_with_resources//:CoolUI",
+        "@swiftpkg_swift_sdk//:IterableSDK",
     ],
 )
 

--- a/examples/resources_example/Tests/MyAppTests/MyAppTests.swift
+++ b/examples/resources_example/Tests/MyAppTests/MyAppTests.swift
@@ -1,5 +1,6 @@
 import AppLovinSDKResources
 import CoolUI
+import IterableSDK
 import SwiftUI
 import XCTest
 
@@ -12,5 +13,15 @@ class MyAppTests: XCTestCase {
     func test_AppLovinSDKResources() throws {
         let url = ALResourceManager.resourceBundleURL
         XCTAssertNotNil(url)
+    }
+    
+    func test_IterableDataModel() throws {
+        let dataModelLoaded = expectation("Iterable CoreData model loaded")
+        
+        let container = NSPersistentContainer(name: "IterableDataModel")
+        container.loadPersistentStores { _, error in
+            XCTAssertNil(error, "Loading persistence stores generated an error: \(error!)")
+            dataModelLoaded.fulfill()
+        }
     }
 }

--- a/examples/resources_example/swift/Package.resolved
+++ b/examples/resources_example/swift/Package.resolved
@@ -71,6 +71,15 @@
         "revision" : "b7af5e6bd9c2987e41730400d1baad13d74a141a",
         "version" : "3.0.4"
       }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Iterable/swift-sdk",
+      "state" : {
+        "revision" : "cb64b4d1717f309dee72a9c71f886888ce3328c3",
+        "version" : "6.5.2"
+      }
     }
   ],
   "version" : 2

--- a/examples/resources_example/swift/Package.swift
+++ b/examples/resources_example/swift/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .package(path: "../third_party/another_package_with_resources"),
         .package(path: "../third_party/app_lovin_sdk"),
         .package(path: "../third_party/package_with_resources"),
+        .package(url: "https://github.com/Iterable/swift-sdk", from: "6.5.0"),
         .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: "3.0.4"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "7.1.0"),
         .package(

--- a/examples/resources_example/swift_deps_index.json
+++ b/examples/resources_example/swift_deps_index.json
@@ -5,7 +5,8 @@
     "googlesignin-ios",
     "package_with_resources",
     "recaptcha-enterprise-mobile-sdk",
-    "sdwebimageswiftui"
+    "sdwebimageswiftui",
+    "swift-sdk"
   ],
   "modules": [
     {
@@ -206,6 +207,28 @@
       "product_memberships": [
         "SDWebImageSwiftUI"
       ]
+    },
+    {
+      "name": "IterableAppExtensions",
+      "c99name": "IterableAppExtensions",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_sdk//:IterableAppExtensions.rspm",
+      "modulemap_label": "@swiftpkg_swift_sdk//:IterableAppExtensions.rspm_modulemap",
+      "package_identity": "swift-sdk",
+      "product_memberships": [
+        "IterableAppExtensions"
+      ]
+    },
+    {
+      "name": "IterableSDK",
+      "c99name": "IterableSDK",
+      "src_type": "swift",
+      "label": "@swiftpkg_swift_sdk//:IterableSDK.rspm",
+      "modulemap_label": "@swiftpkg_swift_sdk//:IterableSDK.rspm_modulemap",
+      "package_identity": "swift-sdk",
+      "product_memberships": [
+        "IterableSDK"
+      ]
     }
   ],
   "products": [
@@ -316,6 +339,18 @@
       "name": "SDWebImageMapKit",
       "type": "library",
       "label": "@swiftpkg_sdwebimage//:SDWebImageMapKit"
+    },
+    {
+      "identity": "swift-sdk",
+      "name": "IterableAppExtensions",
+      "type": "library",
+      "label": "@swiftpkg_swift_sdk//:IterableAppExtensions"
+    },
+    {
+      "identity": "swift-sdk",
+      "name": "IterableSDK",
+      "type": "library",
+      "label": "@swiftpkg_swift_sdk//:IterableSDK"
     }
   ],
   "packages": [
@@ -410,6 +445,15 @@
         "commit": "b7af5e6bd9c2987e41730400d1baad13d74a141a",
         "remote": "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
         "version": "3.0.4"
+      }
+    },
+    {
+      "name": "swiftpkg_swift_sdk",
+      "identity": "swift-sdk",
+      "remote": {
+        "commit": "cb64b4d1717f309dee72a9c71f886888ce3328c3",
+        "remote": "https://github.com/Iterable/swift-sdk",
+        "version": "6.5.2"
       }
     }
   ]

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -253,7 +253,7 @@ def _new_target_from_json_maps(
         ]
 
         for p in resource_files:
-            res = _new_resource_from_discovered_resource(p) # TODO: Use a more accurate function name
+            res = _new_resource_from_discovered_resource(p)
             sets.insert(resources_set, res)
 
     artifact_download_info = None
@@ -339,6 +339,7 @@ def _should_expand_resource(repository_ctx, resource):
     if not repository_files.is_directory(repository_ctx, path):
         return False
     
+    # xcassets and xcdatamodeld folders should be expanded in-place rather than copied directly.
     if path.endswith(".xcassets") or path.endswith(".xcdatamodeld"):
         return True
 

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -229,9 +229,11 @@ def _new_target_from_json_maps(
 
     # The description JSON should have a list with all of the resources with
     # their absolute paths.
+    # Do not include directories in the output.
     resources_set = sets.make([
         _new_resource_from_desc_map(r, pkg_path)
         for r in desc_map.get("resources", [])
+        if not repository_files.is_directory(repository_ctx, r["path"])
     ])
 
     artifact_download_info = None

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -237,14 +237,16 @@ def _new_target_from_json_maps(
 
     # Replace specific resource directories from the desc_map with a list of their contents
     resource_directories = [
-        r for r in sets.to_list(resources_set)
+        r
+        for r in sets.to_list(resources_set)
         if _should_expand_resource(repository_ctx, r)
     ]
     for directory in resource_directories:
         sets.remove(resources_set, directory)
 
         resource_files = [
-            p for p in repository_files.list_files_under(
+            p
+            for p in repository_files.list_files_under(
                 repository_ctx,
                 directory.path,
                 exclude_paths = exclude_paths,
@@ -338,7 +340,7 @@ def _should_expand_resource(repository_ctx, resource):
 
     if not repository_files.is_directory(repository_ctx, path):
         return False
-    
+
     # xcassets and xcdatamodeld folders should be expanded in-place rather than copied directly.
     if path.endswith(".xcassets") or path.endswith(".xcdatamodeld"):
         return True


### PR DESCRIPTION
I'm not sure if this is the best solution, but it did solve my issues. Happy to discuss other approaches.

This is the error I'm seeing:
```
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/internal/ios_rules.bzl", line 444, column 41, in _ios_application_impl
		processor_result = processor.process(
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/internal/processor.bzl", line 747, column 36, in _process
		partial_outputs = [partial.call(p) for p in partials]
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/bazel_skylib~1.5.0/lib/partial.bzl", line 43, column 28, in _call
		return partial.function(*function_args, **function_kwargs)
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/internal/partials/resources.bzl", line 316, column 26, in _resources_partial_impl
		resources.deduplicate(
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/internal/resources.bzl", line 962, column 22, in _deduplicate
		field_handler(field, deduplicated)
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/internal/partials/resources.bzl", line 308, column 37, in _deduplicated_field_handler
		result = processing_func(**processing_args)
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/internal/partials/support/resources_support.bzl", line 261, column 53, in _datamodels
		datamodel_groups.update(group_files_by_directory(
	File "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_apple~3.5.1/apple/utils.bzl", line 117, column 13, in group_files_by_directory
		fail("Expected only files inside directories named with the extensions " +
Error in fail: Expected only files inside directories named with the extensions ["xcdatamodel"], but found: [
  external/rules_swift_package_manager~override~swift_deps~swiftpkg_swift_sdk/swift-sdk/Resources/IterableDataModel.xcdatamodeld
] datamodels
```

I suspect the issues is that the `xcdatamodeld` folder itself is being included in the generated `resources` list here:
```
apple_resource_bundle(
    name = "IterableSDK.rspm_resource_bundle",
    bundle_name = "IterableSDK_IterableSDK",
    infoplists = [":IterableSDK.rspm_resource_bundle_infoplist"],
    resources = [
        "swift-sdk/Resources/Assets.xcassets",
        "swift-sdk/Resources/Assets.xcassets/Contents.json",
        "swift-sdk/Resources/Assets.xcassets/Loading.imageset/Contents.json",
        "swift-sdk/Resources/Assets.xcassets/Loading.imageset/circle-of-dots-png.png",
        "swift-sdk/Resources/IterableDataModel.xcdatamodeld",
        "swift-sdk/Resources/IterableDataModel.xcdatamodeld/IterableDataModel.xcdatamodel/contents",
        "swift-sdk/Resources/SampleInboxCell.xib",
    ],
    visibility = ["//:__subpackages__"],
)
```

Because it's listed in the `desc.json` here:

```json
  "targets" : [
    {
      "c99name" : "IterableSDK",
      "module_type" : "SwiftTarget",
      "name" : "IterableSDK",
      "path" : "swift-sdk",
      "product_memberships" : [
        "IterableSDK"
      ],
      "resources" : [
        {
          "path" : "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_swift_package_manager~override~swift_deps~swiftpkg_swift_sdk/swift-sdk/Resources/SampleInboxCell.xib",
          "rule" : {
            "process" : {

            }
          }
        },
        {
          "path" : "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_swift_package_manager~override~swift_deps~swiftpkg_swift_sdk/swift-sdk/Resources/IterableDataModel.xcdatamodeld",
          "rule" : {
            "process" : {

            }
          }
        },
        {
          "path" : "/private/var/tmp/_bazel_johnflanagan/c6ca44c5b5b4e1c56873b1d5235fffed/external/rules_swift_package_manager~override~swift_deps~swiftpkg_swift_sdk/swift-sdk/Resources/Assets.xcassets",
          "rule" : {
            "process" : {

            }
          }
        }
      ],
```

Skipping directories in the `desc_map` solved the issue for me, but maybe a more correct approach would be to use those directories as inputs into the auto-discovered resource logic and replace the directories with their contents there?