### PR TITLE
chore: add example of SWIFT_PACKAGE defines

### DIFF
--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -44,6 +44,7 @@ swift_binary(
         "@swiftpkg_libwebp_xcode//:libwebp",
         "@swiftpkg_opencombine//:OpenCombine",
         "@swiftpkg_swift_log//:Logging",
+        "@swiftpkg_swift_package_defines_example//:FooSwift",
     ],
 )
 

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -79,5 +79,6 @@ use_repo(
     "swiftpkg_ocmock",
     "swiftpkg_opencombine",
     "swiftpkg_swift_log",
+    "swiftpkg_swift_package_defines_example",
     "swiftpkg_yoti_doc_scan_ios",
 )

--- a/examples/interesting_deps/Package.resolved
+++ b/examples/interesting_deps/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "swift-package-defines-example",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luispadron/swift-package-defines-example",
+      "state" : {
+        "revision" : "e32185cc3c893e81acbb3e359831dbacde4575bc",
+        "version" : "2.0.0"
+      }
+    },
+    {
       "identity" : "yoti-doc-scan-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getyoti/yoti-doc-scan-ios.git",

--- a/examples/interesting_deps/Package.swift
+++ b/examples/interesting_deps/Package.swift
@@ -12,5 +12,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.6.2"),
         .package(url: "https://github.com/erikdoe/ocmock", from: "3.9.4"),
         .package(url: "https://github.com/getyoti/yoti-doc-scan-ios.git", from: "6.0.0"),
+        .package(url: "https://github.com/luispadron/swift-package-defines-example", from: "2.0.0"),
     ]
 )

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -1,5 +1,6 @@
 import CocoaLumberjack
 import CocoaLumberjackSwiftLogBackend
+import FooSwift
 import GEOSwift
 import libwebp
 import Logging
@@ -14,3 +15,5 @@ logger.info("Hello World!")
 
 let webpVersion = WebPGetDecoderVersion()
 logger.info("WebP version: \(webpVersion)")
+
+fooSwift()


### PR DESCRIPTION
Showcases an issue with `SWIFT_PACKAGE` defines when consuming a Swift Package like: https://github.com/luispadron/swift-package-defines-example

The package above builds with `swift build` but fails when building through Bazel in the added example (without #1260)

```sh
cd examples/interesting_deps && bazel build print

ERROR: 
...
external/rules_swift_package_manager~~swift_deps~swiftpkg_swift_package_defines_example/Sources/FooSwift/Foo.swift:5:24: error: cannot find 'foo' in scope
3 | public func fooSwift() {
4 |     print("FooSwift")
5 |     print("ObjC foo: \(foo())")
  |                        `- error: cannot find 'foo' in scope
6 | }
7 | 
```