### PR TITLE
fix: suppress modulemap target via swift interop

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "platforms", version = "0.0.6")
 # rules_swift_package_manager _must_ be a runtime dependency of rules_swift_package_manager.
 bazel_dep(
     name = "rules_swift",
-    version = "2.1.1",
+    version = "2.2.0",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/swiftpkg/internal/BUILD.bazel
+++ b/swiftpkg/internal/BUILD.bazel
@@ -232,6 +232,7 @@ bzl_library(
     deps = [
         ":clang_files",
         ":module_maps",
+        "@build_bazel_rules_swift//swift",
     ],
 )
 

--- a/swiftpkg/internal/generate_modulemap.bzl
+++ b/swiftpkg/internal/generate_modulemap.bzl
@@ -5,6 +5,7 @@
 # https://github.com/bazel-xcode/PodToBUILD/blob/e9bbf68151caf6c8cd9b8ed2fa361b38e0f6a860/BazelExtensions/extensions.bzl#L113
 # https://github.com/bazel-xcode/xchammer/blob/master/sample/UrlGet/Vendor/rules_pods/BazelExtensions/extensions.bzl
 
+load("@build_bazel_rules_swift//swift:swift_interop_info.bzl", "create_swift_interop_info")
 load(":clang_files.bzl", "clang_files")
 load(":module_maps.bzl", "write_module_map")
 
@@ -66,6 +67,12 @@ def _generate_modulemap_impl(ctx):
     )
     provider_hdr = [modulemap_file]
 
+    # This target itself is a modulemap, so suppress any module generation
+    # rules_swift does for it.
+    swift_interop_info = create_swift_interop_info(
+        suppressed = True,
+    )
+
     return [
         DefaultInfo(files = depset([modulemap_file])),
         ModuleMapInfo(
@@ -81,6 +88,7 @@ def _generate_modulemap_impl(ctx):
                 includes = depset([modulemap_file.dirname]),
             ),
         ),
+        swift_interop_info,
     ]
 
 generate_modulemap = rule(


### PR DESCRIPTION
rules_swift will create a modulemap automatically unless the `SwiftInteropInfo` is suppressed. Since the `generate_modulemap` rule itself is a modulemap it should not have a modulemap generated for it.

![Screenshot 2024-12-06 at 12 11 01 PM](https://github.com/user-attachments/assets/8b041952-9077-43f5-a8ba-1b8eb4cc1805)
