### PR TITLE
feat: support non-string attrs in swift_package_tool

### DIFF
--- a/docs/bzlmod_extensions_overview.md
+++ b/docs/bzlmod_extensions_overview.md
@@ -56,9 +56,9 @@ Used to configure the flags used when running the `swift package` binary.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="swift_deps.configure_swift_package-build_path"></a>build_path |  The relative path within the runfiles tree for the Swift Package Manager build directory.   | String | optional |  `".build"`  |
 | <a id="swift_deps.configure_swift_package-cache_path"></a>cache_path |  The relative path within the runfiles tree for the shared Swift Package Manager cache directory.   | String | optional |  `".cache"`  |
-| <a id="swift_deps.configure_swift_package-dependency_caching"></a>dependency_caching |  Whether to enable the dependency cache.   | String | optional |  `"true"`  |
+| <a id="swift_deps.configure_swift_package-dependency_caching"></a>dependency_caching |  Whether to enable the dependency cache.   | Boolean | optional |  `True`  |
 | <a id="swift_deps.configure_swift_package-manifest_cache"></a>manifest_cache |  Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled)   | String | optional |  `"shared"`  |
-| <a id="swift_deps.configure_swift_package-manifest_caching"></a>manifest_caching |  Whether to enable build manifest caching.   | String | optional |  `"true"`  |
+| <a id="swift_deps.configure_swift_package-manifest_caching"></a>manifest_caching |  Whether to enable build manifest caching.   | Boolean | optional |  `True`  |
 
 <a id="swift_deps.from_package"></a>
 

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -58,9 +58,9 @@ swift_deps.from_package(
 swift_deps.configure_swift_package(
     build_path = "spm-build",
     cache_path = "spm-cache",
-    dependency_caching = "false",
+    dependency_caching = False,
     manifest_cache = "none",
-    manifest_caching = "false",
+    manifest_caching = False,
 )
 use_repo(
     swift_deps,

--- a/swiftpkg/internal/swift_package_tool.bzl
+++ b/swiftpkg/internal/swift_package_tool.bzl
@@ -24,8 +24,8 @@ def _swift_package_tool_impl(ctx):
     template_dict.add("%(package_path)s", package_path)
     template_dict.add("%(build_path)s", build_path)
     template_dict.add("%(cache_path)s", cache_path)
-    template_dict.add("%(enable_build_manifest_caching)s", ctx.attr.manifest_caching)
-    template_dict.add("%(enable_dependency_cache)s", ctx.attr.dependency_caching)
+    template_dict.add("%(enable_build_manifest_caching)s", "true" if ctx.attr.manifest_caching else "false")
+    template_dict.add("%(enable_dependency_cache)s", "true" if ctx.attr.dependency_caching else "false")
     template_dict.add("%(manifest_cache)s", ctx.attr.manifest_cache)
 
     ctx.actions.expand_template(
@@ -52,10 +52,9 @@ SWIFT_PACKAGE_CONFIG_ATTRS = {
         doc = "The relative path within the runfiles tree for the shared Swift Package Manager cache directory.",
         default = ".cache",
     ),
-    "dependency_caching": attr.string(
+    "dependency_caching": attr.bool(
         doc = "Whether to enable the dependency cache.",
-        default = "true",
-        values = ["true", "false"],
+        default = True,
     ),
     "manifest_cache": attr.string(
         doc = """Caching mode of Package.swift manifests \
@@ -64,10 +63,9 @@ SWIFT_PACKAGE_CONFIG_ATTRS = {
         default = "shared",
         values = ["shared", "local", "none"],
     ),
-    "manifest_caching": attr.string(
+    "manifest_caching": attr.bool(
         doc = "Whether to enable build manifest caching.",
-        default = "true",
-        values = ["true", "false"],
+        default = True,
     ),
 }
 


### PR DESCRIPTION
Sort of missed doing this in #1307 but it provides a nicer interface for users and will support the `dict` attr for the upcoming Swift Package Registry support.

