### PR TITLE
fix: Don't use legacy UTF8 handling when writing files

### DIFF
--- a/swiftpkg/internal/build_files.bzl
+++ b/swiftpkg/internal/build_files.bzl
@@ -65,7 +65,7 @@ def _write(repository_ctx, build_file, path):
         bld_file_path,
         content = scg.to_starlark(build_file),
         executable = False,
-        legacy_utf8 = False
+        legacy_utf8 = False,
     )
 
 build_files = struct(

--- a/swiftpkg/internal/build_files.bzl
+++ b/swiftpkg/internal/build_files.bzl
@@ -65,6 +65,7 @@ def _write(repository_ctx, build_file, path):
         bld_file_path,
         content = scg.to_starlark(build_file),
         executable = False,
+        legacy_utf8 = False
     )
 
 build_files = struct(


### PR DESCRIPTION
We have a path that includes a unicode character and without this change the build file is being written with a very strangely encoded path.

According to the documentation the default is going to change soon: https://bazel.build/rules/lib/builtins/repository_ctx#file