### PR TITLE
fix: use path-prefix-safe replacement for working directory in SPM JSON output

### DIFF
--- a/swiftpkg/internal/repository_utils.bzl
+++ b/swiftpkg/internal/repository_utils.bzl
@@ -107,7 +107,7 @@ def _parsed_json_from_spm_command(
         arguments,
         env = env,
         working_directory = working_directory,
-    ).replace(working_directory, ".")
+    ).replace(working_directory + "/", "./")
 
     if debug_json_path:
         if not paths.is_absolute(debug_json_path):


### PR DESCRIPTION
## Problem

`.replace(working_directory, ".")` in `repository_utils.bzl` performs a naive substring match, which corrupts transitive local dependency paths when one package directory name is a prefix of another.

For example, with `working_directory = "/path/to/MyApp"`, the path `/path/to/MyAppFrameworks/SomeLib` gets mangled to `.Frameworks/SomeLib` because `/path/to/MyApp` is a substring of `/path/to/MyAppFrameworks`.

This was introduced in v1.13.0 via #2073.

## Fix

Append a trailing slash to both the search and replacement strings (`.replace(working_directory + "/", "./")`), ensuring only full path-prefix matches are replaced.

## Reproduction

Given this directory layout:
```
RootPackage/
├── Package.swift          # depends on LocalPkg
├── LocalPkg/
│   └── Package.swift      # depends on ../LocalPkgUtils
└── LocalPkgUtils/
    └── Package.swift
```

Without the fix, `swift package describe` output for `LocalPkg` has the path `/path/to/LocalPkgUtils` corrupted to `Utils` because `/path/to/LocalPkg` is a substring prefix of `/path/to/LocalPkgUtils`.