### PR TITLE
fix: use constants instead of string for directive names

### DIFF
--- a/gazelle/config.go
+++ b/gazelle/config.go
@@ -166,9 +166,9 @@ func (*swiftLang) Configure(c *config.Config, rel string, f *rule.File) {
 
 	for _, d := range f.Directives {
 		switch d.Key {
-		case "proto_strip_import_prefix":
+		case protoStripImportPrefix:
 			sc.StripImportPrefix = d.Value
-		case "proto_import_prefix":
+		case protoImportPrefix:
 			sc.ImportPrefix = d.Value
 		case swiftModuleNamingConventionDirective:
 			if d.Value == "" {


### PR DESCRIPTION
We should use the constant that we defined instead of a string in the switch statement.
