### PR TITLE
fix: add apple_support to create_example template

### DIFF
--- a/tools/create_example/template_files/MODULE.bazel
+++ b/tools/create_example/template_files/MODULE.bazel
@@ -9,6 +9,7 @@ local_path_override(
 
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.20.2")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
     version = "1.18.0",


### PR DESCRIPTION
Without this change I was getting the following error when creating new examples:
```
ERROR: /private/var/tmp/_bazel_johnflanagan/16c78d03b601ed18f3b30c014db2ef6d/external/rules_swift~~non_module_deps~build_bazel_rules_swift_local_config/BUILD:9:22: in xcode_swift_toolchain rule @@rules_swift~~non_module_deps~build_bazel_rules_swift_local_config//:toolchain:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_johnflanagan/16c78d03b601ed18f3b30c014db2ef6d/external/rules_swift~/swift/internal/xcode_swift_toolchain.bzl", line 555, column 29, in _xcode_swift_toolchain_impl
		target_triples.parse(cc_toolchain.target_gnu_system_name),
	File "/private/var/tmp/_bazel_johnflanagan/16c78d03b601ed18f3b30c014db2ef6d/external/rules_swift~/swift/internal/target_triples.bzl", line 134, column 13, in _parse
		fail("Invalid target triple: {}, this likely means you're using the wrong CC toolchain, make sure you include apple_support in your project".format(triple_string))
Error in fail: Invalid target triple: local, this likely means you're using the wrong CC toolchain, make sure you include apple_support in your project
```