### PR TITLE
fix: `swift_package_tool` so that it works on Linux and MacOS

### DIFF
--- a/.github/actions/set_up_ubuntu/action.yml
+++ b/.github/actions/set_up_ubuntu/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   swift_release_tag:
     description: The Swift release tag.
-    default: "swift-6.0.3-RELEASE"
+    default: "swift-6.1.0-RELEASE"
 
 runs:
   using: composite

--- a/.github/actions/set_up_ubuntu/action.yml
+++ b/.github/actions/set_up_ubuntu/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   swift_release_tag:
     description: The Swift release tag.
-    default: "swift-6.1.0-RELEASE"
+    default: "swift-6.1-RELEASE"
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,6 @@ jobs:
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-      # DEBUG BEGIN
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
-      # DEBUG END
       - uses: ./.github/actions/tidy_and_test
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
       - if: ${{ startsWith(matrix.runner, 'macos') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,13 @@ jobs:
       - uses: ./.github/actions/configure_remote_cache_auth
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-      - uses: ./.github/actions/tidy_and_test
-        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
       # DEBUG BEGIN
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
       # DEBUG END
+      - uses: ./.github/actions/tidy_and_test
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
       - if: ${{ startsWith(matrix.runner, 'macos') }}
         name: Execute tests
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,11 @@ jobs:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
       - uses: ./.github/actions/tidy_and_test
         if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+      # DEBUG BEGIN
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
+      # DEBUG END
       - if: ${{ startsWith(matrix.runner, 'macos') }}
         name: Execute tests
         shell: bash

--- a/examples/vapor_example/do_test
+++ b/examples/vapor_example/do_test
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Use the Bazel binary specified by the integration test. Otherise, fall back 
+# Use the Bazel binary specified by the integration test. Otherise, fall back
 # to bazel.
 bazel="${BIT_BAZEL_BINARY:-bazel}"
 
@@ -11,3 +11,7 @@ bazel="${BIT_BAZEL_BINARY:-bazel}"
 
 # Ensure that it builds and tests pass
 "${bazel}" test //...
+
+# This example is run for MacOS and Linux.  Run //:update_swift_packages to
+# ensure that it works on both platforms.
+"${bazel}" run //:update_swift_packages

--- a/swiftpkg/internal/swift_package_tool_runner_template.sh
+++ b/swiftpkg/internal/swift_package_tool_runner_template.sh
@@ -13,12 +13,19 @@ set -euo pipefail
 #  %(cache_path)s - The path to the cache directory.
 
 if [ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]; then
-  echo "BUILD_WORKSPACE_DIRECTORY is not set, this target may only be \`bazel run\`"
-  exit 1
+	echo "BUILD_WORKSPACE_DIRECTORY is not set, this target may only be \`bazel run\`"
+	exit 1
 fi
+
+# DEBUG BEGIN
+set -x
+# DEBUG END
 
 # Collect template values.
 swift_worker="%(swift_worker)s"
+# DEBUG BEGIN
+"${swift_worker}" --help
+# DEBUG END
 cmd="%(cmd)s"
 package_path="$BUILD_WORKSPACE_DIRECTORY/%(package_path)s"
 build_path="%(build_path)s"
@@ -36,40 +43,40 @@ use_registry_identity_for_scm="%(use_registry_identity_for_scm)s"
 args=()
 
 if [ "$enable_build_manifest_caching" = "true" ]; then
-  args+=("--enable-build-manifest-caching")
+	args+=("--enable-build-manifest-caching")
 else
-  args+=("--disable-build-manifest-caching")
+	args+=("--disable-build-manifest-caching")
 fi
 
 if [ "$enable_dependency_cache" = "true" ]; then
-  args+=("--enable-dependency-cache")
+	args+=("--enable-dependency-cache")
 else
-  args+=("--disable-dependency-cache")
+	args+=("--disable-dependency-cache")
 fi
 
 if [ "$replace_scm_with_registry" = "true" ]; then
-  args+=("--replace-scm-with-registry")
+	args+=("--replace-scm-with-registry")
 fi
 
 if [ "$use_registry_identity_for_scm" = "true" ]; then
-  args+=("--use-registry-identity-for-scm")
+	args+=("--use-registry-identity-for-scm")
 fi
 
 args+=("--manifest-cache=$manifest_cache")
 
 # If registries_json is set, symlink the `.json` file to the `config_path/configuration` directory.
 if [ -n "$registries_json" ]; then
-  mkdir -p "$config_path"
-  ln -sf "$(readlink -f "$registries_json")" "$config_path/registries.json"
+	mkdir -p "$config_path"
+	ln -sf "$(readlink -f "$registries_json")" "$config_path/registries.json"
 fi
 
 # Run the command.
 "$swift_worker" swift package \
-  --build-path "$build_path" \
-  --cache-path "$cache_path" \
-  --config-path "$config_path" \
-  --package-path "$package_path" \
-  --security-path "$security_path" \
-  "$cmd" \
-  "${args[@]}" \
-  "$@"
+	--build-path "$build_path" \
+	--cache-path "$cache_path" \
+	--config-path "$config_path" \
+	--package-path "$package_path" \
+	--security-path "$security_path" \
+	"$cmd" \
+	"${args[@]}" \
+	"$@"

--- a/swiftpkg/internal/swift_package_tool_runner_template.sh
+++ b/swiftpkg/internal/swift_package_tool_runner_template.sh
@@ -17,10 +17,6 @@ if [ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]; then
 	exit 1
 fi
 
-# DEBUG BEGIN
-set -x
-# DEBUG END
-
 # Collect template values.
 swift_worker="%(swift_worker)s"
 cmd="%(cmd)s"
@@ -70,7 +66,7 @@ fi
 # On MacOS, the swift_worker passes the command to xcrun. On Linux, it is a
 # barebones worker implementation that does not support '--find'. So, on Linux,
 # we try to find the Swift executable in the PATH. This is not a good way to do
-# this 😔.
+# this 😔. It is good enough for now.
 swift_executable="$(
 	"${swift_worker}" --find swift ||
 		which swift ||


### PR DESCRIPTION
The Renovate runs have been failing when trying to run `//:update_swift_packages` on modified workspaces. The issue is that the Swift worker processes behave differently on MacOS vs Linux. On MacOS, the arguments are essentially passed through to `xcrun`. On Linux, it is more of a barebones process runner.

Previously, we expected the worker to find `swift` automatically. This does not work on Linux. This PR adds logic to find `swift` by attempting to ask the worker. If that fails, fall back to looking in the `PATH`.

I also upgraded Swift to 6.1 on Ubuntu.

Closes #1591.
