### PR TITLE
feat: use feature for Swift 6 instead of copts

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -141,6 +141,15 @@ def _swift_target_build_file(repository_ctx, pkg_ctx, target):
         features.append(feature)
 
     def _set_swift_version_selects(version, kind = None, condition = None):
+        # rules_swift uses a feature for v6 and depends on that for other logic
+        if version == "6":
+            features.append(bzl_selects.new(
+                value = "swift.enable_v6",
+                kind = kind,
+                condition = condition,
+            ))
+            return
+
         copts.append(bzl_selects.new(
             value = "-swift-version",
             kind = kind,

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -1109,8 +1109,6 @@ swift_binary(
         "-DSWIFT_PACKAGE",
         "-Xcc",
         "-DSWIFT_PACKAGE",
-        "-swift-version",
-        "6",
     ] + select({
         "@rules_swift_package_manager//config_settings/spm/platform:ios": ["-DFOOBAR"],
         "//conditions:default": [],
@@ -1122,6 +1120,7 @@ swift_binary(
         "//conditions:default": [],
     }),
     features = [
+        "swift.enable_v6",
         "swift.experimental.BuiltinModule",
         "swift.upcoming.ExistentialAny",
     ],


### PR DESCRIPTION
rules_swift is special casing this feature and making other decisions
based on if it is enabled. Without this the compiler produces a warning
@ rules_swift HEAD since it assumes you're building for Swift 5.
