### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brentleyjones @cgrindel @jpsim @luispadron


### PR DESCRIPTION
Adds the `CODEOWNERS` file to the repo, we may need to update the repo settings so that reviewers are requested automatically.
