### PR TITLE
fix: add debug output to do_renovate_post_upgrade

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -7,28 +7,40 @@
 set -o errexit -o nounset -o pipefail
 
 # DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") START ==============="
+echo >&2 "*** DEBUG $(basename "${BASH_SOURCE[0]}") START ==============="
+echo >&2 "*** DEBUG pwd: $(pwd)"
+echo >&2 "*** DEBUG git status:"
+git status >&2
+echo >&2 "*** DEBUG git ls-files -m:"
+git ls-files -m >&2
+echo >&2 "*** DEBUG git diff --cached --name-only:"
+git diff --cached --name-only >&2
+echo >&2 "*** DEBUG git diff --name-only HEAD:"
+git diff --name-only HEAD >&2 || echo >&2 "*** DEBUG git diff HEAD failed (maybe no commits)"
+echo >&2 "*** DEBUG find MODULE.bazel files:"
+find . -name MODULE.bazel -not -path './bazel-*' >&2
+echo >&2 "*** DEBUG ==============="
 set -x
 # DEBUG END
 
 # Install Bazelisk, if not found
 if which &>/dev/null bazelisk; then
-	echo "Bazelisk was found."
-	bazelisk="bazelisk"
+  echo "Bazelisk was found."
+  bazelisk="bazelisk"
 else
-	echo "Bazelisk was not found. Installing..."
-	npm install -g @bazel/bazelisk
-	npm_root="$(npm root -g)"
-	bazelisk="${npm_root}/@bazel/bazelisk/bazelisk-linux_amd64"
+  echo "Bazelisk was not found. Installing..."
+  npm install -g @bazel/bazelisk
+  npm_root="$(npm root -g)"
+  bazelisk="${npm_root}/@bazel/bazelisk/bazelisk-linux_amd64"
 fi
 
 # Install build tools
 if which &>/dev/null clang; then
-	echo "clang was found."
+  echo "clang was found."
 else
-	echo "clang was not found. Installing build-essential..."
-	# install-tool clang 12.0.0
-	install-tool clang-12 12.0.0
+  echo "clang was not found. Installing build-essential..."
+  # install-tool clang 12.0.0
+  install-tool clang-12 12.0.0
 fi
 
 # Execute tidy for workspaces with modifications The export of CC and the


### PR DESCRIPTION
## Summary

- Add debug output to `do_renovate_post_upgrade` to diagnose why `tidy_modified` finds no modified workspaces
- Captures: `git status`, `git ls-files -m`, `git diff --cached --name-only`, `git diff --name-only HEAD`, and `find MODULE.bazel`
- This will show the exact git state when Renovate runs the post-upgrade task

## Context

Post-upgrade tasks run but `[tidy_all] No workspaces to tidy.` — the `git ls-files -m` call inside `tidy_all.sh` returns nothing. We need to understand what git state Renovate leaves the repo in before invoking the script.

## Test plan

- [ ] Merge, close existing Renovate PRs (with `--delete-branch`), trigger Renovate run
- [ ] Check Renovate logs for the debug output to understand the git state

🤖 Generated with [Claude Code](https://claude.com/claude-code)