### PR TITLE
fix: respect DEVELOPER_DIR for Xcode version alignment in SPM commands

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 <!-- MARKDOWN TOC: BEGIN -->
+* [How do I ensure SPM resolution uses the correct Xcode version?](#how-do-i-ensure-spm-resolution-uses-the-correct-xcode-version)
 * [Does this replace [rules_spm]?](#does-this-replace-rules_spm)
 * [Where is the Swift gazelle plugin?](#where-is-the-swift-gazelle-plugin)
 * [After running `//:swift_update_pkgs`, I see a `.build` directory. What is it? Do I need it?](#after-running-swift_update_pkgs-i-see-a-build-directory-what-is-it-do-i-need-it)
@@ -11,6 +12,30 @@
   * [How do I fix this issue?](#how-do-i-fix-this-issue)
   * [What is the cause of the error? Why can't `rules_swift_package_manager` handle this situation?](#what-is-the-cause-of-the-error-why-cant-rules_swift_package_manager-handle-this-situation)
   <!-- MARKDOWN TOC: END -->
+
+## How do I ensure SPM resolution uses the correct Xcode version?
+
+`rules_swift_package_manager` runs `swift package dump-package` and `swift package describe` during
+repository fetching to inspect Swift packages. By default, these commands use the Xcode selected by
+`xcode-select`. If you have multiple Xcode versions installed and Bazel uses a different one at
+build time, you can get build failures due to Swift version mismatches.
+
+To ensure the same Xcode is used for both SPM resolution and compilation, add the following to your
+`.bazelrc`:
+
+```
+common --repo_env=DEVELOPER_DIR
+```
+
+This passes your `DEVELOPER_DIR` environment variable through to repository rules and module
+extensions. When `DEVELOPER_DIR` is set, `rules_swift_package_manager` will use that Xcode for SPM
+commands instead of the `xcode-select` default. It also ensures that Bazel invalidates cached
+repository results when you switch Xcode versions.
+
+This follows the [recommendation from `rules_apple`][rules_apple_xcode_doc] for ensuring consistent
+Xcode version selection across the build.
+
+[rules_apple_xcode_doc]: https://github.com/bazelbuild/rules_apple/blob/main/doc/common_info.md#controlling-the-xcode-version
 
 ## Does this replace [rules_spm]?
 

--- a/docs/repository_rules_overview.md
+++ b/docs/repository_rules_overview.md
@@ -41,6 +41,12 @@ Used to build a local Swift package.
 | <a id="local_swift_package-path"></a>path |  The path to the local Swift package directory. This can be an absolute path or a relative path to the workspace root.   | String | required |  |
 | <a id="local_swift_package-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 
+**ENVIRONMENT VARIABLES**
+
+This repository rule depends on the following environment variables:
+
+* `DEVELOPER_DIR`
+
 
 <a id="registry_swift_package"></a>
 
@@ -75,6 +81,12 @@ Used to download and build an external Swift package from a registry.
 | <a id="registry_swift_package-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 | <a id="registry_swift_package-resolved"></a>resolved |  A `Package.resolved`, used to de-duplicate dependency identities when `use_registry_identity_for_scm` or `replace_scm_with_registry` is enabled.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="registry_swift_package-version"></a>version |  The package version.   | String | required |  |
+
+**ENVIRONMENT VARIABLES**
+
+This repository rule depends on the following environment variables:
+
+* `DEVELOPER_DIR`
 
 
 <a id="swift_package"></a>
@@ -124,5 +136,11 @@ Used to download and build an external Swift package.
 | <a id="swift_package-tag"></a>tag |  tag in the remote repository to checked out. Precisely one of branch, tag, or commit must be specified.   | String | optional |  `""`  |
 | <a id="swift_package-verbose"></a>verbose |  -   | Boolean | optional |  `False`  |
 | <a id="swift_package-version"></a>version |  The resolved version of the package.   | String | optional |  `""`  |
+
+**ENVIRONMENT VARIABLES**
+
+This repository rule depends on the following environment variables:
+
+* `DEVELOPER_DIR`
 
 

--- a/examples/aws_crt_example/.bazelrc
+++ b/examples/aws_crt_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/aws_sdk_example/.bazelrc
+++ b/examples/aws_sdk_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/firebase_example/.bazelrc
+++ b/examples/firebase_example/.bazelrc
@@ -7,6 +7,10 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # NOTE: Puposefully not specifying --copt='-std=c99' as it is applied to
 # objc_library targets that contain Objective-C++ files. Tried using
 # --per_file_copt to exclude .mm files, but did not have success.

--- a/examples/google_maps_example/.bazelrc
+++ b/examples/google_maps_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/grdb_example/.bazelrc
+++ b/examples/grdb_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/grpc_example/.bazelrc
+++ b/examples/grpc_example/.bazelrc
@@ -7,6 +7,10 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # GRPC requires C++17 or later.
 build --cxxopt='-std=c++17'
 build --host_cxxopt='-std=c++17'

--- a/examples/injectionnext_example/.bazelrc
+++ b/examples/injectionnext_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/interesting_deps/.bazelrc
+++ b/examples/interesting_deps/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/ios_sim/.bazelrc
+++ b/examples/ios_sim/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/kscrash_example/.bazelrc
+++ b/examples/kscrash_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/language_modes_example/.bazelrc
+++ b/examples/language_modes_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/lottie_ios_example/.bazelrc
+++ b/examples/lottie_ios_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/messagekit_example/.bazelrc
+++ b/examples/messagekit_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/nimble_example/.bazelrc
+++ b/examples/nimble_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/objc_code/.bazelrc
+++ b/examples/objc_code/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/phone_number_kit/.bazelrc
+++ b/examples/phone_number_kit/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/pkg_manifest_minimal/.bazelrc
+++ b/examples/pkg_manifest_minimal/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/resources_example/.bazelrc
+++ b/examples/resources_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/shake_ios_example/.bazelrc
+++ b/examples/shake_ios_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/skip_local_transitive_dependencies_example/.bazelrc
+++ b/examples/skip_local_transitive_dependencies_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/snapkit_example/.bazelrc
+++ b/examples/snapkit_example/.bazelrc
@@ -7,6 +7,10 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # Per https://github.com/firebase/firebase-ios-sdk/blob/master/Package.swift#L1322-L1323
 # NOTE: Puposefully not specifying --copt='-std=c99' as it is applied to 
 # objc_library targets that contain Objective-C++ files. Tried using 

--- a/examples/soto_example/.bazelrc
+++ b/examples/soto_example/.bazelrc
@@ -7,6 +7,10 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # The CNIOBoringSSL uses C++14 features like 'enable_if_t' macro support.
 # For more details on how to enable this in Bazel: 
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168

--- a/examples/sqlite_data_example/.bazelrc
+++ b/examples/sqlite_data_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/stripe_example/.bazelrc
+++ b/examples/stripe_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/swift_package_registry_example/.bazelrc
+++ b/examples/swift_package_registry_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/symlink_example/.bazelrc
+++ b/examples/symlink_example/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR

--- a/examples/tca_example/.bazelrc
+++ b/examples/tca_example/.bazelrc
@@ -7,5 +7,9 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # Prevent hang retrieving external repositories in Bazel 7.1.1.
 build --experimental_worker_for_repo_fetching=off

--- a/examples/vapor_example/.bazelrc
+++ b/examples/vapor_example/.bazelrc
@@ -7,6 +7,10 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # The CNIOBoringSSL uses C++14 features like 'enable_if_t' macro support.
 # For more details on how to enable this in Bazel: 
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168

--- a/examples/xcmetrics_example/.bazelrc
+++ b/examples/xcmetrics_example/.bazelrc
@@ -7,6 +7,10 @@ import %workspace%/../../ci.bazelrc
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
 
+# Ensure SPM resolution uses the same Xcode version as the build.
+# https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+common --repo_env=DEVELOPER_DIR
+
 # The CNIOBoringSSL uses C++14 features like 'enable_if_t' macro support.
 # For more details on how to enable this in Bazel: 
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168

--- a/swiftpkg/bzlmod/swift_deps.bzl
+++ b/swiftpkg/bzlmod/swift_deps.bzl
@@ -15,6 +15,7 @@ load("//swiftpkg/internal:swift_package_tool_repo.bzl", "swift_package_tool_repo
 # MARK: - swift_deps bzlmod Extension
 
 _DO_WHILE_RANGE = range(1000)
+_DEVELOPER_DIR_ENV = "DEVELOPER_DIR"
 
 def _declare_pkgs_from_package(module_ctx, from_package, config_pkgs, config_swift_package):
     """Declare Swift packages from `Package.swift` and `Package.resolved`.
@@ -56,6 +57,15 @@ def _declare_pkgs_from_package(module_ctx, from_package, config_pkgs, config_swi
         env[key] = value
     for key in from_package.env_inherit:
         env[key] = module_ctx.getenv(key)
+
+    # If DEVELOPER_DIR is set in the environment, use it to ensure SPM
+    # commands use the same Xcode as Bazel. This is critical for cache
+    # invalidation and for ensuring the correct Swift version is used
+    # when dumping packages.
+    # See: https://github.com/cgrindel/rules_swift_package_manager/issues/2140
+    dev_dir = module_ctx.getenv(_DEVELOPER_DIR_ENV)
+    if dev_dir:
+        env[_DEVELOPER_DIR_ENV] = dev_dir
 
     # Get the package info.
     pkg_swift = module_ctx.path(from_package.swift)
@@ -164,6 +174,7 @@ def _declare_pkgs_from_package(module_ctx, from_package, config_pkgs, config_swi
                 dep_pkg_info = pkginfos.get(
                     module_ctx,
                     directory = dep.file_system.path,
+                    env = env,
                     debug_path = None,
                     cached_json_directory = dep_cached_json_directory,
                     resolved_pkg_map = None,
@@ -484,4 +495,5 @@ swift_deps = module_extension(
         "configure_swift_package": _configure_swift_package_tag,
         "from_package": _from_package_tag,
     },
+    environ = [_DEVELOPER_DIR_ENV],
 )

--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -101,5 +101,6 @@ _ALL_ATTRS = dicts.add(
 local_swift_package = repository_rule(
     implementation = _local_swift_package_impl,
     attrs = _ALL_ATTRS,
+    environ = ["DEVELOPER_DIR"],
     doc = "Used to build a local Swift package.",
 )

--- a/swiftpkg/internal/registry_swift_package.bzl
+++ b/swiftpkg/internal/registry_swift_package.bzl
@@ -312,6 +312,7 @@ _ALL_ATTRS = dicts.add(
 registry_swift_package = repository_rule(
     implementation = _registry_swift_package_impl,
     attrs = _ALL_ATTRS,
+    environ = ["DEVELOPER_DIR"],
     doc = """\
 Used to download and build an external Swift package from a registry.
 """,

--- a/swiftpkg/internal/swift_package.bzl
+++ b/swiftpkg/internal/swift_package.bzl
@@ -245,6 +245,7 @@ _ALL_ATTRS = dicts.add(
 swift_package = repository_rule(
     implementation = _swift_package_impl,
     attrs = _ALL_ATTRS,
+    environ = ["DEVELOPER_DIR"],
     doc = """\
 Used to download and build an external Swift package.
 """,


### PR DESCRIPTION
## Summary

- Auto-inherit `DEVELOPER_DIR` from the environment in the `swift_deps` module extension so SPM
  commands use the same Xcode that Bazel will use at build time
- Propagate `env` to transitive local dependency inspection (previously missing)
- Declare `environ = ["DEVELOPER_DIR"]` on all repository rules and the module extension so Bazel
  invalidates cached repos when `DEVELOPER_DIR` changes

Closes #2140

🤖 Generated with [Claude Code](https://claude.com/claude-code)