### PR TITLE
fix: usage of `copts` for `SWIFT_PACKAGE`

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -106,6 +106,9 @@ def _swift_target_build_file(pkg_ctx, target):
         # SPM directive instructing the code to build as if a Swift package.
         # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
         "-DSWIFT_PACKAGE",
+        # SPM directive instructing the code to build as if a Swift package for any clang modules.
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
     ]
 
     # GH046: Support plugins.

--- a/swiftpkg/tests/bzl_selects_tests.bzl
+++ b/swiftpkg/tests/bzl_selects_tests.bzl
@@ -158,11 +158,12 @@ def _to_starlark_test(ctx):
         struct(
             msg = "string values",
             khs = {},
-            vals = ["first", "second", "first"],
+            vals = ["-DFoo", "-Xcc", "-DFoo"],
             exp = """\
 [
-    "first",
-    "second",
+    "-DFoo",
+    "-Xcc",
+    "-DFoo",
 ]\
 """,
         ),
@@ -271,22 +272,27 @@ def _to_starlark_test(ctx):
             khs = {},
             vals = [
                 bzl_selects.new(
-                    value = "a",
+                    value = "-DFoo",
                     kind = "mykind",
                     condition = "//myconditions:alpha",
                 ),
                 bzl_selects.new(
-                    value = "b",
+                    value = "-DBar",
                     kind = "mykind",
                     condition = "//myconditions:beta",
                 ),
                 bzl_selects.new(
-                    value = "c",
+                    value = "-DZoo",
                     kind = "mykind",
                     condition = "//myconditions:alpha",
                 ),
                 bzl_selects.new(
-                    value = "a",
+                    value = "-Xcc",
+                    kind = "mykind",
+                    condition = "//myconditions:alpha",
+                ),
+                bzl_selects.new(
+                    value = "-DFoo",
                     kind = "mykind",
                     condition = "//myconditions:alpha",
                 ),
@@ -294,10 +300,12 @@ def _to_starlark_test(ctx):
             exp = """\
 select({
     "//myconditions:alpha": [
-        "a",
-        "c",
+        "-DFoo",
+        "-DZoo",
+        "-Xcc",
+        "-DFoo",
     ],
-    "//myconditions:beta": ["b"],
+    "//myconditions:beta": ["-DBar"],
     "//conditions:default": [],
 })\
 """,

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -495,7 +495,11 @@ swift_library(
     name = "RegularSwiftTargetAsLibrary.rspm",
     always_include_developer_search_paths = True,
     alwayslink = True,
-    copts = ["-DSWIFT_PACKAGE"],
+    copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
+    ],
     module_name = "RegularSwiftTargetAsLibrary",
     package_name = "MyPackage",
     srcs = ["Source/RegularSwiftTargetAsLibrary/RegularSwiftTargetAsLibrary.swift"],
@@ -517,7 +521,11 @@ swift_library(
     name = "RegularTargetForExec.rspm",
     always_include_developer_search_paths = True,
     alwayslink = True,
-    copts = ["-DSWIFT_PACKAGE"],
+    copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
+    ],
     deps = ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
     module_name = "RegularTargetForExec",
     package_name = "MyPackage",
@@ -535,7 +543,11 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "RegularSwiftTargetAsLibraryTests.rspm",
-    copts = ["-DSWIFT_PACKAGE"],
+    copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
+    ],
     deps = ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
     module_name = "RegularSwiftTargetAsLibraryTests",
     package_name = "MyPackage",
@@ -553,6 +565,8 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 swift_binary(
     name = "SwiftExecutableTarget.rspm",
     copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
         "-DSWIFT_PACKAGE",
         "-enable-experimental-feature",
         "BuiltinModule",
@@ -771,7 +785,11 @@ swift_library(
     name = "SwiftLibraryWithConditionalDep.rspm",
     always_include_developer_search_paths = True,
     alwayslink = True,
-    copts = ["-DSWIFT_PACKAGE"],
+    copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
+    ],
     deps = ["@swiftpkg_mypackage//:ClangLibrary.rspm"] + select({
         "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
         "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
@@ -853,7 +871,11 @@ swift_library(
     name = "SwiftForObjcTarget.rspm",
     always_include_developer_search_paths = True,
     alwayslink = True,
-    copts = ["-DSWIFT_PACKAGE"],
+    copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
+    ],
     deps = ["@swiftpkg_mypackage//:ObjcLibraryDep.rspm"],
     features = ["swift.propagate_generated_module_map"],
     generates_header = True,
@@ -895,7 +917,11 @@ swift_library(
     name = "SwiftLibraryWithFilePathResource.rspm",
     always_include_developer_search_paths = True,
     alwayslink = True,
-    copts = ["-DSWIFT_PACKAGE"],
+    copts = [
+        "-DSWIFT_PACKAGE",
+        "-Xcc",
+        "-DSWIFT_PACKAGE",
+    ],
     data = [":SwiftLibraryWithFilePathResource.rspm_resource_bundle"],
     module_name = "SwiftLibraryWithFilePathResource",
     package_name = "MyPackage",


### PR DESCRIPTION
This primarily does two changes:

- Passes `-Xcc -DSWIFT_PACKAGE` for the Swift library target generated `copts` attribute.
- Removes de-duplication in `bzl_selects.bzl`
  - Using `sets` enforces unique values for the fields which is problematic, for example: `copts = ["-DSWIFT_PACKAGE", "-Xcc", "-DSWIFT_PACKAGE"]` are valid copts but would get de-duplicated into `copts = ["-DSWIFT_PACKAGE", "-Xcc"]`.
  - We should not work-around duplicated `deps`, `copts`, etc. in the `BUILD` file generator. If issues arise during the build the `Package.swift` for the package should be fixed if it is a legitimate duplicate.

Fixes #1259