### PR TITLE
fix: watch local packages to refetch if files are added/updated

### DIFF
--- a/swiftpkg/bzlmod/swift_deps.bzl
+++ b/swiftpkg/bzlmod/swift_deps.bzl
@@ -60,7 +60,7 @@ def _declare_pkgs_from_package(module_ctx, from_package, config_pkgs, config_swi
            not dep.source_control:
             # buildifier: disable=print
             print("""
-WARNING: {name} is unresolved and won't be available duing the build, resolve \
+WARNING: {name} is unresolved and won't be available during the build, resolve \
 the Swift package to make it available.\
 """.format(name = dep.name))
             continue

--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -16,7 +16,7 @@ _CODE_IGNORE_LIST = [".", "..", ".build"]
 def _list_contents(repository_ctx, repo_dir, path):
     # Watch directory to ensure the repo is refetched if new files are added to the local package.
     # watch_tree was added in Bazel 7.1.0 so we need to check that it exists before calling it.
-    if hasattr(repository_ctx, 'watch_tree'):
+    if hasattr(repository_ctx, "watch_tree"):
         repository_ctx.watch_tree(path)
 
     exec_result = repository_ctx.execute(

--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -14,8 +14,10 @@ load(":repo_rules.bzl", "repo_rules")
 _CODE_IGNORE_LIST = [".", "..", ".build"]
 
 def _list_contents(repository_ctx, repo_dir, path):
-    # Watch directory to ensure the repo is refetched if new files are added to the local package
-    repository_ctx.watch_tree(path)
+    # Watch directory to ensure the repo is refetched if new files are added to the local package.
+    # watch_tree was added in Bazel 7.1.0 so we need to check that it exists before calling it.
+    if hasattr(repository_ctx, 'watch_tree'):
+        repository_ctx.watch_tree(path)
 
     exec_result = repository_ctx.execute(
         ["ls", "-a", "-1", path],

--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -14,6 +14,9 @@ load(":repo_rules.bzl", "repo_rules")
 _CODE_IGNORE_LIST = [".", "..", ".build"]
 
 def _list_contents(repository_ctx, repo_dir, path):
+    # Watch directory to ensure the repo is refetched if new files are added to the local package
+    repository_ctx.watch_tree(path)
+
     exec_result = repository_ctx.execute(
         ["ls", "-a", "-1", path],
         working_directory = repo_dir,


### PR DESCRIPTION
Call `repository_ctx.watch_tree` to ensure that repositories are refetched for local SPM packages if new files are added or removed. This will also cause a refetch if a file's content changes, but I didn't see a way to only watch for changes to file creation/deletion.

Without this I was experiencing issues where local SPM packages would fail to compile after pulling down changes from git because new files were added without the repo's `BUILD.bazel` file being updated as well.