### PR TITLE
fix: sync Bazel version with BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.1.2
+      - 7.2.1
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
The values need to match for BCR.
