### PR TITLE
fix: set default visibility to public

### DIFF
--- a/config_settings/bazel/apple_platform_type/BUILD.bazel
+++ b/config_settings/bazel/apple_platform_type/BUILD.bazel
@@ -2,14 +2,13 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":apple_platform_types.bzl", "apple_platform_types")
 
-package(default_visibility = ["//visibility:public"])
-
 bzlformat_pkg(name = "bzlformat")
 
 [
     config_setting(
         name = platform_type,
         values = {"apple_platform_type": platform_type},
+        visibility = ["//visibility:public"],
     )
     for platform_type in apple_platform_types.all_values
 ]
@@ -23,4 +22,5 @@ filegroup(
 bzl_library(
     name = "apple_platform_types",
     srcs = ["apple_platform_types.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/config_settings/bazel/compilation_mode/BUILD.bazel
+++ b/config_settings/bazel/compilation_mode/BUILD.bazel
@@ -2,14 +2,13 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":compilation_modes.bzl", "compilation_modes")
 
-package(default_visibility = ["//visibility:public"])
-
 bzlformat_pkg(name = "bzlformat")
 
 [
     config_setting(
         name = comp_mode,
         values = {"compilation_mode": comp_mode},
+        visibility = ["//visibility:public"],
     )
     for comp_mode in compilation_modes.all_values
 ]

--- a/config_settings/bazel/compilation_mode/BUILD.bazel
+++ b/config_settings/bazel/compilation_mode/BUILD.bazel
@@ -2,6 +2,8 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":compilation_modes.bzl", "compilation_modes")
 
+package(default_visibility = ["//visibility:public"])
+
 bzlformat_pkg(name = "bzlformat")
 
 [

--- a/config_settings/spm/configuration/BUILD.bazel
+++ b/config_settings/spm/configuration/BUILD.bazel
@@ -18,6 +18,7 @@ SPM_CONFIG_TO_COMPILATION_MODE = {
     selects.config_setting_group(
         name = spm_config,
         match_all = [bzl_comp_mode],
+        visibility = ["//visibility:public"],
     )
     for (spm_config, bzl_comp_mode) in SPM_CONFIG_TO_COMPILATION_MODE.items()
 ]

--- a/config_settings/spm/platform/BUILD.bazel
+++ b/config_settings/spm/platform/BUILD.bazel
@@ -3,8 +3,6 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":platforms.bzl", "platforms")
 
-package(default_visibility = ["//visibility:public"])
-
 bzlformat_pkg(name = "bzlformat")
 
 # NOTE: Ensure that the list of platforms in
@@ -22,6 +20,7 @@ bzlformat_pkg(name = "bzlformat")
             # "//config_settings/bazel/apple_platform_type:{}".format(pi.bzl),
             "@platforms//os:{}".format(pi.os),
         ],
+        visibility = ["//visibility:public"],
     )
     for pi in platforms.all_platform_infos
     if pi.bzl != None and pi.os != None
@@ -33,6 +32,7 @@ bzlformat_pkg(name = "bzlformat")
         constraint_values = [
             "@platforms//os:{}".format(pi.os),
         ],
+        visibility = ["//visibility:public"],
     )
     for pi in platforms.all_platform_infos
     if pi.bzl == None and pi.os != None
@@ -47,5 +47,6 @@ filegroup(
 bzl_library(
     name = "platforms",
     srcs = ["platforms.bzl"],
+    visibility = ["//visibility:public"],
     deps = ["//config_settings/bazel/apple_platform_type:apple_platform_types"],
 )

--- a/config_settings/spm/platform_configuration/BUILD.bazel
+++ b/config_settings/spm/platform_configuration/BUILD.bazel
@@ -3,8 +3,6 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":platform_configurations.bzl", "platform_configurations")
 
-package(default_visibility = ["//visibility:public"])
-
 bzlformat_pkg(name = "bzlformat")
 
 [
@@ -17,6 +15,7 @@ bzlformat_pkg(name = "bzlformat")
             "//config_settings/spm/configuration:{}".format(pc.configuration),
             "//config_settings/spm/platform:{}".format(pc.platform),
         ],
+        visibility = ["//visibility:public"],
     )
     for pc in platform_configurations.all_values
 ]
@@ -24,6 +23,7 @@ bzlformat_pkg(name = "bzlformat")
 bzl_library(
     name = "platform_configurations",
     srcs = ["platform_configurations.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
         "//config_settings/spm/configuration:configurations",
         "//config_settings/spm/platform:platforms",


### PR DESCRIPTION
I added `package(default_visibility = ["//visibility:public"])` to the `compilation_mode` package so its behavior matches the other `//config_settings/...` packages that already declare a public default.

Follow-up to discuss: should we add `--incompatible_config_setting_private_default_visibility` or `--incompatible_enforce_config_setting_visibility` to `.bazelrc`, I'm not sure if this could have unwanted effects.

fixes: #1715 