### PR TITLE
feat: derive package minimum OS attributes

### DIFF
--- a/config_settings/spm/platform/platforms.bzl
+++ b/config_settings/spm/platform/platforms.bzl
@@ -52,6 +52,15 @@ _PLATFORM_INFOS = [
     _platform_info(spm = "driverkit", bzl = None, os = None),
 ]
 
+def _normalize(name):
+    """Returns the canonical SPM platform name.
+
+    SwiftPM's JSON can use PackageDescription spellings such as `visionOS`.
+    Internally, RSPM platform labels and Bazel Apple platform types use
+    lowercase names.
+    """
+    return name.lower()
+
 def _label(name):
     """Returns the condition label for the SPM platform name.
 
@@ -62,6 +71,8 @@ def _label(name):
         The condition label as a `string`.
     """
 
+    name = _normalize(name)
+
     # There is currently no support Mac Catalyst in Bazel. These are Mac apps
     # that use iOS frameworks. Treat it like iOS for now.
     if name == "maccatalyst":
@@ -71,16 +82,22 @@ def _label(name):
     return "@rules_swift_package_manager//config_settings/spm/platform:{}".format(name)
 
 def _is_supported(name):
+    name = _normalize(name)
     return name != "maccatalyst"
 
 def _supported(names):
-    return [n for n in names if _is_supported(n)]
+    return [
+        _normalize(n)
+        for n in names
+        if _is_supported(n)
+    ]
 
 platforms = struct(
     macos = "macos",
     maccatalyst = "maccatalyst",
     ios = "ios",
     tvos = "tvos",
+    visionos = "visionos",
     watchos = "watchos",
     linux = "linux",
     windows = "windows",
@@ -89,6 +106,7 @@ platforms = struct(
     openbsd = "openbsd",
     all_values = [pi.spm for pi in _PLATFORM_INFOS],
     all_platform_infos = _PLATFORM_INFOS,
+    normalize = _normalize,
     label = _label,
     is_supported = _is_supported,
     supported = _supported,

--- a/swiftpkg/internal/BUILD.bazel
+++ b/swiftpkg/internal/BUILD.bazel
@@ -105,6 +105,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "minimum_os_versions",
+    srcs = ["minimum_os_versions.bzl"],
+    visibility = ["//swiftpkg:__subpackages__"],
+    deps = ["//config_settings/spm/platform:platforms"],
+)
+
+bzl_library(
     name = "load_statements",
     srcs = ["load_statements.bzl"],
     visibility = ["//swiftpkg:__subpackages__"],

--- a/swiftpkg/internal/minimum_os_versions.bzl
+++ b/swiftpkg/internal/minimum_os_versions.bzl
@@ -1,0 +1,59 @@
+"""Package platform version helpers for minimum OS transition wrappers."""
+
+load(
+    "//config_settings/spm/platform:platforms.bzl",
+    spm_platforms = "platforms",
+)
+
+_MINIMUM_OS_ATTR_BY_PLATFORM = {
+    spm_platforms.ios: "ios_minimum_os",
+    spm_platforms.macos: "macos_minimum_os",
+    spm_platforms.tvos: "tvos_minimum_os",
+    spm_platforms.visionos: "visionos_minimum_os",
+    spm_platforms.watchos: "watchos_minimum_os",
+}
+
+# Repository-time fallbacks for omitted Package.swift platform declarations.
+# Match SwiftPM's hard-coded PackageModel.Platform.oldestSupportedVersion
+# values, which SwiftPM uses when deriving undeclared package platforms.
+# https://github.com/swiftlang/swift-package-manager/blob/1e873736f010e2cb88989d5f23a266d305cf1cbc/Sources/PackageModel/Platform.swift#L40-L46
+_FALLBACK_MINIMUM_OS_BY_PLATFORM = {
+    spm_platforms.ios: "12.0",
+    spm_platforms.macos: "10.13",
+    spm_platforms.tvos: "12.0",
+    spm_platforms.visionos: "1.0",
+    spm_platforms.watchos: "4.0",
+}
+
+def _fallback(platform_name):
+    platform_name = spm_platforms.normalize(platform_name)
+    minimum_os = _FALLBACK_MINIMUM_OS_BY_PLATFORM.get(platform_name)
+    if minimum_os == None:
+        fail("No fallback minimum OS is defined for platform '{}'.".format(platform_name))
+    return minimum_os
+
+def _by_platform(pkg_info):
+    versions = {
+        platform_name: _fallback(platform_name)
+        for platform_name in _MINIMUM_OS_ATTR_BY_PLATFORM
+    }
+
+    for platform in pkg_info.platforms:
+        platform_name = spm_platforms.normalize(platform.name)
+        if platform_name in _MINIMUM_OS_ATTR_BY_PLATFORM:
+            versions[platform_name] = platform.version
+
+    return versions
+
+def _transition_attrs(pkg_info):
+    versions = _by_platform(pkg_info)
+    return {
+        attr_name: versions[platform_name]
+        for platform_name, attr_name in _MINIMUM_OS_ATTR_BY_PLATFORM.items()
+    }
+
+minimum_os_versions = struct(
+    by_platform = _by_platform,
+    fallback = _fallback,
+    transition_attrs = _transition_attrs,
+)

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -1001,7 +1001,7 @@ def _new_platform(name, version):
         A `struct` representing a Swift package platform.
     """
     return struct(
-        name = name,
+        name = spm_platforms.normalize(name),
         version = version,
     )
 

--- a/swiftpkg/tests/BUILD.bazel
+++ b/swiftpkg/tests/BUILD.bazel
@@ -8,6 +8,7 @@ load(":build_files_tests.bzl", "build_files_test_suite")
 load(":bzl_selects_tests.bzl", "bzl_selects_test_suite")
 load(":clang_files_tests.bzl", "clang_files_test_suite")
 load(":load_statements_tests.bzl", "load_statements_test_suite")
+load(":minimum_os_versions_tests.bzl", "minimum_os_versions_test_suite")
 load(":objc_files_tests.bzl", "objc_files_test_suite")
 load(":pkginfo_ext_deps_tests.bzl", "pkginfo_ext_deps_test_suite")
 load(":pkginfo_target_deps_tests.bzl", "pkginfo_target_deps_test_suite")
@@ -41,6 +42,8 @@ build_files_test_suite()
 clang_files_test_suite()
 
 load_statements_test_suite()
+
+minimum_os_versions_test_suite()
 
 objc_files_test_suite()
 

--- a/swiftpkg/tests/BUILD.bazel
+++ b/swiftpkg/tests/BUILD.bazel
@@ -19,6 +19,7 @@ load(":repository_files_tests.bzl", "repository_files_test_suite")
 load(":repository_utils_tests.bzl", "repository_utils_test_suite")
 load(":resource_files_tests.bzl", "resource_files_test_suite")
 load(":semver_tests.bzl", "semver_test_suite")
+load(":spm_platforms_tests.bzl", "spm_platforms_test_suite")
 load(":starlark_codegen_tests.bzl", "starlark_codegen_test_suite")
 load(":swift_files_tests.bzl", "swift_files_test_suite")
 load(":swift_package_tool_tests.bzl", "swift_package_tool_test_suite")
@@ -64,6 +65,8 @@ resource_files_test_suite()
 bzl_selects_test_suite()
 
 semver_test_suite()
+
+spm_platforms_test_suite()
 
 starlark_codegen_test_suite()
 

--- a/swiftpkg/tests/minimum_os_versions_tests.bzl
+++ b/swiftpkg/tests/minimum_os_versions_tests.bzl
@@ -1,0 +1,68 @@
+"""Tests for package minimum OS version helpers."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//swiftpkg/internal:minimum_os_versions.bzl", "minimum_os_versions")
+load("//swiftpkg/internal:pkginfos.bzl", "pkginfos")
+
+def _pkg_info(platforms = []):
+    return struct(platforms = platforms)
+
+def _transition_attrs_uses_declared_versions_test(ctx):
+    env = unittest.begin(ctx)
+
+    attrs = minimum_os_versions.transition_attrs(_pkg_info(platforms = [
+        pkginfos.new_platform("iOS", "13.0"),
+        pkginfos.new_platform("macOS", "10.15"),
+        pkginfos.new_platform("tvOS", "13.0"),
+        pkginfos.new_platform("visionOS", "1.0"),
+        pkginfos.new_platform("watchOS", "6.0"),
+    ]))
+
+    asserts.equals(env, {
+        "ios_minimum_os": "13.0",
+        "macos_minimum_os": "10.15",
+        "tvos_minimum_os": "13.0",
+        "visionos_minimum_os": "1.0",
+        "watchos_minimum_os": "6.0",
+    }, attrs)
+
+    return unittest.end(env)
+
+transition_attrs_uses_declared_versions_test = unittest.make(_transition_attrs_uses_declared_versions_test)
+
+def _transition_attrs_uses_fallbacks_for_omitted_platforms_test(ctx):
+    env = unittest.begin(ctx)
+
+    attrs = minimum_os_versions.transition_attrs(_pkg_info(platforms = [
+        pkginfos.new_platform("iOS", "13.0"),
+        pkginfos.new_platform("linux", "5.0"),
+    ]))
+
+    asserts.equals(env, {
+        "ios_minimum_os": "13.0",
+        "macos_minimum_os": "10.13",
+        "tvos_minimum_os": "12.0",
+        "visionos_minimum_os": "1.0",
+        "watchos_minimum_os": "4.0",
+    }, attrs)
+
+    return unittest.end(env)
+
+transition_attrs_uses_fallbacks_for_omitted_platforms_test = unittest.make(_transition_attrs_uses_fallbacks_for_omitted_platforms_test)
+
+def _fallback_accepts_package_description_spelling_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "1.0", minimum_os_versions.fallback("visionOS"))
+
+    return unittest.end(env)
+
+fallback_accepts_package_description_spelling_test = unittest.make(_fallback_accepts_package_description_spelling_test)
+
+def minimum_os_versions_test_suite():
+    return unittest.suite(
+        "minimum_os_versions_tests",
+        transition_attrs_uses_declared_versions_test,
+        transition_attrs_uses_fallbacks_for_omitted_platforms_test,
+        fallback_accepts_package_description_spelling_test,
+    )

--- a/swiftpkg/tests/spm_platforms_tests.bzl
+++ b/swiftpkg/tests/spm_platforms_tests.bzl
@@ -1,0 +1,54 @@
+"""Tests for the Swift package platform mapping module."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(
+    "//config_settings/spm/platform:platforms.bzl",
+    spm_platforms = "platforms",
+)
+
+def _normalize_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "ios", spm_platforms.normalize("iOS"))
+    asserts.equals(env, "macos", spm_platforms.normalize("macOS"))
+    asserts.equals(env, "tvos", spm_platforms.normalize("tvOS"))
+    asserts.equals(env, "visionos", spm_platforms.normalize("visionOS"))
+    asserts.equals(env, "watchos", spm_platforms.normalize("watchOS"))
+
+    return unittest.end(env)
+
+normalize_test = unittest.make(_normalize_test)
+
+def _label_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "@rules_swift_package_manager//config_settings/spm/platform:visionos",
+        spm_platforms.label("visionOS"),
+    )
+
+    return unittest.end(env)
+
+label_test = unittest.make(_label_test)
+
+def _supported_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        ["ios", "visionos", "watchos"],
+        spm_platforms.supported(["iOS", "visionOS", "watchOS", "macCatalyst"]),
+    )
+
+    return unittest.end(env)
+
+supported_test = unittest.make(_supported_test)
+
+def spm_platforms_test_suite():
+    return unittest.suite(
+        "spm_platforms_tests",
+        normalize_test,
+        label_test,
+        supported_test,
+    )


### PR DESCRIPTION
Add a `minimum_os_versions` helper that converts package platform declarations into the per-platform attributes (`ios_minimum_os`, `macos_minimum_os`, `tvos_minimum_os`, `visionos_minimum_os`, and `watchos_minimum_os`) consumed by minimum OS transition wrappers.

Platforms omitted from `Package.swift` fall back to SwiftPM's `PackageModel.Platform.oldestSupportedVersion` values: iOS 12.0, macOS 10.13, tvOS 12.0, visionOS 1.0, and watchOS 4.0.

Stacked on #2251 — the cumulative diff includes that PR's changes until it merges; review focus here is the second commit.