### PR TITLE
fix: better handling for unresolved package dependencies

### DIFF
--- a/swiftpkg/bzlmod/swift_deps.bzl
+++ b/swiftpkg/bzlmod/swift_deps.bzl
@@ -166,11 +166,11 @@ def _declare_pkgs_from_package(module_ctx, from_package, config_pkgs, config_swi
 
     # Declare the Bazel repositories.
     for dep in all_deps_by_id.values():
-        # Declare a placeholder repository for unresolved dependencies., 
-        # for example for a new packgage added to the `Package.swift` 
+        # Declare a placeholder repository for unresolved dependencies.,
+        # for example for a new packgage added to the `Package.swift`
         # which has not been resolved yet.
-        # This allows the module extension to not fail abruptly in cases 
-        # where a new package dependency is added and a user runs 
+        # This allows the module extension to not fail abruptly in cases
+        # where a new package dependency is added and a user runs
         # bazel run @swift_package//:resolve.
         if not dep.file_system and \
            (not dep.source_control or not dep.source_control.pin or not dep.source_control.pin.state) and \


### PR DESCRIPTION
Updates this such that we handle unresolved packages by resolving them to an empty repository. This allows the module extension to not fail abruptly in cases where a new package dependency is added and a user runs `bazel run @swift_package//:resolve`.

This fixes errors like:

```
ERROR: /private/var/tmp/_bazel_eamorde/979ccde8f2b7c523a76a6fe66ef56c48/external/rules_swift_package_manager~/swiftpkg/bzlmod/swift_deps.bzl:233:31: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_eamorde/979ccde8f2b7c523a76a6fe66ef56c48/external/rules_swift_package_manager~/swiftpkg/bzlmod/swift_deps.bzl", line 315, column 43, in _swift_deps_impl
		_declare_pkgs_from_package(
	File "/private/var/tmp/_bazel_eamorde/979ccde8f2b7c523a76a6fe66ef56c48/external/rules_swift_package_manager~/swiftpkg/bzlmod/swift_deps.bzl", line 188, column 37, in _declare_pkgs_from_package
		_declare_pkg_from_dependency(dep, config_pkg, from_package, config_swift_package)
	File "/private/var/tmp/_bazel_eamorde/979ccde8f2b7c523a76a6fe66ef56c48/external/rules_swift_package_manager~/swiftpkg/bzlmod/swift_deps.bzl", line 233, column 31, in _declare_pkg_from_dependency
		commit = pin.state.revision,
Error: 'NoneType' value has no field or method 'revision'
```