### PR TITLE
chore: update BCR Bazel version to match .bazelversion

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.3.1
+      - 7.3.2
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
The BCR version must match the version in `.bazelversion`.
