### PR TITLE
fix: Separate artifact downloading from build file generation

### DIFF
--- a/swiftpkg/internal/local_swift_package.bzl
+++ b/swiftpkg/internal/local_swift_package.bzl
@@ -81,6 +81,9 @@ def _local_swift_package_impl(repository_ctx):
         cached_json_directory,
         target_deps = repository_ctx.attr.target_deps,
     )
+
+    repo_rules.download_artifacts(repository_ctx, pkg_ctx)
+
     repo_rules.gen_build_files(repository_ctx, pkg_ctx)
 
     return update_attrs(repository_ctx.attr, _ALL_ATTRS.keys(), {})

--- a/swiftpkg/internal/registry_swift_package.bzl
+++ b/swiftpkg/internal/registry_swift_package.bzl
@@ -257,6 +257,8 @@ def _registry_swift_package_impl(repository_ctx):
         target_deps = repository_ctx.attr.target_deps,
     )
 
+    repo_rules.download_artifacts(repository_ctx, pkg_ctx)
+
     repo_rules.gen_build_files(repository_ctx, pkg_ctx)
 
     # Remove unused modulemaps to prevent module redefinition errors

--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -92,6 +92,26 @@ def _check_spm_version(repository_ctx, env = {}):
 higher. Found version %s installed.\
 """ % (min_spm_ver, spm_ver))
 
+def _download_artifacts(repository_ctx, pkg_ctx):
+    for target in pkg_ctx.pkg_info.targets:
+        if target.type == target_types.binary and target.artifact_download_info != None:
+            url = target.artifact_download_info.url
+            auth = _get_auth(repository_ctx, [url])
+            artifact_download_info = target.artifact_download_info
+
+            result = repository_ctx.download_and_extract(
+                url = url,
+                output = target.path,
+                sha256 = artifact_download_info.checksum,
+                auth = auth,
+            )
+
+            if not result.success:
+                fail("Failed to download artifact. url: {url}, sha256: {sha256}".format(
+                    url = artifact_download_info.url,
+                    sha256 = artifact_download_info.checksum,
+                ))
+
 def _gen_build_files(repository_ctx, pkg_ctx):
     if repository_ctx.attr.build_file:
         # Use template() with no substitutions to copy the file. There is
@@ -122,17 +142,10 @@ def _gen_build_files(repository_ctx, pkg_ctx):
 
         artifact_infos = []
         if target.type == target_types.binary:
-            if target.artifact_download_info != None:
-                artifact_infos = _download_artifact(
-                    repository_ctx,
-                    target.artifact_download_info,
-                    target.path,
-                )
-            else:
-                artifact_infos = _artifact_infos_from_path(
-                    repository_ctx,
-                    target.path,
-                )
+            artifact_infos = _artifact_infos_from_path(
+                repository_ctx,
+                target.path,
+            )
 
         bld_file = swiftpkg_build_files.new_for_target(
             repository_ctx,
@@ -203,23 +216,6 @@ WARNING: Found multiple XCFramework binary artifacts in the downloaded artifact:
         for xf in xcframework_dirs
     ]
 
-def _download_artifact(repository_ctx, artifact_download_info, path):
-    url = artifact_download_info.url
-    auth = _get_auth(repository_ctx, [url])
-
-    result = repository_ctx.download_and_extract(
-        url = url,
-        output = path,
-        sha256 = artifact_download_info.checksum,
-        auth = auth,
-    )
-    if not result.success:
-        fail("Failed to download artifact. url: {url}, sha256: {sha256}".format(
-            url = artifact_download_info.url,
-            sha256 = artifact_download_info.checksum,
-        ))
-    return _artifact_infos_from_path(repository_ctx, path)
-
 # Copied from "@bazel_tools//tools/build_defs/repo:utils.bzl". Availaible starting with 7.1.0
 def _get_auth(ctx, urls):
     """Utility function to obtain the correct auth dict for a list of urls from .netrc file.
@@ -275,6 +271,7 @@ def _remove_modulemaps(repository_ctx, directory, targets):
 
 repo_rules = struct(
     check_spm_version = _check_spm_version,
+    download_artifacts = _download_artifacts,
     env_attr = _env_attr,
     env_attrs = _env_attrs,
     gen_build_files = _gen_build_files,

--- a/swiftpkg/internal/swift_package.bzl
+++ b/swiftpkg/internal/swift_package.bzl
@@ -97,6 +97,9 @@ def _swift_package_impl(repository_ctx):
         replace_scm_with_registry = replace_scm_with_registry,
         target_deps = repository_ctx.attr.target_deps,
     )
+
+    repo_rules.download_artifacts(repository_ctx, pkg_ctx)
+
     repo_rules.gen_build_files(repository_ctx, pkg_ctx)
 
     # Remove the git stuff

--- a/swiftpkg/tests/repo_rules_tests.bzl
+++ b/swiftpkg/tests/repo_rules_tests.bzl
@@ -3,6 +3,104 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//swiftpkg/internal:repo_rules.bzl", "repo_rules")
 
+def _download_artifacts_test(ctx):
+    """download_artifacts downloads remote binary artifacts"""
+    env = unittest.begin(ctx)
+
+    calls = {"download_and_extract": [], "execute": [], "read": []}
+
+    # buildifier: disable=unused-variable
+    def _download_and_extract(url, output, sha256 = "", auth = {}):
+        calls["download_and_extract"].append(struct(
+            auth = auth,
+            output = output,
+            sha256 = sha256,
+            url = url,
+        ))
+        return struct(success = True)
+
+    # buildifier: disable=unused-variable
+    def _execute(args, environment = {}, quiet = True):
+        calls["execute"].append(args)
+        return struct(return_code = 0, stdout = "", stderr = "")
+
+    # buildifier: disable=unused-variable
+    def _read(path, watch = "auto"):
+        calls["read"].append(struct(path = path, watch = watch))
+        return ""
+
+    build_file_label = "//some/pkg:BUILD.custom"
+    repository_ctx = struct(
+        attr = struct(
+            build_file = build_file_label,
+            netrc = "auth.netrc",
+        ),
+        download_and_extract = _download_and_extract,
+        execute = _execute,
+        name = "bzlmodmangled~test_pkg",
+        read = _read,
+    )
+
+    pkg_info = struct(
+        name = "TestPkg",
+        path = "",
+        products = [],
+        targets = [
+            struct(
+                artifact_download_info = struct(
+                    checksum = "abc123",
+                    url = "https://example.com/Artifact.zip",
+                ),
+                path = "remote/archive/Artifact.zip",
+                type = "binary",
+            ),
+            struct(
+                artifact_download_info = None,
+                path = "Local.xcframework",
+                type = "binary",
+            ),
+            struct(
+                artifact_download_info = struct(
+                    checksum = "def456",
+                    url = "https://example.com/Source.zip",
+                ),
+                path = "remote/archive/Source.zip",
+                type = "regular",
+            ),
+        ],
+        url = "https://github.com/example/test-pkg",
+        version = "1.0.0",
+    )
+    pkg_ctx = struct(pkg_info = pkg_info)
+
+    repo_rules.download_artifacts(repository_ctx, pkg_ctx)
+
+    asserts.equals(
+        env,
+        [struct(path = "auth.netrc", watch = "no")],
+        calls["read"],
+        "the configured netrc should be read for download auth",
+    )
+    asserts.equals(
+        env,
+        [
+            struct(
+                auth = {},
+                output = "remote/archive/Artifact.zip",
+                sha256 = "abc123",
+                url = "https://example.com/Artifact.zip",
+            ),
+        ],
+        calls["download_and_extract"],
+        "only remote binary artifacts should be downloaded",
+    )
+
+    return unittest.end(env)
+
+download_artifacts_test = unittest.make(
+    _download_artifacts_test,
+)
+
 def _gen_build_files_with_build_file_test(ctx):
     """When build_file is set, gen_build_files should use it and skip \
     generation."""
@@ -112,6 +210,7 @@ gen_build_files_without_build_file_test = unittest.make(
 def repo_rules_test_suite():
     return unittest.suite(
         "repo_rules_tests",
+        download_artifacts_test,
         gen_build_files_with_build_file_test,
         gen_build_files_without_build_file_test,
     )


### PR DESCRIPTION
Separate downloading of remote artifacts from build file generation. This ensures that remote artifacts are downloaded even when a custom build file is provided.

Alternate approach to https://github.com/cgrindel/rules_swift_package_manager/pull/2315 as discussed on Slack:
https://bazelbuild.slack.com/archives/C09TMF7SK5M/p1779902023383319?thread_ts=1779467061.166369&cid=C09TMF7SK5M