### PR TITLE
fix: ensure that lowercased `.s` files are collected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
             runner: ubuntu-22.04
           - test: '@@//examples:grpc_example_test_bazel_.bazelversion'
             runner: macos-15
+          - test: '@@//examples:injectionnext_example_test_bazel_.bazelversion'
+            runner: macos-15
           - test: '@@//examples:interesting_deps_test_bazel_.bazelversion'
             runner: macos-15
           - test: '@@//examples:ios_sim_test_bazel_.bazelversion'

--- a/examples/example_infos.bzl
+++ b/examples/example_infos.bzl
@@ -138,6 +138,7 @@ _macos_single_bazel_version_test_examples = [
     "firebase_example",
     "google_maps_example",
     "interesting_deps",
+    "injectionnext_example",
     "ios_sim",
     "kscrash_example",
     "lottie_ios_example",

--- a/examples/injectionnext_example/README.md
+++ b/examples/injectionnext_example/README.md
@@ -1,5 +1,5 @@
 # InjectionNext Example
 
-This Package contains code that is written in Objective-C++ along with plain C
-code. It validates that the correct cc_library targets are created to link the
-C code with the Objective-C++ target.
+This package depends on InjectionNext, which contains Objective-C++, plain C,
+and lower-case `.s` assembly sources. It validates that the generated
+`cc_library` targets include and link those sources with the Swift product.

--- a/examples/injectionnext_example/Tests/BUILD.bazel
+++ b/examples/injectionnext_example/Tests/BUILD.bazel
@@ -8,6 +8,7 @@ swift_library(
     module_name = "Tests",
     tags = ["manual"],
     visibility = ["//visibility:public"],
+    deps = ["@swiftpkg_injectionnext//:InjectionNext"],
 )
 
 ios_unit_test(

--- a/examples/injectionnext_example/Tests/EmptyTest.swift
+++ b/examples/injectionnext_example/Tests/EmptyTest.swift
@@ -1,4 +1,4 @@
-import InjectionNext
+import InjectionBundle
 import XCTest
 
 final class EmptyTest: XCTestCase {

--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -25,7 +25,7 @@ _OBJC_SRC_EXTS = [".m"]
 _OBJCXX_SRC_EXTS = [".mm"]
 
 # Assembly source extensions
-_ASSEMBLY_SRC_EXTS = [".S"]
+_ASSEMBLY_SRC_EXTS = [".S", ".s"]
 
 # Sources that should be included when constructing other cc_xxx targets
 _OTHER_SRC_EXTS = [".so", ".o", ".inc"]

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -252,6 +252,7 @@ def _organize_srcs_test(ctx):
         "foo.mm",
         "foo.o",
         "foo.S",
+        "foo.s",
     ]
     actual = clang_files.organize_srcs(srcs)
     expected = struct(
@@ -259,7 +260,7 @@ def _organize_srcs_test(ctx):
         cxx_srcs = ["foo.cc", "foo.cpp"],
         objc_srcs = ["foo.m"],
         objcxx_srcs = ["foo.mm"],
-        assembly_srcs = ["foo.S"],
+        assembly_srcs = ["foo.S", "foo.s"],
         other_srcs = ["foo.inc", "foo.so", "foo.o"],
     )
     asserts.equals(env, expected, actual)


### PR DESCRIPTION
My attempt to integrate [InjectionNext](https://github.com/johnno1962/InjectionNext) was failing with linker errors due to missing assembly files.
Prior to this change we were collecting `.S` but not also the lowercase variant `.s`.
I did consider approach where we would lowercase the extension but ended up just adding the `.s` to the list since it is explicit that people tent to use both `.s` and `.S`.
