### PR TITLE
fix: dont fail on unresolved registry packages

### DIFF
--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -921,6 +921,9 @@ def _new_registry(pin):
     Returns:
         A `struct` representing a registry dependency.
     """
+    if not pin:
+        return None
+
     return struct(
         pin = pin,
     )


### PR DESCRIPTION
Similar to #1223 but for registry packages, let's users run `@swift_package//:resolve` without crashing with:

```sh
ERROR: /private/var/tmp/_bazel_lpadron/0ee4409da52ac4ece68cb8fe68c1de00/external/rules_swift_package_manager+/swiftpkg/bzlmod/swift_deps.bzl:273:34: Traceback (most recent call last):
        File "/private/var/tmp/_bazel_lpadron/0ee4409da52ac4ece68cb8fe68c1de00/external/rules_swift_package_manager+/swiftpkg/bzlmod/swift_deps.bzl", line 315, column 43, in _swift_deps_impl
                _declare_pkgs_from_package(
        File "/private/var/tmp/_bazel_lpadron/0ee4409da52ac4ece68cb8fe68c1de00/external/rules_swift_package_manager+/swiftpkg/bzlmod/swift_deps.bzl", line 188, column 37, in _declare_pkgs_from_package
                _declare_pkg_from_dependency(dep, config_pkg, from_package, config_swift_package)
        File "/private/var/tmp/_bazel_lpadron/0ee4409da52ac4ece68cb8fe68c1de00/external/rules_swift_package_manager+/swiftpkg/bzlmod/swift_deps.bzl", line 273, column 34, in _declare_pkg_from_dependency
                id = dep.registry.pin.identity,
Error: 'NoneType' value has no field or method 'identity'
```