### PR TITLE
chore: sync Bazel version in BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.3.2
+      - 7.4.0
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Must be the same for BCR presubmit to succeed.