### PR TITLE
fix: Use `swift_interop_hint` instead of `swift_module` tag

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,12 +23,12 @@ bazel_dep(name = "platforms", version = "0.0.6")
 # rules_swift_package_manager _must_ be a runtime dependency of rules_swift_package_manager.
 bazel_dep(
     name = "rules_swift",
-    version = "1.16.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(
     name = "rules_apple",
-    version = "3.1.1",
+    version = "3.6.0",
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(

--- a/bzlmod/workspace/MODULE.bazel
+++ b/bzlmod/workspace/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/bzlmod/workspace/Tests/MyLibraryTests/BUILD.bazel
+++ b/bzlmod/workspace/Tests/MyLibraryTests/BUILD.bazel
@@ -5,7 +5,6 @@ swift_test(
     name = "MyLibraryTests",
     srcs = [
         "MyLibraryTests.swift",
-        "main.swift",
     ],
     module_name = "MyLibraryTests",
     deps = ["//Sources/MyLibrary"],

--- a/bzlmod/workspace/Tests/MyLibraryTests/MyLibraryTests.swift
+++ b/bzlmod/workspace/Tests/MyLibraryTests/MyLibraryTests.swift
@@ -5,8 +5,4 @@ final class MyLibraryTests: XCTestCase {
     func testExample() throws {
         XCTAssertEqual(World().name, "World")
     }
-
-    static var allTests = [
-      ("testExample", testExample),
-    ]
 }

--- a/bzlmod/workspace/Tests/MyLibraryTests/main.swift
+++ b/bzlmod/workspace/Tests/MyLibraryTests/main.swift
@@ -1,7 +1,0 @@
-#if os(Linux)
-import XCTest
-
-XCTMain([
-    testCase(MyLibraryTests.allTests),
-])
-#endif

--- a/examples/firebase_example/MODULE.bazel
+++ b/examples/firebase_example/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/google_maps_example/MODULE.bazel
+++ b/examples/google_maps_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/grpc_example/MODULE.bazel
+++ b/examples/grpc_example/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/examples/grpc_example/sources/test/BUILD.bazel
+++ b/examples/grpc_example/sources/test/BUILD.bazel
@@ -4,7 +4,6 @@ swift_test(
     name = "test",
     srcs = [
         "client_unit_test.swift",
-        "main.swift",
     ],
     module_name = "Test",
     deps = [

--- a/examples/grpc_example/sources/test/client_unit_test.swift
+++ b/examples/grpc_example/sources/test/client_unit_test.swift
@@ -29,9 +29,9 @@ public class EchoProvider: EchoService_EchoProvider {
   }
 
   public func echo(
-    request: EchoService_EchoRequest, 
-    context: StatusOnlyCallContext) 
-    -> EventLoopFuture<EchoService_EchoResponse> 
+    request: EchoService_EchoRequest,
+    context: StatusOnlyCallContext)
+    -> EventLoopFuture<EchoService_EchoResponse>
   {
     let response = EchoService_EchoResponse.with {
       $0.contents = request.contents
@@ -99,8 +99,4 @@ class ClientUnitTest: XCTestCase {
 
     self.wait(for: [completed], timeout: 10.0)
   }
-
-  static var allTests = [
-    ("testGetWithRealClientAndServer", testGetWithRealClientAndServer),
-  ]
 }

--- a/examples/grpc_example/sources/test/main.swift
+++ b/examples/grpc_example/sources/test/main.swift
@@ -1,7 +1,0 @@
-#if os(Linux)
-import XCTest
-
-XCTMain([
-  testCase(ClientUnitTest.allTests),
-])
-#endif

--- a/examples/grpc_package_example/MODULE.bazel
+++ b/examples/grpc_package_example/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/examples/grpc_package_example/sources/test/BUILD.bazel
+++ b/examples/grpc_package_example/sources/test/BUILD.bazel
@@ -4,7 +4,6 @@ swift_test(
     name = "test",
     srcs = [
         "client_unit_test.swift",
-        "main.swift",
     ],
     module_name = "Test",
     deps = [

--- a/examples/grpc_package_example/sources/test/client_unit_test.swift
+++ b/examples/grpc_package_example/sources/test/client_unit_test.swift
@@ -27,9 +27,9 @@ public class EchoProvider: EchoService_EchoProvider {
   }
 
   public func echo(
-    request: EchoServiceServer.EchoService_EchoRequest, 
-    context: StatusOnlyCallContext) 
-    -> EventLoopFuture<EchoServiceServer.EchoService_EchoResponse> 
+    request: EchoServiceServer.EchoService_EchoRequest,
+    context: StatusOnlyCallContext)
+    -> EventLoopFuture<EchoServiceServer.EchoService_EchoResponse>
   {
     let response = EchoServiceServer.EchoService_EchoResponse.with {
       $0.contents = request.contents
@@ -97,8 +97,4 @@ class ClientUnitTest: XCTestCase {
 
     self.wait(for: [completed], timeout: 10.0)
   }
-
-  static var allTests = [
-    ("testGetWithRealClientAndServer", testGetWithRealClientAndServer),
-  ]
 }

--- a/examples/grpc_package_example/sources/test/main.swift
+++ b/examples/grpc_package_example/sources/test/main.swift
@@ -1,7 +1,0 @@
-#if os(Linux)
-import XCTest
-
-XCTMain([
-  testCase(ClientUnitTest.allTests),
-])
-#endif

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/examples/ios_sim/MODULE.bazel
+++ b/examples/ios_sim/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/lottie_ios_example/MODULE.bazel
+++ b/examples/lottie_ios_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/messagekit_example/MODULE.bazel
+++ b/examples/messagekit_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/nimble_example/MODULE.bazel
+++ b/examples/nimble_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/objc_code/MODULE.bazel
+++ b/examples/objc_code/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/examples/phone_number_kit/MODULE.bazel
+++ b/examples/phone_number_kit/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/pkg_manifest_minimal/MODULE.bazel
+++ b/examples/pkg_manifest_minimal/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/examples/pkg_manifest_minimal/Tests/MyLibraryTests/BUILD.bazel
+++ b/examples/pkg_manifest_minimal/Tests/MyLibraryTests/BUILD.bazel
@@ -4,7 +4,6 @@ swift_test(
     name = "MyLibraryTests",
     srcs = [
         "MyLibraryTests.swift",
-        "main.swift",
     ],
     module_name = "MyLibraryTests",
     deps = ["//Sources/MyLibrary"],

--- a/examples/pkg_manifest_minimal/Tests/MyLibraryTests/main.swift
+++ b/examples/pkg_manifest_minimal/Tests/MyLibraryTests/main.swift
@@ -1,7 +1,0 @@
-#if os(Linux)
-import XCTest
-
-XCTMain([
-    testCase(MyLibraryTests.allTests),
-])
-#endif

--- a/examples/resources_example/MODULE.bazel
+++ b/examples/resources_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/shake_ios_example/MODULE.bazel
+++ b/examples/shake_ios_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/snapkit_example/MODULE.bazel
+++ b/examples/snapkit_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/soto_example/MODULE.bazel
+++ b/examples/soto_example/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/soto_example/Tests/SotoTests/BUILD.bazel
+++ b/examples/soto_example/Tests/SotoTests/BUILD.bazel
@@ -4,7 +4,6 @@ swift_test(
     name = "SotoTests",
     srcs = [
         "SotoTests.swift",
-        "main.swift",
     ],
     module_name = "SotoTests",
     deps = ["@swiftpkg_soto//:SotoS3"],

--- a/examples/soto_example/Tests/SotoTests/SotoTests.swift
+++ b/examples/soto_example/Tests/SotoTests/SotoTests.swift
@@ -7,8 +7,4 @@ class SotoTests: XCTestCase {
         let createBucketRequest = S3.CreateBucketRequest(bucket: bucketName)
         XCTAssertEqual(createBucketRequest.bucket, bucketName)
     }
-
-    static var allTests = [
-        ("testSomething", testSomething),
-    ]
 }

--- a/examples/soto_example/Tests/SotoTests/main.swift
+++ b/examples/soto_example/Tests/SotoTests/main.swift
@@ -1,7 +1,0 @@
-#if os(Linux)
-    import XCTest
-
-    XCTMain([
-        testCase(SotoTests.allTests),
-    ])
-#endif

--- a/examples/stripe_example/MODULE.bazel
+++ b/examples/stripe_example/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/symlink_example/MODULE.bazel
+++ b/examples/symlink_example/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/tca_example/MODULE.bazel
+++ b/examples/tca_example/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/vapor_example/MODULE.bazel
+++ b/examples/vapor_example/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/vapor_example/Tests/AppTests/AppTests.swift
+++ b/examples/vapor_example/Tests/AppTests/AppTests.swift
@@ -12,8 +12,4 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.body.string, "Hello, Timmy!")
         })
     }
-
-    static var allTests = [
-      ("testHelloWorld", testHelloWorld),
-    ]
 }

--- a/examples/vapor_example/Tests/AppTests/BUILD.bazel
+++ b/examples/vapor_example/Tests/AppTests/BUILD.bazel
@@ -4,7 +4,6 @@ swift_test(
     name = "AppTests",
     srcs = [
         "AppTests.swift",
-        "main.swift",
     ],
     module_name = "AppTests",
     deps = [

--- a/examples/vapor_example/Tests/AppTests/main.swift
+++ b/examples/vapor_example/Tests/AppTests/main.swift
@@ -1,7 +1,0 @@
-#if os(Linux)
-import XCTest
-
-XCTMain([
-    testCase(AppTests.allTests),
-])
-#endif

--- a/examples/vapor_example/WORKSPACE
+++ b/examples/vapor_example/WORKSPACE
@@ -48,8 +48,8 @@ gazelle_dependencies()
 
 http_archive(
     name = "build_bazel_rules_swift",
-    sha256 = "bb01097c7c7a1407f8ad49a1a0b1960655cf823c26ad2782d0b7d15b323838e2",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz",
+    sha256 = "9919ed1d8dae509645bfd380537ae6501528d8de971caebed6d5185b9970dc4d",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz",
 )
 
 load(

--- a/examples/xcmetrics_example/MODULE.bazel
+++ b/examples/xcmetrics_example/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 

--- a/swiftpkg/internal/pkginfo_targets.bzl
+++ b/swiftpkg/internal/pkginfo_targets.bzl
@@ -9,6 +9,7 @@ _objc_resource_bundle_accessor_hdr_suffix = "_objc_resource_bundle_accessor_hdr"
 _objc_resource_bundle_accessor_impl_suffix = "_objc_resource_bundle_accessor_impl"
 _resource_bundle_accessor_suffix = "_resource_bundle_accessor"
 _resource_bundle_infoplist_suffix = "_resource_bundle_infoplist"
+_swift_hint_suffix = "_swift_hint"
 
 def _get(targets, name, fail_if_not_found = True):
     """Retrieves the target with the given name from a list of targets.
@@ -135,6 +136,17 @@ def _is_modulemap_label(target_name):
         target.
     """
     return target_name.endswith(_modulemap_suffix)
+
+def _swift_hint_label_name(target_name):
+    """Returns the name of the related `swift_interopt_hint` target.
+
+    Args:
+        target_name: The publicly advertised name for the `cc_library` target.
+
+    Returns:
+        The name of the `swift_interopt_hint` target as a `string`.
+    """
+    return target_name + _swift_hint_suffix
 
 def _resource_bundle_name(module_name):
     """Returns the `bundle_name` for the module.
@@ -267,6 +279,7 @@ def make_pkginfo_targets(bazel_labels):
         resource_bundle_label_name = _resource_bundle_label_name,
         resource_bundle_name = _resource_bundle_name,
         srcs = _srcs,
+        swift_hint_label_name = _swift_hint_label_name,
     )
 
 pkginfo_targets = make_pkginfo_targets(bazel_labels = bazel_labels)

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -231,7 +231,6 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             # Module name
             "-fmodule-name={}".format(target.c99name),
         ],
-        "tags": ["swift_module={}".format(target.c99name)],
         "visibility": ["//:__subpackages__"],
     }
 
@@ -423,9 +422,19 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             ),
         ]
     else:
-        load_stmts = []
+        load_stmts = [swift_interop_hint_load_stmt]
+        aspect_hint_target_name = pkginfo_targets.swift_hint_label_name(
+            bzl_target_name,
+        )
+        attrs["aspect_hints"] = [":{}".format(aspect_hint_target_name)]
+        aspect_hint_attrs = {"module_name": target.c99name}
         decls = [
             build_decls.new(clang_kinds.library, bzl_target_name, attrs = attrs),
+            build_decls.new(
+                kind = swift_kinds.interop_hint,
+                name = aspect_hint_target_name,
+                attrs = aspect_hint_attrs,
+            ),
         ]
     all_build_files.append(build_files.new(
         load_stmts = load_stmts,
@@ -809,6 +818,7 @@ swift_kinds = struct(
     test = "swift_test",
     c_module = "swift_c_module",
     compiler_plugin = "swift_compiler_plugin",
+    interop_hint = "swift_interop_hint",
 )
 
 swift_library_load_stmt = load_statements.new(
@@ -834,6 +844,11 @@ swift_c_module_load_stmt = load_statements.new(
 swift_compiler_plugin_load_stmt = load_statements.new(
     swift_location,
     swift_kinds.compiler_plugin,
+)
+
+swift_interop_hint_load_stmt = load_statements.new(
+    swift_location,
+    swift_kinds.interop_hint,
 )
 
 swift_test_load_stmt = load_statements.new(swift_location, swift_kinds.test)

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -571,9 +571,11 @@ swift_binary(
             msg = "simple clang target",
             name = "ClangLibrary",
             exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_interop_hint")
 
 cc_library(
     name = "ClangLibrary.rspm",
+    aspect_hints = [":ClangLibrary.rspm_swift_hint"],
     copts = [
         "-fblocks",
         "-fobjc-arc",
@@ -593,9 +595,13 @@ cc_library(
         "src/foo.cc",
         "src/foo.h",
     ],
-    tags = ["swift_module=ClangLibrary"],
     textual_hdrs = ["src/foo.cc"],
     visibility = ["//:__subpackages__"],
+)
+
+swift_interop_hint(
+    name = "ClangLibrary.rspm_swift_hint",
+    module_name = "ClangLibrary",
 )
 """,
         ),
@@ -652,7 +658,6 @@ objc_library(
         "src/foo.h",
         "src/foo.m",
     ],
-    tags = ["swift_module=ObjcLibrary"],
     textual_hdrs = ["src/foo.m"],
     visibility = ["//:__subpackages__"],
 )
@@ -711,7 +716,6 @@ objc_library(
         "src/foo.h",
         "src/foo.m",
     ],
-    tags = ["swift_module=ObjcLibraryWithModulemap"],
     textual_hdrs = ["src/foo.m"],
     visibility = ["//:__subpackages__"],
 )
@@ -744,9 +748,11 @@ swift_library(
             msg = "Clang target with conditional dep",
             name = "ClangLibraryWithConditionalDep",
             exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_interop_hint")
 
 cc_library(
     name = "ClangLibraryWithConditionalDep.rspm",
+    aspect_hints = [":ClangLibraryWithConditionalDep.rspm_swift_hint"],
     copts = [
         "-fblocks",
         "-fobjc-arc",
@@ -766,9 +772,13 @@ cc_library(
         "src/foo.cc",
         "src/foo.h",
     ],
-    tags = ["swift_module=ClangLibraryWithConditionalDep"],
     textual_hdrs = ["src/foo.cc"],
     visibility = ["//:__subpackages__"],
+)
+
+swift_interop_hint(
+    name = "ClangLibraryWithConditionalDep.rspm_swift_hint",
+    module_name = "ClangLibraryWithConditionalDep",
 )
 """,
         ),
@@ -908,7 +918,6 @@ objc_library(
         ":ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_hdr",
         ":ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_impl",
     ],
-    tags = ["swift_module=ObjcLibraryWithResources"],
     textual_hdrs = ["src/foo.m"],
     visibility = ["//:__subpackages__"],
 )

--- a/tools/create_example/template_files/MODULE.bazel
+++ b/tools/create_example/template_files/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "apple_support", version = "1.15.1")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(


### PR DESCRIPTION
Needed for rules_swift 2.0+. Only works with rules_swift 2.0+.
