### PR TITLE
fix: typo in publish_to_bcr workflow

### DIFF
--- a/.github/workflows/publish_to_bcr.yml
+++ b/.github/workflows/publish_to_bcr.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
+      tag_name:
         description: "The release tag to publish (e.g. v1.2.3)"
         required: true
         type: string


### PR DESCRIPTION
Ensure that the input `tag_name` matches the alternative input names.
