### PR TITLE
fix: Define DEBUG for Clang targets in dbg

### DIFF
--- a/config_settings/bazel/compilation_mode/compilation_modes.bzl
+++ b/config_settings/bazel/compilation_mode/compilation_modes.bzl
@@ -1,5 +1,16 @@
 """Module for Bazel compilation modes."""
 
+def _label(name):
+    """Returns the condition label for the Bazel compilation mode name.
+
+    Args:
+        name: The Bazel compilation mode name as a `string`.
+
+    Returns:
+        The condition label as a `string`.
+    """
+    return "@rules_swift_package_manager//config_settings/bazel/compilation_mode:{}".format(name)
+
 compilation_modes = struct(
     debug = "dbg",
     optimized = "opt",
@@ -9,4 +20,5 @@ compilation_modes = struct(
         "opt",
         "fastbuild",
     ],
+    label = _label,
 )

--- a/swiftpkg/internal/BUILD.bazel
+++ b/swiftpkg/internal/BUILD.bazel
@@ -130,6 +130,7 @@ bzl_library(
         ":repository_files",
         ":starlark_codegen",
         ":swift_files",
+        "//config_settings/bazel/compilation_mode:compilation_modes",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:sets",
         "@cgrindel_bazel_starlib//bzllib:defs",

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -12,6 +12,10 @@ load(":pkginfo_target_deps.bzl", "pkginfo_target_deps")
 load(":pkginfo_targets.bzl", "pkginfo_targets")
 load(":pkginfos.bzl", "build_setting_kinds", "module_types", "pkginfos", "target_types")
 load(":starlark_codegen.bzl", scg = "starlark_codegen")
+load(
+    "//config_settings/bazel/compilation_mode:compilation_modes.bzl",
+    bazel_compilation_modes = "compilation_modes"
+)
 
 # MARK: - Target Entry Point
 
@@ -296,7 +300,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
     copts.append(
         bzl_selects.new(
             value = "-DDEBUG=1",
-            condition = "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg",
+            condition = bazel_compilation_modes.label(bazel_compilation_modes.debug),
         ),
     )
 

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -292,6 +292,14 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         "-fmodule-name={}".format(target.c99name),
     ]
 
+    # SPM defines DEBUG=1 for clang targets when building for debug
+    copts.append(
+        bzl_selects.new(
+            value = "-DDEBUG=1",
+            condition = "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg",
+        )
+    )
+
     # Do not add the srcs from the clang_src_info, yet. We will do that at the
     # end of this function where we will create separate targets based upon the
     # type of source file.

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -297,7 +297,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
         bzl_selects.new(
             value = "-DDEBUG=1",
             condition = "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg",
-        )
+        ),
     )
 
     # Do not add the srcs from the clang_src_info, yet. We will do that at the

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -2,6 +2,10 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "bazel_labels", "lists")
+load(
+    "//config_settings/bazel/compilation_mode:compilation_modes.bzl",
+    bazel_compilation_modes = "compilation_modes",
+)
 load(":artifact_infos.bzl", "artifact_types", "link_types")
 load(":bazel_apple_platforms.bzl", "bazel_apple_platforms")
 load(":build_decls.bzl", "build_decls")
@@ -12,10 +16,6 @@ load(":pkginfo_target_deps.bzl", "pkginfo_target_deps")
 load(":pkginfo_targets.bzl", "pkginfo_targets")
 load(":pkginfos.bzl", "build_setting_kinds", "module_types", "pkginfos", "target_types")
 load(":starlark_codegen.bzl", scg = "starlark_codegen")
-load(
-    "//config_settings/bazel/compilation_mode:compilation_modes.bzl",
-    bazel_compilation_modes = "compilation_modes"
-)
 
 # MARK: - Target Entry Point
 

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -664,6 +664,9 @@ cc_library(
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage/src",
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage",
     ] + select({
+        "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg": ["-DDEBUG=1"],
+        "//conditions:default": [],
+    }) + select({
         "@rules_swift_package_manager//config_settings/spm/configuration:release": ["-danger"],
         "//conditions:default": [],
     }),
@@ -728,7 +731,10 @@ objc_library(
         "-DSWIFT_PACKAGE=1",
         "-fmodule-name=ObjcLibrary",
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage/src",
-    ],
+    ] + select({
+        "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg": ["-DDEBUG=1"],
+        "//conditions:default": [],
+    }),
     deps = ["@swiftpkg_mypackage//:ObjcLibraryDep.rspm"],
     enable_modules = True,
     hdrs = ["include/external.h"],
@@ -788,7 +794,10 @@ objc_library(
         "-DSWIFT_PACKAGE=1",
         "-fmodule-name=ObjcLibraryWithModulemap",
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage/src",
-    ],
+    ] + select({
+        "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg": ["-DDEBUG=1"],
+        "//conditions:default": [],
+    }),
     deps = ["@swiftpkg_mypackage//:ObjcLibraryDep.rspm"],
     enable_modules = True,
     hdrs = ["include/external.h"],
@@ -881,7 +890,10 @@ cc_library(
         "-DSWIFT_PACKAGE=1",
         "-fmodule-name=ClangLibraryWithConditionalDep",
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage/src",
-    ],
+    ] + select({
+        "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg": ["-DDEBUG=1"],
+        "//conditions:default": [],
+    }),
     deps = select({
         "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:ClangLibrary.rspm"],
         "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:ClangLibrary.rspm"],
@@ -1089,7 +1101,10 @@ objc_library(
         "-fmodule-name=ObjcLibraryWithResources",
         "-Iexternal/bzlmodmangled~swiftpkg_mypackage/src",
         "-include$(location :ObjcLibraryWithResources.rspm_objc_resource_bundle_accessor_hdr)",
-    ],
+    ] + select({
+        "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg": ["-DDEBUG=1"],
+        "//conditions:default": [],
+    }),
     data = [":ObjcLibraryWithResources.rspm_resource_bundle"],
     enable_modules = True,
     hdrs = ["include/external.h"],


### PR DESCRIPTION
SPM conditionally defines `DEBUG=1` for Clang targets. We should too.

```swift
    /// A list of compilation conditions to enable for conditional compilation expressions.
    private var activeCompilationConditions: [String] {
        var compilationConditions = ["-DSWIFT_PACKAGE=1"]

        switch buildParameters.configuration {
        case .debug:
            compilationConditions += ["-DDEBUG=1"]
        case .release:
            break
        }

        return compilationConditions
    }
```
https://github.com/swiftlang/swift-package-manager/blob/2b0505e24798468102e9ec1937bb485346c59695/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift#L448-L459

This was causing a linker issue in debug for InjectionNext which relies on DEBUG to conditionally include/exclude chunks of code in a C file with SPM
https://github.com/johnno1962/DLKit/blob/8619936ecb668618f95fe1507325ac6ee9710d5a/Sources/DLKitC/DLKitC.c#L14

