### PR TITLE
fix: Replicates SPM default behavior for publicHeadersPath: If this is nil, the directory is set to include

### DIFF
--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -1067,6 +1067,14 @@ def _new_clang_src_info_from_sources(
             paths.normalize(paths.join(abs_target_path, public_hdrs_path)),
         )
 
+    # If the Swift package manifest does not specify a public headers path,
+    # use the default "include" directory, if it exists.
+    # This copies the behavior of the canonical Swift Package Manager implementation.
+    # https://developer.apple.com/documentation/packagedescription/target/publicheaderspath
+    if public_hdrs_path == None:
+        if repository_files.path_exists(repository_ctx, paths.join(abs_target_path, "include")):
+            public_includes.append(paths.join(abs_target_path, "include"))
+
     # If the Swift package manifest has explicit source paths, respect them.
     # (Be sure to include any explicitly specified include directories.)
     # Otherwise, use all of the source files under the target path.


### PR DESCRIPTION
# Match SPM's default behavior for public headers path

When SPM processes a target without an explicit `publicHeadersPath`, it follows these rules:
1. If `publicHeadersPath` is nil and an `include/` directory exists, use `include/` as the public headers path
2. This makes all headers in the `include/` directory visible to dependent targets

This PR replicates this canonical behavior by:
- Checking for the existence of `include/` directory when `publicHeadersPath` is not set
- Using `include/` as the public headers path if it exists
- Making all headers in `include/*.h` visible to clang targets

https://developer.apple.com/documentation/packagedescription/target/publicheaderspath