### PR TITLE
fix: Add custom module maps to `hdrs`

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -343,7 +343,15 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         "visibility": _target_visibility(pkg_ctx.pkg_info.expose_build_targets),
     }
     if clang_src_info.hdrs:
-        attrs["hdrs"] = clang_src_info.hdrs
+        hdrs = clang_src_info.hdrs
+
+        if clang_src_info.modulemap_path:
+            # We add the custom module map to `hdrs` to insure it's part of the
+            # inputs of downstream targets. Without this sandboxed or RBE builds
+            # can fail.
+            hdrs = hdrs + [clang_src_info.modulemap_path]
+
+        attrs["hdrs"] = hdrs
     if clang_src_info.public_includes:
         attrs["includes"] = clang_src_info.public_includes
     if clang_src_info.textual_hdrs:


### PR DESCRIPTION
We add the custom module map to `hdrs` to insure it's part of the inputs of downstream targets. Without this sandboxed or RBE builds can fail.