### PR TITLE
fix: remove .swift-version file during package setup

### DIFF
--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -58,6 +58,11 @@ def _local_swift_package_impl(repository_ctx):
         link_name = paths.join(repo_dir, base)
         repository_ctx.symlink(orig_file, link_name)
 
+    # Remove the `.swift-version` symlink (the original file in the user's
+    # source tree is preserved) so that Swift toolchain proxies do not require
+    # a specific Swift version when running SPM commands.
+    repo_rules.remove_swift_version_file(repository_ctx, repo_dir)
+
     # Create the WORKSPACE
     repo_rules.write_workspace_file(repository_ctx, repo_dir)
 

--- a/swiftpkg/internal/registry_swift_package.bzl
+++ b/swiftpkg/internal/registry_swift_package.bzl
@@ -224,6 +224,10 @@ def _registry_swift_package_impl(repository_ctx):
     # Remove any Bazel build files.
     repo_rules.remove_bazel_files(repository_ctx, directory)
 
+    # Remove any `.swift-version` file so that Swift toolchain proxies do not
+    # require a specific Swift version when running SPM commands.
+    repo_rules.remove_swift_version_file(repository_ctx, directory)
+
     # Generate the WORKSPACE file
     repo_rules.write_workspace_file(repository_ctx, directory)
 

--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -236,6 +236,12 @@ def _remove_bazel_files(repository_ctx, directory):
     for file in files:
         repository_files.find_and_delete_files(repository_ctx, directory, file)
 
+def _remove_swift_version_file(repository_ctx, directory):
+    # A `.swift-version` file in the package root can hijack Swift toolchain
+    # proxies (e.g. `swiftly`) into requiring a version that isn't installed.
+    # https://github.com/swiftlang/swiftly/issues/504
+    repository_ctx.delete(paths.join(directory, ".swift-version"))
+
 def _remove_modulemaps(repository_ctx, directory, targets):
     repository_files.find_and_delete_files(
         repository_ctx,
@@ -261,6 +267,7 @@ repo_rules = struct(
     get_exec_env = _get_exec_env,
     remove_bazel_files = _remove_bazel_files,
     remove_modulemaps = _remove_modulemaps,
+    remove_swift_version_file = _remove_swift_version_file,
     swift_attrs = _swift_attrs,
     write_workspace_file = _write_workspace_file,
 )

--- a/swiftpkg/internal/swift_package.bzl
+++ b/swiftpkg/internal/swift_package.bzl
@@ -63,6 +63,10 @@ def _swift_package_impl(repository_ctx):
     # Remove any Bazel build files.
     repo_rules.remove_bazel_files(repository_ctx, directory)
 
+    # Remove any `.swift-version` file so that Swift toolchain proxies do not
+    # require a specific Swift version when running SPM commands.
+    repo_rules.remove_swift_version_file(repository_ctx, directory)
+
     # Generate the WORKSPACE file
     repo_rules.write_workspace_file(repository_ctx, directory)
 


### PR DESCRIPTION
## Summary

- Adds `repo_rules.remove_swift_version_file` and calls it once during package setup in `swift_package`, `registry_swift_package`, and `local_swift_package`.
- Centralizes the deletion alongside `remove_bazel_files` / `remove_modulemaps` instead of running it inside `_execute_spm_command`.
- Uses `repository_ctx.delete`, which is cross-platform and (in the `local_swift_package` case) removes only the symlink in the repo dir, preserving the original `.swift-version` file in the user's source tree.

A `.swift-version` file in the package root can hijack Swift toolchain proxies (e.g. [swiftly](https://github.com/swiftlang/swiftly/issues/504)) into requiring a Swift version that isn't installed, causing SPM commands to fail.

## Relationship to #2246

This is a sibling PR to #2246 that takes a slightly different approach:

- Runs the deletion **once per package setup** rather than on every SPM command (the original places the `rm` inside `_execute_spm_command`, which fires for `swift package --version`, every `swift package describe`, etc.).
- Uses `repository_ctx.delete` instead of shelling out to `rm -f` — matches how `.git` is removed in `swift_package.bzl`.
- Lives next to the existing `remove_bazel_files` / `remove_modulemaps` helpers for consistency.

Either approach fixes the underlying issue. Putting this up so the alternative is reviewable; happy to close in favor of #2246 if preferred.

## Test plan

- [x] `bazel test //swiftpkg/...` — 227 tests pass
- [ ] Manual verification with a package that contains a `.swift-version` file pointing to an uninstalled toolchain