### PR TITLE
chore: update BCR Bazel version to match .bazelversion

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.4.1
+      - 7.5.0
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
The `.bazelversion` in the root of this repo was updated to 7.5.0 in [this PR](https://github.com/cgrindel/rules_swift_package_manager/commit/ab943c4368712b7d47aa88501e0f34b83c4d19df) but the Bazel Central Registry pre-submit job wasn't updated to match.

As a result versions [0.46.0](https://github.com/bazelbuild/bazel-central-registry/pull/3803) and [0.47.0](https://github.com/bazelbuild/bazel-central-registry/pull/3880) are failing CI on the registry and haven't been merged for release.