### PR TITLE
fix: parsing modulemaps with comments

### DIFF
--- a/swiftpkg/internal/modulemap_parser/parser.bzl
+++ b/swiftpkg/internal/modulemap_parser/parser.bzl
@@ -26,7 +26,7 @@ def _parse(text):
         collect_result = None
         err = None
 
-        if token.type == tts.newline:
+        if token.type == tts.newline or token.type == tts.comment:
             pass
 
         elif token.type == tts.reserved:

--- a/swiftpkg/tests/modulemap_parser/tokenizer_tests.bzl
+++ b/swiftpkg/tests/modulemap_parser/tokenizer_tests.bzl
@@ -82,6 +82,28 @@ def _tokenize_test(ctx):
     result = tokenizer.tokenize(text)
     asserts.equals(env, expected, result, "consume string literals")
 
+    text = "// single line comment 1\n/* single line comment 2 */"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.comment("// single line comment 1"),
+            tokens.newline(),
+            tokens.comment("/* single line comment 2 */"),
+        ],
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume single line comments")
+
+    text = "/*\nmulti line comment\nline 1\n // line 2\n*/\n// single line comment"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.comment("/*\nmulti line comment\nline 1\n // line 2\n*/"),
+            tokens.newline(),
+            tokens.comment("// single line comment"),
+        ],
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume multi line comments")
+
     return unittest.end(env)
 
 tokenize_test = unittest.make(_tokenize_test)


### PR DESCRIPTION

Fixes the tokenizer and modulemap parser to support C99 formatted comments. This is probably not amazing but we'll be able to move off this soon: https://github.com/bazelbuild/rules_swift/pull/1212