### PR TITLE
feat: add freebsd platform to allow resolving more Swift packages

### DIFF
--- a/config_settings/spm/platform/platforms.bzl
+++ b/config_settings/spm/platform/platforms.bzl
@@ -37,6 +37,7 @@ _NON_APPLE_PLATFORMS = [
     "android",
     "wasi",
     "openbsd",
+    "freebsd",
 ]
 
 _PLATFORM_INFOS = [

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -54,6 +54,7 @@ swift_binary(
         "@swiftpkg_opencombine//:OpenCombine",
         "@swiftpkg_swift_log//:Logging",
         "@swiftpkg_swift_package_defines_example//:FooSwift",
+        "@swiftpkg_swift_subprocess//:Subprocess",
     ],
 )
 

--- a/examples/interesting_deps/MODULE.bazel
+++ b/examples/interesting_deps/MODULE.bazel
@@ -92,5 +92,6 @@ use_repo(
     "swiftpkg_opencombine",
     "swiftpkg_swift_log",
     "swiftpkg_swift_package_defines_example",
+    "swiftpkg_swift_subprocess",
     "swiftpkg_yoti_doc_scan_ios",
 )

--- a/examples/interesting_deps/Package.resolved
+++ b/examples/interesting_deps/Package.resolved
@@ -73,6 +73,24 @@
       }
     },
     {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess",
+      "state" : {
+        "revision" : "44be5d56aa4b26dc2003a67c0288a6a68366a87d",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "yoti-doc-scan-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getyoti/yoti-doc-scan-ios.git",

--- a/examples/interesting_deps/Package.swift
+++ b/examples/interesting_deps/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.1
 
 import Foundation
 import PackageDescription
@@ -17,6 +17,7 @@ let dependencies: [Package.Dependency] = {
             .package(url: "https://github.com/erikdoe/ocmock", from: "3.9.4"),
             .package(url: "https://github.com/getyoti/yoti-doc-scan-ios.git", from: "7.0.0"),
             .package(url: "https://github.com/luispadron/swift-package-defines-example", from: "2.0.0"),
+            .package(url: "https://github.com/swiftlang/swift-subprocess", from: "0.1.0"),
         ]
     } else {
         return [

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -5,6 +5,7 @@ import GEOSwift
 import libwebp
 import Logging
 import OpenCombine
+import Subprocess
 
 // Configure DDLog to be the backend for the swift-log.
 DDLog.add(DDTTYLogger.sharedInstance!)
@@ -17,3 +18,9 @@ let webpVersion = WebPGetDecoderVersion()
 logger.info("WebP version: \(webpVersion)")
 
 fooSwift()
+
+let result = try await run(.name("ls"), output: .string(limit: 4096))
+
+print(result.processIdentifier)
+print(result.terminationStatus)
+print(result.standardOutput)


### PR DESCRIPTION
Fixes the following error for some packages (like https://github.com/swiftlang/swift-subprocess)


```
ERROR: /private/var/tmp/_bazel_lpadron/9ae9416857eb79bb978de35a53d54970/external/rules_swift_package_manager+/config_settings/spm/platform/BUILD.bazel: no such target '@@rules_swift_package_manager+//config_settings/spm/platform:freebsd': target 'freebsd' not declared in package 'config_settings/spm/platform' defined by /private/var/tmp/_bazel_lpadron/9ae9416857eb79bb978de35a53d54970/external/rules_swift_package_manager+/config_settings/spm/platform/BUILD.bazel (did you mean openbsd?)
```