### PR TITLE
chore(ci): migrate to publish-to-bcr GitHub workflow

### DIFF
--- a/.github/workflows/publish_to_bcr.yml
+++ b/.github/workflows/publish_to_bcr.yml
@@ -1,0 +1,23 @@
+name: Publish to BCR
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The release tag to publish (e.g. v1.2.3)"
+        required: true
+        type: string
+permissions:
+  contents: write
+jobs:
+  publish_to_bcr:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@0bd40ad4f872b4d216d3f01bc0844ade304e2b5a # v1.1.0
+    with:
+      tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.event.release.tag_name }}
+      registry_fork: cgrindel/bazel-central-registry
+      attest: false
+      author_name: Chuck Grindel
+      author_email: chuckgrindel@gmail.com
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/release/README.md
+++ b/release/README.md
@@ -4,7 +4,6 @@ The release process for this repository is implemented using GitHub Actions and 
 macros](https://github.com/cgrindel/bazel-starlib/tree/main/bzlrelease). This document describes how
 to create a release.
 
-
 ## How to Create a Release
 
 Once all of the code for a release has been merged to main, the release process can be started by
@@ -24,11 +23,13 @@ the following steps:
 3. Creates a GitHub release.
 4. Updates the `README.md` with the latest workspace snippet information.
 5. Creates a PR with the updated `README.md` configured to auto-merge if all the checks pass.
+6. Triggers the [Publish to BCR workflow](.github/workflows/publish_to_bcr.yml) which automatically
+   submits the release to the Bazel Central Registry.
 
 There are two ways that this process could fail. First, if an improperly formatted release tag is
 specified, the release workflow will fail. Be sure to prefix the release tag with `v`. Second, the
 PR that contains the updates to the README.md file could fail if the PR cannot be automatically
-merged. 
+merged.
 
 ## Other Scenarios
 
@@ -61,3 +62,36 @@ If the failure occurred after the creation of the release, you have two options:
 One should be very careful with option #1 as clients may see the failed release and attempt to use
 it. Option #2 is always the safest path.
 
+## Bazel Central Registry (BCR) Publication
+
+The repository uses the [publish-to-bcr GitHub workflow](https://github.com/bazel-contrib/publish-to-bcr)
+to automatically submit releases to the Bazel Central Registry.
+
+### Automatic Publication
+
+When a GitHub release is published, the [Publish to BCR workflow](.github/workflows/publish_to_bcr.yml)
+is automatically triggered. This workflow:
+
+1. Creates a pull request in the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry)
+   via the fork at `cgrindel/bazel-central-registry`.
+2. Uses the BCR configuration files in the `.bcr/` directory to populate module metadata.
+3. Runs presubmit tests defined in `.bcr/presubmit.yml` to verify the release.
+
+### Manual Publication
+
+If you need to manually trigger BCR publication for a specific release, you can do so using the
+GitHub Actions UI:
+
+1. Go to the [Publish to BCR workflow](../../actions/workflows/publish_to_bcr.yml) in GitHub Actions.
+2. Click "Run workflow".
+3. Enter the release tag (e.g., `v1.2.3`).
+4. Click "Run workflow" to start the publication process.
+
+### BCR Configuration
+
+The BCR publication process is configured through files in the `.bcr/` directory:
+
+- `config.yml` - Specifies the fixed releaser information
+- `presubmit.yml` - Defines tests that run during BCR presubmit validation
+- `metadata.template.json` - Template for module metadata
+- `source.template.json` - Template for source archive information


### PR DESCRIPTION
## Summary

- Migrate from deprecated Publish to BCR GitHub app to the publish-to-bcr workflow
- Add automated BCR publication triggered by GitHub releases
- Add manual workflow dispatch capability for BCR publication
- Update release documentation with BCR publication information

## Changes

- Add `.github/workflows/publish_to_bcr.yml` using `bazel-contrib/publish-to-bcr@v1.1.0`
- Update `release/README.md` with new BCR publication section documenting:
  - Automatic publication process
  - Manual publication instructions
  - BCR configuration file descriptions

## Test Plan

- [ ] Verify workflow file syntax is valid
- [ ] Ensure `BCR_PUBLISH_TOKEN` secret is configured in repository settings
- [ ] Test automatic publication by creating a test release
- [ ] Verify BCR PR is created in `cgrindel/bazel-central-registry`
- [ ] Confirm presubmit tests run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)