### PR TITLE
fix: ignore unresolved packages in Package.swift

### DIFF
--- a/swiftpkg/bzlmod/swift_deps.bzl
+++ b/swiftpkg/bzlmod/swift_deps.bzl
@@ -48,6 +48,19 @@ def _declare_pkgs_from_package(module_ctx, from_package, config_pkgs):
     direct_dep_repo_names = []
     direct_dep_pkg_infos = {}
     for dep in pkg_info.dependencies:
+        # Ignore unresolved dependencies, for example for a new packgage added
+        # to the `Package.swift` which has not been resolved yet.
+        # By ignoring these for now we can allow the build to progress while
+        # expecting a resolution in the future.
+        if not dep.file_system and \
+           not dep.source_control:
+            # buildifier: disable=print
+            print("""
+WARNING: {name} is unresolved and won't be available duing the build, resolve \
+the Swift package to make it available.\
+""".format(name = dep.name))
+            continue
+
         bazel_repo_name = bazel_repo_names.from_identity(dep.identity)
         direct_dep_repo_names.append(bazel_repo_name)
         pkg_info_label = "@{}//:pkg_info.json".format(bazel_repo_name)
@@ -168,9 +181,6 @@ def _declare_pkg_from_dependency(dep, config_pkg):
             path = dep.file_system.path,
             dependencies_index = None,
         )
-
-    else:
-        fail("Unrecognized dependency type for {}.".format(dep.identity))
 
 def _swift_deps_impl(module_ctx):
     config_pkgs = {}

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -690,10 +690,7 @@ def _new_dependency(identity, name, source_control = None, file_system = None):
     Returns:
         A `struct` representing an external dependency.
     """
-    if not source_control and not file_system:
-        fail("""\
-A dependency must have either a source_control or file_system arg.\
-""")
+
     return struct(
         identity = identity,
         name = pkginfo_dependencies.normalize_name(name),
@@ -710,6 +707,9 @@ def _new_source_control(pin):
     Returns:
         A `struct` representing source control info for a dependency.
     """
+    if not pin:
+        return None
+
     return struct(
         pin = pin,
     )


### PR DESCRIPTION
This fixes an issue where if a brand new dependency is added to the `Package.swift` when `Package.resolved` has not yet been updated, the Bazel build fails. It fails because there is no `pin` available for the `source_control` dependency as the `Package.resolved` has not yet been updated.

For example, a command line tool built using `rules_swift_package_manager` which has a `Package.swift` for `swift-argument-parser`. If a new dependency is added to the `Package.swift` but not yet used in any of the Bazel targets and no `swift package resolve` has been run when a build is run the build will fail with:

```
File bazel-path/external/rules_swift_package_manager~/swiftpkg/bzlmod/swift_deps.bzl", line 152, column 25, in _declare_pkg_from_dependency
                commit = pin.state.revision,
Error: 'NoneType' value has no field or method 'state'
```

This change allows the build to progress by simply ignoring the unresolved dependencies until a `swift package resolve` is run by the user.