### PR TITLE
fix: only attach Apple resource bundles on Apple platforms

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -215,9 +215,9 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
             target,
         )
         all_build_files.append(swift_apple_res_bundle_info.build_file)
-        _update_attr_list("data", ":{}".format(
+        attrs["data"] = _apple_resource_bundle_data(
             swift_apple_res_bundle_info.bundle_label_name,
-        ))
+        )
         _update_attr_list("srcs", ":{}".format(
             swift_apple_res_bundle_info.accessor_label_name,
         ))
@@ -661,9 +661,9 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                 target,
             )
             all_build_files.append(clang_apple_res_bundle_info.build_file)
-            attrs["data"] = [":{}".format(
+            attrs["data"] = _apple_resource_bundle_data(
                 clang_apple_res_bundle_info.bundle_label_name,
-            )]
+            )
             if clang_apple_res_bundle_info.objc_accessor_hdr_label_name:
                 res_objcxx_srcs = [
                     ":{}".format(
@@ -1091,6 +1091,27 @@ def _apple_resource_bundle(target, package_name, default_localization, expose_bu
         bundle_label_name = bundle_label_name,
         build_file = build_files.new(load_stmts = load_stmts, decls = decls),
     )
+
+def _apple_resource_bundle_data(bundle_label_name):
+    """Returns a `select()` attaching the Apple resource bundle only on Apple platforms.
+
+    rules_apple's resource bundles require a resolved Apple platform constraint, so
+    depending on one unconditionally breaks non-Apple (e.g. Linux) builds. Gating the
+    `data` attachment behind the Apple platform conditions keeps the bundle on Apple
+    targets while leaving non-Apple targets with no bundle dependency.
+
+    Args:
+        bundle_label_name: The resource bundle target name as a `string`.
+
+    Returns:
+        A `select()` expression for the `data` attribute.
+    """
+    return bzl_selects.to_starlark([
+        bzl_selects.new(
+            value = ":{}".format(bundle_label_name),
+            condition = "@apple_support//configs:apple",
+        ),
+    ])
 
 def _apple_resource_bundle_for_swift(pkg_ctx, target):
     apple_res_bundle_info = _apple_resource_bundle(

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -1582,7 +1582,10 @@ swift_library(
         "-Xcc",
         "-DSWIFT_PACKAGE",
     ],
-    data = [":SwiftLibraryWithFilePathResource.rspm_resource_bundle"],
+    data = select({
+        "@apple_support//configs:apple": [":SwiftLibraryWithFilePathResource.rspm_resource_bundle"],
+        "//conditions:default": [],
+    }),
     module_name = "SwiftLibraryWithFilePathResource",
     package_name = "MyPackage",
     srcs = [
@@ -1650,7 +1653,10 @@ swift_library(
         "-Xcc",
         "-DSWIFT_PACKAGE",
     ],
-    data = [":SwiftLibraryWithPrecompiledBundleResource.rspm_resource_bundle"],
+    data = select({
+        "@apple_support//configs:apple": [":SwiftLibraryWithPrecompiledBundleResource.rspm_resource_bundle"],
+        "//conditions:default": [],
+    }),
     module_name = "SwiftLibraryWithPrecompiledBundleResource",
     package_name = "MyPackage",
     srcs = [
@@ -1715,7 +1721,10 @@ objc_library(
         "@rules_swift_package_manager//config_settings/bazel/compilation_mode:dbg": ["-DDEBUG=1"],
         "//conditions:default": [],
     }),
-    data = [":ObjcLibraryWithResources.rspm_resource_bundle"],
+    data = select({
+        "@apple_support//configs:apple": [":ObjcLibraryWithResources.rspm_resource_bundle"],
+        "//conditions:default": [],
+    }),
     enable_modules = True,
     hdrs = ["include/external.h"],
     includes = ["include"],


### PR DESCRIPTION
## Problem

SwiftPM packages that declare resources (e.g. SwiftProtobuf's `PrivacyInfo.xcprivacy`) get an `apple_resource_bundle` / `apple_precompiled_resource_bundle` generated and attached to the target's `data` **unconditionally**.

rules_apple resource bundles require a resolved Apple platform constraint, so building such a package for a non-Apple platform (e.g. Linux) fails during analysis:

```
in environment_plist rule @@rules_apple+//apple/internal:environment_plist_ios:
Error in fail: ERROR: A valid Apple platform constraint could not be found from the resolved toolchain.
```

This blocks any Linux consumer whose dependency graph includes a resource-bearing SwiftPM package.

## Fix

Gate the resource-bundle `data` attachment behind apple_support's `apple` condition via `select()`, for both the Swift and Clang target generators:

```starlark
data = select({
    "@apple_support//configs:apple": [":Foo.rspm_resource_bundle"],
    "//conditions:default": [],
}),
```

Non-Apple targets get no bundle dependency. The `Bundle.module` accessor stays in `srcs` on all platforms, so the package's Swift/ObjC sources still compile; the Apple-only bundle is simply not pulled into the non-Apple graph.

## Testing

- Updated the golden expectations in `swiftpkg_build_files_tests.bzl` (file-path resource, precompiled bundle, and ObjC resource cases).
- `bazel test //swiftpkg/internal/... //swiftpkg/tests/...` — 251/251 pass.