### PR TITLE
fix: synchronize the Bazel version for the BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.1.1
+      - 7.1.2
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Need to synchronize the Bazel version in `.bazelversion` with the value in the presubmit YAML file.
