### PR TITLE
chore: add unit tests for working directory replacement (GH-2139)

### DIFF
--- a/swiftpkg/internal/repository_utils.bzl
+++ b/swiftpkg/internal/repository_utils.bzl
@@ -107,7 +107,8 @@ def _parsed_json_from_spm_command(
         arguments,
         env = env,
         working_directory = working_directory,
-    ).replace(working_directory + "/", "./")
+    )
+    json_str = _replace_working_directory(json_str, working_directory)
 
     if debug_json_path:
         if not paths.is_absolute(debug_json_path):
@@ -163,10 +164,34 @@ def _struct_to_kwargs(*, struct, keys):
             kwargs[k] = v
     return kwargs
 
+def _replace_working_directory(json_str, working_directory):
+    """Replace the working directory prefix in a JSON string.
+
+    Uses a path-prefix-safe replacement by appending a trailing
+    slash to ensure only full path-prefix matches are replaced.
+    Without the trailing slash, a working directory like
+    "/path/to/MyApp" would incorrectly match
+    "/path/to/MyAppFrameworks".
+
+    Args:
+        json_str: A `string` containing JSON output from an
+            SPM command.
+        working_directory: A `string` representing the working
+            directory path.
+
+    Returns:
+        A `string` with the working directory prefix replaced
+        by "./".
+    """
+    if not working_directory:
+        return json_str
+    return json_str.replace(working_directory + "/", "./")
+
 repository_utils = struct(
     exec_spm_command = _execute_spm_command,
     is_macos = _is_macos,
     package_name = _package_name,
     parsed_json_from_spm_command = _parsed_json_from_spm_command,
+    replace_working_directory = _replace_working_directory,
     struct_to_kwargs = _struct_to_kwargs,
 )

--- a/swiftpkg/tests/BUILD.bazel
+++ b/swiftpkg/tests/BUILD.bazel
@@ -13,6 +13,7 @@ load(":pkginfo_ext_deps_tests.bzl", "pkginfo_ext_deps_test_suite")
 load(":pkginfo_target_deps_tests.bzl", "pkginfo_target_deps_test_suite")
 load(":pkginfo_targets_tests.bzl", "pkginfo_targets_test_suite")
 load(":repository_files_tests.bzl", "repository_files_test_suite")
+load(":repository_utils_tests.bzl", "repository_utils_test_suite")
 load(":resource_files_tests.bzl", "resource_files_test_suite")
 load(":semver_tests.bzl", "semver_test_suite")
 load(":starlark_codegen_tests.bzl", "starlark_codegen_test_suite")
@@ -46,6 +47,8 @@ pkginfo_target_deps_test_suite()
 pkginfo_targets_test_suite()
 
 repository_files_test_suite()
+
+repository_utils_test_suite()
 
 resource_files_test_suite()
 

--- a/swiftpkg/tests/repository_utils_tests.bzl
+++ b/swiftpkg/tests/repository_utils_tests.bzl
@@ -1,0 +1,102 @@
+"""Tests for `repository_utils` module."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(
+    "//swiftpkg/internal:repository_utils.bzl",
+    "repository_utils",
+)
+
+def _replace_working_directory_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            msg = "simple replacement",
+            json_str = """\
+{"path": "/path/to/MyApp/Sources/main.swift"}\
+""",
+            working_directory = "/path/to/MyApp",
+            expected = """\
+{"path": "./Sources/main.swift"}\
+""",
+        ),
+        struct(
+            msg = """\
+prefix-safe: does not corrupt paths sharing a prefix (GH-2139)\
+""",
+            json_str = """\
+{
+  "path": "/path/to/LocalPkg/Sources/main.swift",
+  "dep": "/path/to/LocalPkgUtils/Sources/lib.swift"
+}\
+""",
+            working_directory = "/path/to/LocalPkg",
+            expected = """\
+{
+  "path": "./Sources/main.swift",
+  "dep": "/path/to/LocalPkgUtils/Sources/lib.swift"
+}\
+""",
+        ),
+        struct(
+            msg = "multiple occurrences replaced",
+            json_str = """\
+{"src": "/work/dir/a.swift", "test": "/work/dir/b.swift"}\
+""",
+            working_directory = "/work/dir",
+            expected = """\
+{"src": "./a.swift", "test": "./b.swift"}\
+""",
+        ),
+        struct(
+            msg = "no match leaves string unchanged",
+            json_str = """\
+{"path": "/other/place/file.swift"}\
+""",
+            working_directory = "/path/to/MyApp",
+            expected = """\
+{"path": "/other/place/file.swift"}\
+""",
+        ),
+        struct(
+            msg = """\
+empty working directory leaves string unchanged\
+""",
+            json_str = """\
+{"path": "/path/to/MyApp/file.swift"}\
+""",
+            working_directory = "",
+            expected = """\
+{"path": "/path/to/MyApp/file.swift"}\
+""",
+        ),
+        struct(
+            msg = """\
+working directory without trailing content is not replaced\
+""",
+            json_str = """\
+{"name": "/path/to/MyApp"}\
+""",
+            working_directory = "/path/to/MyApp",
+            expected = """\
+{"name": "/path/to/MyApp"}\
+""",
+        ),
+    ]
+
+    for test in tests:
+        actual = repository_utils.replace_working_directory(
+            test.json_str,
+            test.working_directory,
+        )
+        asserts.equals(env, test.expected, actual, test.msg)
+
+    return unittest.end(env)
+
+replace_working_directory_test = unittest.make(_replace_working_directory_test)
+
+def repository_utils_test_suite():
+    return unittest.suite(
+        "repository_utils_tests",
+        replace_working_directory_test,
+    )


### PR DESCRIPTION
## Summary

- Extract `replace_working_directory` helper from `_parsed_json_from_spm_command` in `repository_utils.bzl` to make the path replacement logic independently testable
- Add `repository_utils_tests.bzl` with 6 test cases covering the path-prefix-safe replacement behavior, including the specific scenario from GH-2139 where `/path/to/LocalPkg` was incorrectly matching `/path/to/LocalPkgUtils`
- Register the new test suite in `swiftpkg/tests/BUILD.bazel`

## Test plan

- [x] `bazel test //swiftpkg/tests:repository_utils_tests` — all 6 test cases pass
- [x] `bazel test //...` — all 339 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)