### PR TITLE
fix: fix `byName` resolution

### DIFF
--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -81,7 +81,7 @@ def _resolve_by_name(pkg_ctx, name):
 
     ext_dep = lists.find(
         pkg_ctx.pkg_info.dependencies,
-        lambda d: d.identity == normalized_name,
+        lambda d: d.name == normalized_name,
     )
     if ext_dep != None:
         return [bazel_labels.new(
@@ -89,7 +89,7 @@ def _resolve_by_name(pkg_ctx, name):
             repository_name = bazel_repo_names.from_identity(ext_dep.identity),
             package = "",
         )]
-    fail("Unable to resolve byName reference {name} in {repo_name}.".format(
+    fail("Unable to resolve byName reference {name} in {repo_name}. {deps}".format(
         name = name,
         repo_name = repo_name,
     ))

--- a/swiftpkg/internal/pkginfo_target_deps.bzl
+++ b/swiftpkg/internal/pkginfo_target_deps.bzl
@@ -89,7 +89,7 @@ def _resolve_by_name(pkg_ctx, name):
             repository_name = bazel_repo_names.from_identity(ext_dep.identity),
             package = "",
         )]
-    fail("Unable to resolve byName reference {name} in {repo_name}. {deps}".format(
+    fail("Unable to resolve byName reference {name} in {repo_name}.".format(
         name = name,
         repo_name = repo_name,
     ))

--- a/swiftpkg/tests/pkginfo_target_deps_tests.bzl
+++ b/swiftpkg/tests/pkginfo_target_deps_tests.bzl
@@ -25,7 +25,7 @@ _target_dep_condition = pkginfos.new_target_dependency_condition(
 # AwesomePackage (external dependency)
 
 _external_dep = pkginfos.new_dependency(
-    identity = "awesomepackage",
+    identity = "awesomepackage-identity",
     name = "AwesomePackage",
     file_system = pkginfos.new_file_system(
         path = "/path/to/AwesomePackage",
@@ -134,7 +134,7 @@ def _bzl_select_list_test(ctx):
                     kind = pkginfo_target_deps.target_dep_kind,
                     value = [
                         bazel_labels.normalize(
-                            "@swiftpkg_awesomepackage//:AwesomePackage",
+                            "@swiftpkg_awesomepackage_identity//:AwesomePackage",
                         ),
                     ],
                 ),
@@ -148,7 +148,7 @@ def _bzl_select_list_test(ctx):
                     kind = pkginfo_target_deps.target_dep_kind,
                     value = [
                         bazel_labels.normalize(
-                            "@swiftpkg_awesomepackage//:AwesomeProduct",
+                            "@swiftpkg_awesomepackage_identity//:AwesomeProduct",
                         ),
                     ],
                 ),
@@ -162,7 +162,7 @@ def _bzl_select_list_test(ctx):
                     kind = pkginfo_target_deps.target_dep_kind,
                     value = [
                         bazel_labels.normalize(
-                            "@swiftpkg_awesomepackage//:AwesomeProduct",
+                            "@swiftpkg_awesomepackage_identity//:AwesomeProduct",
                         ),
                     ],
                     condition = c,


### PR DESCRIPTION
In the case of `accessibilitysnapshot`, it depends on `SnapshotTesting` by name. `SnapshotTesting` has an identity of `swift-snapshot-testing` (based on the git url, but it could be different for mirrors/forks), but the name is `snapshottesting`.
