### PR TITLE
feat: Add initial support to System Library

### DIFF
--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -375,6 +375,20 @@ def _new_target_from_json_maps(
                 pkg_path = pkg_path,
                 sources = clang_src_info.explicit_srcs + clang_src_info.hdrs,
             )
+    elif module_type == module_types.system_library:
+        # System libraries have their headers/modulemaps in the library root path, so the root path is the public path
+        public_hdrs_path = ""
+        
+        clang_src_info = _new_clang_src_info_from_sources(
+            repository_ctx = repository_ctx,
+            pkg_path = pkg_path,
+            c99name = c99name,
+            target_path = target_path,
+            source_paths = source_paths,
+            public_hdrs_path = public_hdrs_path,
+            exclude_paths = exclude_paths,
+            other_hdr_srch_paths = [],
+        )
 
     return _new_target(
         name = target_name,

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -85,7 +85,6 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
         else:
             target_deps.append(target_dep)
             continue
-        
 
     if macro_targets:
         attrs["plugins"] = [
@@ -690,12 +689,12 @@ def _system_library_build_file(target):
 
     bzl_target_name = pkginfo_targets.bazel_label_name(target)
 
-    decls = [ 
+    decls = [
         build_decls.new(
             kind = objc_kinds.library,
             name = bzl_target_name,
             attrs = attrs,
-        )
+        ),
     ]
 
     return build_files.new(

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -19,7 +19,7 @@ def _new_for_target(repository_ctx, pkg_ctx, target, artifact_infos = []):
     if target.module_type == module_types.clang:
         return _clang_target_build_file(repository_ctx, pkg_ctx, target)
     elif target.module_type == module_types.swift:
-        return _swift_target_build_file(pkg_ctx, target)
+        return _swift_target_build_file(repository_ctx, pkg_ctx, target)
     elif target.module_type == module_types.system_library:
         return _system_library_build_file(target)
     elif target.module_type == module_types.binary:
@@ -36,7 +36,7 @@ def _new_for_target(repository_ctx, pkg_ctx, target, artifact_infos = []):
 
 # MARK: - Swift Target
 
-def _swift_target_build_file(pkg_ctx, target):
+def _swift_target_build_file(repository_ctx, pkg_ctx, target):
     if target.swift_src_info == None:
         fail("Expected a `swift_src_info`. name: ", target.name)
 
@@ -80,10 +80,12 @@ def _swift_target_build_file(pkg_ctx, target):
             fail_if_not_found = False,
         )
 
-        if not dep_target or dep_target.type != target_types.macro:
+        if dep_target and dep_target.type == target_types.macro:
+            macro_targets.append(dep_target)
+        else:
             target_deps.append(target_dep)
             continue
-        macro_targets.append(dep_target)
+        
 
     if macro_targets:
         attrs["plugins"] = [
@@ -107,6 +109,15 @@ def _swift_target_build_file(pkg_ctx, target):
         # https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code
         "-DSWIFT_PACKAGE",
     ]
+
+    linkopts = []
+    if target.linker_settings != None:
+        linkopts.extend(lists.flatten([
+            bzl_selects.new_from_build_setting(bs)
+            for bs in target.linker_settings.linked_libraries
+        ]))
+    if linkopts:
+        attrs["linkopts"] = _starlarkify_clang_attrs(repository_ctx, {"linkopts": linkopts})["linkopts"]
 
     # GH046: Support plugins.
 
@@ -647,12 +658,49 @@ def _starlarkify_clang_attrs(repository_ctx, attrs):
 
 # MARK: - System Library Targets
 
-# GH009(chuck): Remove unused-variable directives
-
-# buildifier: disable=unused-variable
 def _system_library_build_file(target):
-    # GH009(chuck): Implement _system_library_build_file
-    return None
+    attrs = {
+        "visibility": ["//:__subpackages__"],
+    }
+
+    # These flags are used by SPM when compiling clang modules.
+    copts = [
+        # Enable 'blocks' language feature
+        "-fblocks",
+        # Synthesize retain and release calls for Objective-C pointers
+        "-fobjc-arc",
+        # Enable support for PIC macros
+        "-fPIC",
+        # The SWIFT_PACKAGE define is a magical value that SPM uses when it
+        # builds clang libraries that will be used as Swift modules.
+        "-DSWIFT_PACKAGE=1",
+    ]
+    attrs["copts"] = copts
+
+    module_map_file = target.clang_src_info.modulemap_path
+    attrs["module_map"] = module_map_file
+
+    # System library targets must include a modulemap file.
+    # https://github.com/swiftlang/swift-package-manager/blob/12c14222fdde2ffd8303a2c805fed1b1eb802e5c/Sources/PackageLoading/PackageBuilder.swift#L853
+    if not module_map_file:
+        fail("Expected a modulemap file for a system library target. name: ", target.name)
+
+    header_files = target.clang_src_info.hdrs
+    attrs["hdrs"] = header_files
+
+    bzl_target_name = pkginfo_targets.bazel_label_name(target)
+
+    decls = [ 
+        build_decls.new(
+            kind = objc_kinds.library,
+            name = bzl_target_name,
+            attrs = attrs,
+        )
+    ]
+
+    return build_files.new(
+        decls = decls,
+    )
 
 # MARK: - Apple xcframework Targets
 

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -69,6 +69,15 @@ _pkg_info = pkginfos.new(
             targets = ["RegularSwiftTargetAsLibrary"],
         ),
         pkginfos.new_product(
+            name = "SystemLibraryTarget",
+            type = pkginfos.new_product_type(
+                library = pkginfos.new_library_type(
+                    library_type_kinds.automatic,
+                ),
+            ),
+            targets = ["SystemLibraryTarget"],
+        ),
+        pkginfos.new_product(
             name = "ObjcLibraryWithModulemap",
             type = pkginfos.new_product_type(
                 library = pkginfos.new_library_type(
@@ -117,6 +126,20 @@ _pkg_info = pkginfos.new(
             dependencies = [],
             repo_name = _repo_name,
             swift_src_info = pkginfos.new_swift_src_info(),
+        ),
+        pkginfos.new_target(
+            name = "SystemLibraryTarget",
+            type = "regular",
+            c99name = "SystemLibraryTarget",
+            module_type = "SystemLibraryTarget",
+            path = "Source/SystemLibraryTarget",
+            sources = [],
+            dependencies = [],
+            repo_name = _repo_name,
+            clang_src_info = pkginfos.new_clang_src_info(
+                hdrs = ["someHeader.h"],
+                modulemap_path = "module.modulemap",
+            ),
         ),
         pkginfos.new_target(
             name = "RegularSwiftTargetAsLibraryTests",
@@ -758,6 +781,25 @@ swift_interop_hint(
     name = "ObjcLibraryWithModulemap.rspm_swift_hint",
     module_map = "include/module.modulemap",
     module_name = "ObjcLibraryWithModulemap",
+)
+""",
+        ),
+        struct(
+            msg = "System library Target declaration",
+            name = "SystemLibraryTarget",
+            exp = """\
+
+objc_library(
+    name = "SystemLibraryTarget.rspm",
+    copts = [
+        "-fblocks",
+        "-fobjc-arc",
+        "-fPIC",
+        "-DSWIFT_PACKAGE=1",
+    ],
+    hdrs = ["someHeader.h"],
+    module_map = "module.modulemap",
+    visibility = ["//:__subpackages__"],
 )
 """,
         ),


### PR DESCRIPTION
# Initial Support for System Libraries

This PR adds initial support for system libraries in the build system. This implementation focuses on basic system library integration without external package manager support (e.g., Homebrew).

## Changes
- Added basic system library detection and linking
- System libraries are linked directly from standard system paths
- Added validation for system library paths

## Limitations
- Does not support external package managers (e.g., Homebrew, apt)
- Limited to default system library paths
- No version management for system dependencies

## Future Work
- Add support for external package managers
- Implement version management for system libraries
- Add support for external providers library search paths

## Testing
- Added tests for basic system library linking
- Verified functionality with standard system libraries