### PR TITLE
fix: publish_token secret in publish_to_bcr

### DIFF
--- a/.github/workflows/publish_to_bcr.yml
+++ b/.github/workflows/publish_to_bcr.yml
@@ -20,4 +20,4 @@ jobs:
       author_name: Chuck Grindel
       author_email: chuckgrindel@gmail.com
     secrets:
-      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Fix incorrect secret name.
