### PR TITLE
chore: upgrade `bazel-starlib` to 0.26.0 for organized release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,10 @@ jobs:
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/tidy_and_test
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+      - name: Execute tests
+        # GH1569: Do not run tidy on macos.
+        if: ${{ startsWith(matrix.runner, 'macos') }}
+        shell: bash
+        run: |
+          bazelisk test //... 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,7 @@ jobs:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/tidy_and_test
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
-      - name: Execute tests
-        # GH1569: Do not run tidy on macos.
-        if: ${{ startsWith(matrix.runner, 'macos') }}
+      - if: ${{ startsWith(matrix.runner, 'macos') }}
+        name: Execute tests
         shell: bash
-        run: |
-          bazelisk test //... 
+        run: "bazelisk test //... \n"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 
 # MARK: - Runtime Dependencies
 
-bazel_dep(name = "cgrindel_bazel_starlib", version = "0.25.2")
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.26.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(

--- a/examples/firebase_example/MODULE.bazel
+++ b/examples/firebase_example/MODULE.bazel
@@ -26,7 +26,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_xcodeproj",
-    version = "2.10.0",
+    version = "2.11.2",
     dev_dependency = True,
 )
 bazel_dep(

--- a/examples/ios_sim/MODULE.bazel
+++ b/examples/ios_sim/MODULE.bazel
@@ -42,7 +42,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_xcodeproj",
-    version = "2.10.0",
+    version = "2.11.2",
     dev_dependency = True,
 )
 


### PR DESCRIPTION
This version of `bazel-starlib` supports organized release notes.
