### PR TITLE
fix: use Xcode 16.3 to address failures on macos-15 GH runner

### DIFF
--- a/.github/actions/set_up_macos/action.yml
+++ b/.github/actions/set_up_macos/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2'
+        xcode-version: '16.3'
     - name: Confirm Xcode Version
       shell: bash
       run: |


### PR DESCRIPTION
Closes #1596.
