### PR TITLE
fix: Ignore invalid xcframework paths

### DIFF
--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -139,6 +139,17 @@ def _artifact_infos_from_path(repository_ctx, path):
             by_name = "*.xcframework",
         )
 
+    # NOTE: SPM validates the `.xcframework` paths by decoding the `Info.plist` file.
+    # This would be more involved to do in Starlark, so instead we'll assume
+    # that a `.xcframework` dir is a potential candidate if it contains a
+    # `Info.plist` file without checking the file contents.
+    # See: https://github.com/swiftlang/swift-package-manager/blob/c26c12f54357fb7246c0bdbe3483105389f056b8/Sources/Workspace/Workspace%2BBinaryArtifacts.swift#L771-L780
+    xcframework_dirs = [
+        xf
+        for xf in xcframework_dirs
+        if repository_files.path_exists(repository_ctx, paths.join(xf, "Info.plist"))
+    ]
+
     # If multiple found, use the last one which is what SPM currently does:
     # https://github.com/swiftlang/swift-package-manager/blob/c26c12f54357fb7246c0bdbe3483105389f056b8/Sources/Workspace/Workspace%2BBinaryArtifacts.swift#L699-L723
     if len(xcframework_dirs) > 1:


### PR DESCRIPTION
The rules should ignore invalid `.xcframework` paths like SPM does ([see here](https://github.com/swiftlang/swift-package-manager/blob/c26c12f54357fb7246c0bdbe3483105389f056b8/Sources/Workspace/Workspace%2BBinaryArtifacts.swift#L771-L780)). Unlike SPM however, in Starlark we do not have a readily available `.plist` decoder so we will simply ensure that an `Info.plist` file exists and let the build rules handle potential issues.

This fixes cases where I was getting warnings because our .zip file contains a `__MACOSX` directory that contains a `.xcframework` directory (this is used for metadata by macOS). All the files are prefixed with `._` so the Info.plist check here fixes including these bad paths in our search.

```
DEBUG: /private/var/tmp/_bazel_lpadron/9ae9416857eb79bb978de35a53d54970/external/rules_swift_package_manager~/swiftpkg/internal/repo_rules.bzl:156:14: WARNING: Found multiple XCFramework binary artifacts in the downloaded artifact: ["remote/archive/AppsFlyerLib-Dynamic.xcframework.zip/__MACOSX/AppsFlyerLib.xcframework", "remote/archive/AppsFlyerLib-Dynamic.xcframework.zip/AppsFlyerLib.xcframework"], using the last one.
```