### PR TITLE
fix(bzlmod-example): cap swift-log below 1.9.0 for BCR Swift 6.0.x

### DIFF
--- a/bzlmod/workspace/Package.resolved
+++ b/bzlmod/workspace/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
+        "version" : "1.8.0"
       }
     }
   ],

--- a/bzlmod/workspace/Package.swift
+++ b/bzlmod/workspace/Package.swift
@@ -9,7 +9,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.1"),
-        .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
+        // swift-log 1.9.0+ declares swift-tools-version >= 6.1, which the
+        // BCR macOS Buildkite runner's installed Swift (6.0.x) cannot parse.
+        // Cap below 1.9.0 so SPM resolves to 1.8.0, whose manifest declares
+        // swift-tools-version 6.0 and is readable on the runner. Drop the
+        // upper bound once BCR's runner ships Swift >= 6.2.
+        .package(url: "https://github.com/apple/swift-log", "1.5.4" ..< "1.9.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary

- Caps `bzlmod/workspace`'s swift-log dep at `< 1.9.0` so SPM resolves to 1.8.0 instead of 1.12.0.
- Re-resolves `Package.resolved` to pin swift-log @ 1.8.0.

## Why

The BCR macOS Buildkite runner ships Swift **6.0.3**. swift-log released a string of `swift-tools-version` bumps in its `Package.swift`:

| swift-log | swift-tools-version |
|-----------|---------------------|
| 1.8.0 | 6.0 |
| 1.9.0 | 6.1 |
| 1.10.0 | 6.1 |
| 1.10.1 | 6.2 |
| 1.11.0 | 6.2 |
| 1.12.0 | 6.2 |

A Swift 6.0.x toolchain refuses to parse a manifest whose declared tools-version is higher than the running compiler. Our rules invoke SPM at repository-fetch time on each swiftpkg dep to extract package info, so an unreadable manifest fails the whole `//bzlmod:e2e_test` on BCR with:

```
error: 'rules_swift_package_manager++swift_deps+swiftpkg_swift_log': package … is using Swift tools version 6.2.0 but the installed version is 6.0.3
```

This is what tipped over the [v1.16.0 BCR PR](https://github.com/bazelbuild/bazel-central-registry/pull/8706) once the unrelated `vendor_src/+` blocker was fixed (#2261). The test passes locally and on our `macos-15` GitHub Actions runners only because their Xcode ships Swift >= 6.2.

Fix: bound the constraint to `"1.5.4" ..< "1.9.0"` so SPM resolves to 1.8.0, which declares `swift-tools-version: 6.0` and is readable on the BCR runner. A comment on the dep explains the rationale and the condition for dropping the upper bound (BCR runner upgrades to Swift >= 6.2).

## Test plan

- [x] `swift package resolve` (Swift 6.2.3) → swift-log 1.8.0
- [x] `bazel run //:tidy` in `bzlmod/workspace`
- [x] `bazel test //...` in `bzlmod/workspace` — 9/9 pass
- [x] `bazel test //bzlmod:e2e_test` from repo root — pass

## Notes

This is the second of two fixes for the v1.16.0 BCR breakage. The first (#2261) bumped `.bcr/presubmit.yml`'s Bazel matrix to 8.6.0 to work around a separate BCR-script bug. With both fixes in, the next release should sail through BCR — at least until something else in our example dependency graph bumps its tools-version.