### PR TITLE
docs: clarify when to enable `declare_swift_deps_info`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ development inside a Bazel workspace.
 ## Table of Contents
 
 <!-- MARKDOWN TOC: BEGIN -->
-
-- [Documentation](#documentation)
-- [Prerequisites](#prerequisites)
-  - [Mac OS](#mac-os)
-  - [Linux](#linux)
-- [Quickstart](#quickstart)
-  - [1. Enable bzlmod](#1-enable-bzlmod)
-  - [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
-  - [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
-  - [4. Run `swift package update`](#4-run-swift-package-update)
-  - [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
-  - [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
-  - [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
-  - [8. Build and test your project.](#8-build-and-test-your-project)
-  - [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
-  - [10. Start coding](#10-start-coding)
-- [Tips and Tricks](#tips-and-tricks)
+* [Documentation](#documentation)
+* [Prerequisites](#prerequisites)
+  * [Mac OS](#mac-os)
+  * [Linux](#linux)
+* [Quickstart](#quickstart)
+  * [1. Enable bzlmod](#1-enable-bzlmod)
+  * [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
+    * [(Optional) Enable `swit_deps_info` generation for the Gazelle plugin](#optional-enable-swit_deps_info-generation-for-the-gazelle-plugin)
+  * [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
+  * [4. Run `swift package update`](#4-run-swift-package-update)
+  * [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
+  * [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
+  * [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
+  * [8. Build and test your project.](#8-build-and-test-your-project)
+  * [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
+  * [10. Start coding](#10-start-coding)
+* [Tips and Tricks](#tips-and-tricks)
 <!-- MARKDOWN TOC: END -->
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -13,23 +13,24 @@ development inside a Bazel workspace.
 ## Table of Contents
 
 <!-- MARKDOWN TOC: BEGIN -->
-* [Documentation](#documentation)
-* [Prerequisites](#prerequisites)
-  * [Mac OS](#mac-os)
-  * [Linux](#linux)
-* [Quickstart](#quickstart)
-  * [1. Enable bzlmod](#1-enable-bzlmod)
-  * [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
-    * [(Optional) Enable `swit_deps_info` generation for the Gazelle plugin](#optional-enable-swit_deps_info-generation-for-the-gazelle-plugin)
-  * [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
-  * [4. Run `swift package update`](#4-run-swift-package-update)
-  * [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
-  * [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
-  * [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
-  * [8. Build and test your project.](#8-build-and-test-your-project)
-  * [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
-  * [10. Start coding](#10-start-coding)
-* [Tips and Tricks](#tips-and-tricks)
+
+- [Documentation](#documentation)
+- [Prerequisites](#prerequisites)
+  - [Mac OS](#mac-os)
+  - [Linux](#linux)
+- [Quickstart](#quickstart)
+  - [1. Enable bzlmod](#1-enable-bzlmod)
+  - [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
+    - [(Optional) Enable `swit_deps_info` generation for the Gazelle plugin](#optional-enable-swit_deps_info-generation-for-the-gazelle-plugin)
+  - [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
+  - [4. Run `swift package update`](#4-run-swift-package-update)
+  - [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
+  - [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
+  - [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
+  - [8. Build and test your project.](#8-build-and-test-your-project)
+  - [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
+  - [10. Start coding](#10-start-coding)
+- [Tips and Tricks](#tips-and-tricks)
 <!-- MARKDOWN TOC: END -->
 
 ## Documentation
@@ -117,8 +118,7 @@ use_repo(
 )
 ```
 
-You will also need to add a dependency on [rules_swift]. Follow the links below to get the latest
-bzlmod snippets to insert into your `MODULE.bazel`.
+You will also need to add a dependency on [rules_swift].
 
 NOTE: Some Swift package manager features (e.g., resources) use rules from [rules_apple]. It is a
 dependency for `rules_swift_package_manager`. However, you do not need to declare it unless you use

--- a/README.md
+++ b/README.md
@@ -13,22 +13,23 @@ development inside a Bazel workspace.
 ## Table of Contents
 
 <!-- MARKDOWN TOC: BEGIN -->
-* [Documentation](#documentation)
-* [Prerequisites](#prerequisites)
-  * [Mac OS](#mac-os)
-  * [Linux](#linux)
-* [Quickstart](#quickstart)
-  * [1. Enable bzlmod](#1-enable-bzlmod)
-  * [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
-  * [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
-  * [4. Run `swift package update`](#4-run-swift-package-update)
-  * [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
-  * [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
-  * [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
-  * [8. Build and test your project.](#8-build-and-test-your-project)
-  * [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
-  * [10. Start coding](#10-start-coding)
-* [Tips and Tricks](#tips-and-tricks)
+
+- [Documentation](#documentation)
+- [Prerequisites](#prerequisites)
+  - [Mac OS](#mac-os)
+  - [Linux](#linux)
+- [Quickstart](#quickstart)
+  - [1. Enable bzlmod](#1-enable-bzlmod)
+  - [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
+  - [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
+  - [4. Run `swift package update`](#4-run-swift-package-update)
+  - [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
+  - [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
+  - [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
+  - [8. Build and test your project.](#8-build-and-test-your-project)
+  - [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
+  - [10. Start coding](#10-start-coding)
+- [Tips and Tricks](#tips-and-tricks)
 <!-- MARKDOWN TOC: END -->
 
 ## Documentation
@@ -116,15 +117,27 @@ use_repo(
 )
 ```
 
-You will also need to add a dependency on Gazelle and `rules_swift`. Follow
-the links below to get the latest bzlmod snippets to insert into your `MODULE.bazel`.
-
-- [gazelle](https://registry.bazel.build/modules/gazelle)
-- [rules_swift](https://registry.bazel.build/modules/rules_swift)
+You will also need to add a dependency on [rules_swift]. Follow the links below to get the latest
+bzlmod snippets to insert into your `MODULE.bazel`.
 
 NOTE: Some Swift package manager features (e.g., resources) use rules from [rules_apple]. It is a
 dependency for `rules_swift_package_manager`. However, you do not need to declare it unless you use
 any of the rules in your project.
+
+#### (Optional) Enable `swit_deps_info` generation for the Gazelle plugin
+
+If you will be using the Gazelle plugin for Swift, you will need to enable the generation of
+the `swift_deps_info` repository by enabling `declare_swift_deps_info`.
+
+```bazel
+swift_deps.from_package(
+    declare_swift_deps_info = True, # <=== Enable swift_deps_info generation for the Gazelle plugin
+    resolved = "//:Package.resolved",
+    swift = "//:Package.swift",
+)
+```
+
+You will also need to add a dependency on [Gazelle](https://registry.bazel.build/modules/gazelle).
 
 ### 3. Create a minimal `Package.swift` file.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ NOTE: Some Swift package manager features (e.g., resources) use rules from [rule
 dependency for `rules_swift_package_manager`. However, you do not need to declare it unless you use
 any of the rules in your project.
 
-#### (Optional) Enable `swit_deps_info` generation for the Gazelle plugin
+#### (Optional) Enable `swift_deps_info` generation for the Gazelle plugin
 
 If you will be using the Gazelle plugin for Swift, you will need to enable the generation of
 the `swift_deps_info` repository by enabling `declare_swift_deps_info`.

--- a/README.md
+++ b/README.md
@@ -13,24 +13,23 @@ development inside a Bazel workspace.
 ## Table of Contents
 
 <!-- MARKDOWN TOC: BEGIN -->
-
-- [Documentation](#documentation)
-- [Prerequisites](#prerequisites)
-  - [Mac OS](#mac-os)
-  - [Linux](#linux)
-- [Quickstart](#quickstart)
-  - [1. Enable bzlmod](#1-enable-bzlmod)
-  - [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
-    - [(Optional) Enable `swit_deps_info` generation for the Gazelle plugin](#optional-enable-swit_deps_info-generation-for-the-gazelle-plugin)
-  - [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
-  - [4. Run `swift package update`](#4-run-swift-package-update)
-  - [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
-  - [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
-  - [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
-  - [8. Build and test your project.](#8-build-and-test-your-project)
-  - [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
-  - [10. Start coding](#10-start-coding)
-- [Tips and Tricks](#tips-and-tricks)
+* [Documentation](#documentation)
+* [Prerequisites](#prerequisites)
+  * [Mac OS](#mac-os)
+  * [Linux](#linux)
+* [Quickstart](#quickstart)
+  * [1. Enable bzlmod](#1-enable-bzlmod)
+  * [2. Configure your `MODULE.bazel` to use rules_swift_package_manager.](#2-configure-your-modulebazel-to-use-rules_swift_package_manager)
+    * [(Optional) Enable `swift_deps_info` generation for the Gazelle plugin](#optional-enable-swift_deps_info-generation-for-the-gazelle-plugin)
+  * [3. Create a minimal `Package.swift` file.](#3-create-a-minimal-packageswift-file)
+  * [4. Run `swift package update`](#4-run-swift-package-update)
+  * [5. Run `bazel mod tidy`.](#5-run-bazel-mod-tidy)
+  * [6. Add Gazelle targets to `BUILD.bazel` at the root of your workspace.](#6-add-gazelle-targets-to-buildbazel-at-the-root-of-your-workspace)
+  * [7. Create or update Bazel build files for your project.](#7-create-or-update-bazel-build-files-for-your-project)
+  * [8. Build and test your project.](#8-build-and-test-your-project)
+  * [9. Check in `Package.swift`, `Package.resolved`, and `MODULE.bazel`.](#9-check-in-packageswift-packageresolved-and-modulebazel)
+  * [10. Start coding](#10-start-coding)
+* [Tips and Tricks](#tips-and-tricks)
 <!-- MARKDOWN TOC: END -->
 
 ## Documentation


### PR DESCRIPTION
Clarify when the `declare_swift_deps_info` attribute should be enabled for workspaces that use  `rules_swift_package_manager`.

Closes #1176.
