### PR TITLE
fix: update rules_go dependency to fix Bazel compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(
     name = "rules_go",
-    version = "0.57.0",
+    version = "0.58.2",
     repo_name = "io_bazel_rules_go",
 )
 


### PR DESCRIPTION
Bazel 8.5+ has rules_go issues in lower versions: https://github.com/bazel-contrib/rules_go/issues/4480.
