### PR TITLE
chore(deps): update cgrindel_bazel_starlib to v0.30.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 
 # MARK: - Runtime Dependencies
 
-bazel_dep(name = "cgrindel_bazel_starlib", version = "0.28.0")
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.30.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(


### PR DESCRIPTION
## Summary

- Updates `cgrindel_bazel_starlib` from v0.28.0 to v0.30.0 in the root `MODULE.bazel`
- Fixes Renovate post-upgrade tasks silently failing because `tidy_all.sh` in v0.28.0 searches for removed `WORKSPACE` files instead of `MODULE.bazel`
- PR #2064 updated example `MODULE.bazel` files but missed the root one

## Test plan

- [x] `bazel test //...` — all 337 tests pass
- [ ] Smoke integration tests
- [ ] Verify Renovate post-upgrade tasks execute correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)