### PR TITLE
fix: typo in author_email for publish_to_bcr.yml

### DIFF
--- a/.github/workflows/publish_to_bcr.yml
+++ b/.github/workflows/publish_to_bcr.yml
@@ -18,6 +18,6 @@ jobs:
       registry_fork: cgrindel/bazel-central-registry
       attest: false
       author_name: Chuck Grindel
-      author_email: chuckgrindel@gmail.com
+      author_email: chuck.grindel@gmail.com
     secrets:
       publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Fix typo in the email address.
