### PR TITLE
feat: set a default `--security-path` for swift_package_tool

### DIFF
--- a/docs/bzlmod_extensions_overview.md
+++ b/docs/bzlmod_extensions_overview.md
@@ -18,7 +18,7 @@ swift_deps = use_extension("@rules_swift_package_manager//:extensions.bzl", "swi
 swift_deps.configure_package(<a href="#swift_deps.configure_package-name">name</a>, <a href="#swift_deps.configure_package-init_submodules">init_submodules</a>, <a href="#swift_deps.configure_package-patch_args">patch_args</a>, <a href="#swift_deps.configure_package-patch_cmds">patch_cmds</a>, <a href="#swift_deps.configure_package-patch_cmds_win">patch_cmds_win</a>,
                              <a href="#swift_deps.configure_package-patch_tool">patch_tool</a>, <a href="#swift_deps.configure_package-patches">patches</a>, <a href="#swift_deps.configure_package-recursive_init_submodules">recursive_init_submodules</a>)
 swift_deps.configure_swift_package(<a href="#swift_deps.configure_swift_package-build_path">build_path</a>, <a href="#swift_deps.configure_swift_package-cache_path">cache_path</a>, <a href="#swift_deps.configure_swift_package-dependency_caching">dependency_caching</a>, <a href="#swift_deps.configure_swift_package-manifest_cache">manifest_cache</a>,
-                                   <a href="#swift_deps.configure_swift_package-manifest_caching">manifest_caching</a>)
+                                   <a href="#swift_deps.configure_swift_package-manifest_caching">manifest_caching</a>, <a href="#swift_deps.configure_swift_package-security_path">security_path</a>)
 swift_deps.from_package(<a href="#swift_deps.from_package-declare_swift_deps_info">declare_swift_deps_info</a>, <a href="#swift_deps.from_package-declare_swift_package">declare_swift_package</a>, <a href="#swift_deps.from_package-resolved">resolved</a>, <a href="#swift_deps.from_package-swift">swift</a>)
 </pre>
 
@@ -59,6 +59,7 @@ Used to configure the flags used when running the `swift package` binary.
 | <a id="swift_deps.configure_swift_package-dependency_caching"></a>dependency_caching |  Whether to enable the dependency cache.   | Boolean | optional |  `True`  |
 | <a id="swift_deps.configure_swift_package-manifest_cache"></a>manifest_cache |  Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled)   | String | optional |  `"shared"`  |
 | <a id="swift_deps.configure_swift_package-manifest_caching"></a>manifest_caching |  Whether to enable build manifest caching.   | Boolean | optional |  `True`  |
+| <a id="swift_deps.configure_swift_package-security_path"></a>security_path |  The relative path within the runfiles tree for the security directory.   | String | optional |  `".security"`  |
 
 <a id="swift_deps.from_package"></a>
 

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -61,6 +61,7 @@ swift_deps.configure_swift_package(
     dependency_caching = False,
     manifest_cache = "none",
     manifest_caching = False,
+    security_path = "spm-security",
 )
 use_repo(
     swift_deps,

--- a/swiftpkg/internal/swift_package_tool.bzl
+++ b/swiftpkg/internal/swift_package_tool.bzl
@@ -27,6 +27,7 @@ def _swift_package_tool_impl(ctx):
     template_dict.add("%(enable_build_manifest_caching)s", "true" if ctx.attr.manifest_caching else "false")
     template_dict.add("%(enable_dependency_cache)s", "true" if ctx.attr.dependency_caching else "false")
     template_dict.add("%(manifest_cache)s", ctx.attr.manifest_cache)
+    template_dict.add("%(security_path)s", ctx.attr.security_path)
 
     ctx.actions.expand_template(
         template = ctx.file._runner_template,
@@ -66,6 +67,10 @@ SWIFT_PACKAGE_CONFIG_ATTRS = {
     "manifest_caching": attr.bool(
         doc = "Whether to enable build manifest caching.",
         default = True,
+    ),
+    "security_path": attr.string(
+        doc = "The relative path within the runfiles tree for the security directory.",
+        default = ".security",
     ),
 }
 

--- a/swiftpkg/internal/swift_package_tool_runner_template.sh
+++ b/swiftpkg/internal/swift_package_tool_runner_template.sh
@@ -26,6 +26,7 @@ cache_path="%(cache_path)s"
 enable_build_manifest_caching="%(enable_build_manifest_caching)s"
 enable_dependency_cache="%(enable_dependency_cache)s"
 manifest_cache="%(manifest_cache)s"
+security_path="%(security_path)s"
 
 # Construct dynamic arguments.
 args=()
@@ -46,9 +47,10 @@ args+=("--manifest-cache=$manifest_cache")
 
 # Run the command.
 "$swift_worker" swift package \
-  --package-path "$package_path" \
   --build-path "$build_path" \
   --cache-path "$cache_path" \
+  --package-path "$package_path" \
+  --security-path "$security_path" \
   "$cmd" \
   "${args[@]}" \
   "$@"


### PR DESCRIPTION
Add support for setting a custom `--security-path`. This also ensures the global path is not used.

