### PR TITLE
fix(bcr): bump BCR presubmit Bazel version to 8.6.0

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     platform: ["macos"]
     bazel:
       # This needs to exactly match the value used in .bazelversion at the root.
-      - 7.5.0
+      - 8.6.0
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
## Summary

- Bumps `.bcr/presubmit.yml` from `7.5.0` to `8.6.0` so the BCR presubmit's matrix matches the project's `.bazelversion` (per the file's own comment).

## Why

The BCR presubmit script's vendor step was changed in [bazelbuild/continuous-integration#2541](https://github.com/bazelbuild/continuous-integration/pull/2541) to use the **highest** Bazel version listed in `presubmit.yml` (instead of `latest`). With only `7.5.0` in the matrix, vendoring runs on Bazel 7 and writes `vendor_src` directories using the `~` canonical-name separator. The script still expects `<module>+`, so `shutil.move` fails before any test runs:

```
FileNotFoundError: '.../vendor_src/rules_swift_package_manager+'
```

This took down the [v1.16.0 BCR PR](https://github.com/bazelbuild/bazel-central-registry/pull/8706). I already pushed the same one-line bump directly into that PR's branch so it doesn't have to wait on a republish; this commit ensures the next publish-to-bcr release also carries the fix.

`.bazelversion` has been on 8.x for a while — `.bcr/presubmit.yml` just drifted out of sync.

## Test plan

- [x] `bazel test //...` — 385/385 pass

## Notes

The BCR PR #8706 is still red after this fix lands the `+` separator issue, but for an unrelated reason: `bzlmod/workspace/Package.resolved` pins `swift-log 1.12.0`, whose `Package.swift` declares `swift-tools-version: 6.2.0`, while the BCR macOS runner has Swift `6.0.3`. That's a separate fix.