### PR TITLE
fix(bzlmod-example): re-cap swift-log below 1.9.0 for BCR Swift 6.0.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,12 @@
       "matchPackageNames": ["apple/swift-async-algorithms"],
       "matchFileNames": ["examples/swift_package_registry_example/Package.swift"],
       "enabled": false
+    },
+    {
+      "description": "The BCR macOS Buildkite runner ships Swift 6.0.x and cannot parse swift-log's manifest from 1.9.0 onward (declares swift-tools-version >= 6.1). The bzlmod e2e test's workspace must stay pinned at swift-log < 1.9.0 so SPM resolves to 1.8.0 (tools 6.0). See #2262.",
+      "matchPackageNames": ["apple/swift-log"],
+      "matchFileNames": ["bzlmod/workspace/Package.swift"],
+      "enabled": false
     }
   ]
 }

--- a/bzlmod/workspace/Package.resolved
+++ b/bzlmod/workspace/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
+        "version" : "1.8.0"
       }
     }
   ],

--- a/bzlmod/workspace/Package.swift
+++ b/bzlmod/workspace/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // Cap below 1.9.0 so SPM resolves to 1.8.0, whose manifest declares
         // swift-tools-version 6.0 and is readable on the runner. Drop the
         // upper bound once BCR's runner ships Swift >= 6.2.
-        .package(url: "https://github.com/apple/swift-log", "1.5.4" ..< "1.12.1"),
+        .package(url: "https://github.com/apple/swift-log", "1.5.4" ..< "1.9.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary

The v1.18.0 BCR PR ([bazelbuild/bazel-central-registry#9042](https://github.com/bazelbuild/bazel-central-registry/pull/9042)) fails on the macOS Buildkite runner with:

```
error: 'swiftpkg_swift_log' is using Swift tools version 6.2.0 but the installed version is 6.0.3
error: invalid manifests …
```

The runner still ships Swift 6.0.3, and `bzlmod/workspace/Package.resolved` in v1.18.0 pins swift-log 1.12.0, whose `Package.swift` declares `swift-tools-version:6.2`. `swift package dump-package` fails inside the `@@swiftpkg_swift_log` repo fetch, so `//bzlmod:e2e_test` can't even reach analysis.

## Why the cap broke

#2262 originally pinned swift-log to `..< 1.9.0` to avoid exactly this. Renovate then quietly raised the bound twice without anyone noticing the cap intent:

- #2265: `..< 1.9.0` → `..< 1.12.0`
- #2299: `..< 1.12.0` → `..< 1.12.1`

The pre-existing comment still said \"cap below 1.9.0\" the whole time.

## Changes

- `bzlmod/workspace/Package.swift` — restore `..< 1.9.0` upper bound on swift-log; comment now matches the actual cap again
- `bzlmod/workspace/Package.resolved` — re-resolved via `swift package resolve`; swift-log now pins to 1.8.0 (declares `swift-tools-version:6.0`, parses on BCR's Swift 6.0.3)
- `.github/renovate.json` — disable `apple/swift-log` updates for `bzlmod/workspace/Package.swift` so the cap stops drifting (mirrors the existing `swift-async-algorithms` exclusion)

## Follow-up

PR #9042 itself can't be amended — BCR builds from the v1.18.0 tarball. Once this merges we'll need to cut v1.18.1; the auto-publish bot will open a fresh BCR PR and #9042 can be closed.

## Test plan

- [x] `swift package resolve` in `bzlmod/workspace` → swift-log 1.8.0
- [ ] BCR presubmit on the eventual v1.18.1 PR