### PR TITLE
fix: Add missing assembly src files to ObjCxx

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -511,7 +511,8 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                     name = child_name,
                     attrs = attrs,
                     rule_kind = rule_kind,
-                    srcs = clang_src_info.organized_srcs.cxx_srcs +
+                    srcs = clang_src_info.organized_srcs.assembly_srcs +
+                           clang_src_info.organized_srcs.cxx_srcs +
                            clang_src_info.organized_srcs.objcxx_srcs +
                            clang_src_info.organized_srcs.other_srcs +
                            res_objcxx_srcs,


### PR DESCRIPTION
Assembly files like `.S` are allowed in `srcs` of `objc_library` but we were dropping these because it was only being handled in the `else` case where we do not have Objective-C srcs.

A package that requires this change to build is: https://github.com/microsoft/plcrashreporter. I did not add an example of that here because it unfortunately still does not build in sandbox mode (because of issues with the `Package.swift` using `excludes`, I can work on updating the package and adding the example here at a later time).

[See this change for how it was done before we split the targets](https://github.com/cgrindel/rules_swift_package_manager/commit/6d12d535660958018f341cedfc567d1fd19a427a#diff-b4f84bf6654c556e5a44572cef98ce510f12dfea788eed39432b9af5f3e4559dL21)