### PR TITLE
fix: find swift via xcrun or PATH

### DIFF
--- a/swiftpkg/internal/swift_package_lib.sh
+++ b/swiftpkg/internal/swift_package_lib.sh
@@ -8,28 +8,20 @@
 #
 # Usage: source this file and call the functions you need.
 
-# Resolves the `swift` executable path from the swift_worker binary.
-# Falls back to `which swift` if --find is not supported (e.g. Linux).
-#
-# Arguments:
-#   $1 - path to the swift_worker executable
-#
-# Outputs:
-#   Prints the resolved swift executable path to stdout.
+# Prints the path to the `swift` executable: via `xcrun` on Apple (the
+# selected Xcode toolchain), otherwise from PATH.
 spl_resolve_swift_executable() {
-  local swift_worker="$1"
-  local swift_executable
-  swift_executable="$(
-    "${swift_worker}" --find swift \
-      || which swift \
-      || (
-        # `exit 1` only exits this `(...)` subshell, not the caller.
-        # The nonzero status propagates through `$(...)` and trips
-        # `errexit` in the surrounding script.
-        echo >&2 "Could not find the swift executable."
-        exit 1
-      )
-  )"
+  local swift_executable=""
+  if command -v xcrun >/dev/null 2>&1; then
+    swift_executable="$(xcrun --find swift 2>/dev/null || true)"
+  fi
+  if [[ -z ${swift_executable} || ! -x ${swift_executable} ]]; then
+    swift_executable="$(command -v swift || true)"
+  fi
+  if [[ -z ${swift_executable} || ! -x ${swift_executable} ]]; then
+    echo >&2 "Could not find the swift executable."
+    exit 1
+  fi
   echo "${swift_executable}"
 }
 
@@ -53,7 +45,6 @@ spl_setup_registries() {
 # executes a `swift package` command with the full set of SPM flags.
 #
 # Arguments (passed as flag-value pairs):
-#   --swift_worker <path>
 #   --cmd <update|resolve>
 #   --package_path <path>
 #   --build_path <path>
@@ -73,7 +64,6 @@ spl_setup_registries() {
 # Any remaining arguments after -- are appended to the swift package
 # command.
 spl_run_swift_package() {
-  local swift_worker=""
   local cmd=""
   local package_path=""
   local build_path=""
@@ -93,10 +83,6 @@ spl_run_swift_package() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --swift_worker)
-        swift_worker="$2"
-        shift 2
-        ;;
       --cmd)
         cmd="$2"
         shift 2
@@ -172,7 +158,6 @@ spl_run_swift_package() {
   # Validate required flags. package_path is intentionally omitted
   # because the empty string is valid (root-workspace Package.swift).
   local missing=()
-  [[ -z ${swift_worker} ]] && missing+=("--swift_worker")
   [[ -z ${cmd} ]] && missing+=("--cmd")
   [[ -z ${build_path} ]] && missing+=("--build_path")
   [[ -z ${cache_path} ]] && missing+=("--cache_path")
@@ -194,7 +179,7 @@ spl_run_swift_package() {
 
   # Resolve swift executable.
   local swift_executable
-  swift_executable="$(spl_resolve_swift_executable "${swift_worker}")"
+  swift_executable="$(spl_resolve_swift_executable)"
 
   # Construct dynamic arguments.
   local args=()

--- a/swiftpkg/internal/swift_worker_binary.bzl
+++ b/swiftpkg/internal/swift_worker_binary.bzl
@@ -1,12 +1,7 @@
 """Implementation for the `swift_worker_binary` rule."""
 
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
-
 def _swift_worker_binary_impl(ctx):
     tool_executable = ctx.executable.tool
-
-    toolchain = swift_common.get_toolchain(ctx)
-    swift_worker = toolchain.swift_worker
 
     # Write extra_args to a params file (one arg per line) so the
     # launcher can read them at runtime without Starlark-side shell
@@ -33,7 +28,6 @@ def _swift_worker_binary_impl(ctx):
         substitutions = {
             "{ARGS_FILE}": args_file.short_path,
             "{TOOL}": tool_executable.short_path,
-            "{WORKER}": swift_worker.executable.short_path,
         },
         is_executable = True,
     )
@@ -42,7 +36,7 @@ def _swift_worker_binary_impl(ctx):
     # rule and thus empty default_runfiles), plus merge each dep's
     # default_runfiles to pick up transitive runfiles from rule targets.
     runfiles = ctx.runfiles(
-        files = ctx.files.data + [args_file, swift_worker.executable],
+        files = ctx.files.data + [args_file],
     )
     runfiles = runfiles.merge(ctx.attr.tool[DefaultInfo].default_runfiles)
     for dep in ctx.attr.data:
@@ -59,10 +53,9 @@ def _swift_worker_binary_impl(ctx):
 swift_worker_binary = rule(
     implementation = _swift_worker_binary_impl,
     doc = """\
-A reusable rule that resolves the Swift toolchain and generates a launcher \
-script. It wraps a provided tool executable, passing `--swift_worker <path>` \
-as the first arguments so the tool can locate and use the Bazel-configured \
-Swift toolchain.\
+A reusable rule that generates a launcher script wrapping a provided tool \
+executable. Baked-in extra_args are passed before any user-provided \
+command-line arguments.\
 """,
     executable = True,
     attrs = {
@@ -72,23 +65,19 @@ Swift toolchain.\
         ),
         "extra_args": attr.string_list(
             doc = """\
-Additional arguments baked into the launcher script after --swift_worker. \
-These are passed before any user-provided command-line arguments.\
+Additional arguments baked into the launcher script, passed before any \
+user-provided command-line arguments.\
 """,
         ),
         "tool": attr.label(
             executable = True,
             cfg = "exec",
             mandatory = True,
-            doc = """\
-The executable to run. The launcher passes --swift_worker <path> as the \
-first args, followed by any user-provided args.\
-""",
+            doc = "The executable to run, followed by any user-provided args.",
         ),
         "_launcher_template": attr.label(
             default = "@rules_swift_package_manager//swiftpkg/internal:swift_worker_binary_launcher.sh.tmpl",
             allow_single_file = True,
         ),
     },
-    toolchains = swift_common.use_toolchain(),
 )

--- a/swiftpkg/internal/swift_worker_binary_launcher.sh.tmpl
+++ b/swiftpkg/internal/swift_worker_binary_launcher.sh.tmpl
@@ -18,7 +18,7 @@ while IFS= read -r line; do
   extra_args+=("$line")
 done <"{ARGS_FILE}"
 if [[ ${#extra_args[@]} -gt 0 ]]; then
-  exec "{TOOL}" --swift_worker "{WORKER}" "${extra_args[@]}" "$@"
+  exec "{TOOL}" "${extra_args[@]}" "$@"
 else
-  exec "{TOOL}" --swift_worker "{WORKER}" "$@"
+  exec "{TOOL}" "$@"
 fi

--- a/swiftpkg/tests/swift_package_lib_tests/swift_package_lib_test.sh
+++ b/swiftpkg/tests/swift_package_lib_tests/swift_package_lib_test.sh
@@ -78,26 +78,27 @@ write_script() {
   chmod +x "${path}"
 }
 
-# When the swift_worker --find returns a path, use it.
-resolve_ok_dir="$(new_tmp_dir)"
-worker_ok="${resolve_ok_dir}/worker"
-write_script "${worker_ok}" 'echo "/fake/resolved/swift"'
-resolve_output="$(spl_resolve_swift_executable "${worker_ok}")"
+# When xcrun is available (Apple), resolve swift via `xcrun --find swift`.
+resolve_xcrun_dir="$(new_tmp_dir)"
+fake_swift_xcrun="${resolve_xcrun_dir}/swift"
+write_script "${fake_swift_xcrun}" 'echo xcrun-swift'
+write_script "${resolve_xcrun_dir}/xcrun" \
+  "[ \"\$1\" = '--find' ] && [ \"\$2\" = 'swift' ] && echo '${fake_swift_xcrun}'"
+xcrun_output="$(PATH="${resolve_xcrun_dir}:${PATH}" \
+  spl_resolve_swift_executable /unused/worker)"
 assert_equal \
-  "/fake/resolved/swift" "${resolve_output}" \
-  "swift_worker --find output should be used when it succeeds"
+  "${fake_swift_xcrun}" "${xcrun_output}" \
+  "xcrun --find swift should be used when xcrun is available"
 
-# When swift_worker fails, fall back to `which swift` on PATH.
-resolve_fallback_dir="$(new_tmp_dir)"
-worker_fail="${resolve_fallback_dir}/worker"
-write_script "${worker_fail}" 'exit 1'
-fake_swift="${resolve_fallback_dir}/swift"
-write_script "${fake_swift}" 'echo fake-swift-called'
-fallback_output="$(PATH="${resolve_fallback_dir}:${PATH}" \
-  spl_resolve_swift_executable "${worker_fail}")"
+# When xcrun is unavailable (e.g. Linux), fall back to `swift` on PATH.
+resolve_path_dir="$(new_tmp_dir)"
+fake_swift_path="${resolve_path_dir}/swift"
+write_script "${fake_swift_path}" 'echo path-swift'
+fallback_output="$(PATH="${resolve_path_dir}" \
+  spl_resolve_swift_executable /unused/worker)"
 assert_equal \
-  "${fake_swift}" "${fallback_output}" \
-  "which swift should be used when swift_worker fails"
+  "${fake_swift_path}" "${fallback_output}" \
+  "swift on PATH should be used when xcrun is unavailable"
 
 # MARK - spl_run_swift_package required-flag validation
 
@@ -110,7 +111,7 @@ set -e
 assert_equal \
   "1" "${validation_rc}" \
   "missing required flags should return exit code 1"
-for flag in --swift_worker --cmd --build_path --cache_path \
+for flag in --cmd --build_path --cache_path \
   --config_path --security_path; do
   case "${validation_err}" in
     *"${flag}"*) ;;
@@ -121,7 +122,7 @@ done
 # MARK - spl_run_swift_package (argv capture via fake swift)
 
 # Stand up a fake swift that writes its argv (one arg per line) to
-# ${SWIFT_ARGS_FILE}, plus a swift_worker that resolves to it.
+# ${SWIFT_ARGS_FILE}, plus a fake xcrun that resolves swift to it.
 run_dir="$(new_tmp_dir)"
 swift_args_file="${run_dir}/swift_args.txt"
 fake_run_swift="${run_dir}/swift"
@@ -138,21 +139,20 @@ fi
 FAKE_SWIFT
 chmod +x "${fake_run_swift}"
 
-fake_run_worker="${run_dir}/worker"
-cat >"${fake_run_worker}" <<FAKE_WORKER
+fake_xcrun="${run_dir}/xcrun"
+cat >"${fake_xcrun}" <<FAKE_XCRUN
 #!/usr/bin/env bash
-echo "${fake_run_swift}"
-FAKE_WORKER
-chmod +x "${fake_run_worker}"
+[ "\$1" = "--find" ] && [ "\$2" = "swift" ] && echo "${fake_run_swift}"
+FAKE_XCRUN
+chmod +x "${fake_xcrun}"
 
 # BUILD_WORKSPACE_DIRECTORY must be set or the function exits.
 workspace_dir="${run_dir}/ws"
 mkdir -p "${workspace_dir}"
 
 export SWIFT_ARGS_FILE="${swift_args_file}"
-BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
+PATH="${run_dir}:${PATH}" BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
   spl_run_swift_package \
-  --swift_worker "${fake_run_worker}" \
   --cmd resolve \
   --package_path pkgsub \
   --build_path .build \
@@ -213,9 +213,8 @@ netrc_space_realpath="$(readlink -f "${netrc_space_file}")"
 # Reset argv file so the next invocation is captured cleanly.
 : >"${swift_args_file}"
 
-BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
+PATH="${run_dir}:${PATH}" BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
   spl_run_swift_package \
-  --swift_worker "${fake_run_worker}" \
   --cmd resolve \
   --package_path pkgsub \
   --build_path .build \
@@ -244,9 +243,8 @@ swift_env_file="${run_dir}/swift_env.txt"
 : >"${swift_env_file}"
 export SWIFT_ENV_FILE="${swift_env_file}"
 
-BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
+PATH="${run_dir}:${PATH}" BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
   spl_run_swift_package \
-  --swift_worker "${fake_run_worker}" \
   --cmd resolve \
   --package_path pkgsub \
   --build_path .build \
@@ -297,9 +295,8 @@ unset SWIFT_ENV_FILE SPL_TEST_FOO SPL_TEST_SPACED
 # variable to enable this splitting.
 : >"${swift_args_file}"
 
-BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
+PATH="${run_dir}:${PATH}" BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
   spl_run_swift_package \
-  --swift_worker "${fake_run_worker}" \
   --cmd resolve \
   --package_path pkgsub \
   --build_path .build \
@@ -333,9 +330,8 @@ echo '{"registries":{"example":{"url":"https://example.invalid"}}}' \
 reg_plumb_config="${reg_plumb_dir}/.config"
 : >"${swift_args_file}"
 
-BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
+PATH="${run_dir}:${PATH}" BUILD_WORKSPACE_DIRECTORY="${workspace_dir}" \
   spl_run_swift_package \
-  --swift_worker "${fake_run_worker}" \
   --cmd resolve \
   --package_path pkgsub \
   --build_path .build \
@@ -370,7 +366,6 @@ set +e
 bwd_err="$(
   unset BUILD_WORKSPACE_DIRECTORY
   spl_run_swift_package \
-    --swift_worker "${fake_run_worker}" \
     --cmd resolve \
     --package_path pkgsub \
     --build_path .build \


### PR DESCRIPTION
Previously this used the `swift_worker` and had a fallback for linux to use `PATH`, the `swift_worker` logic breaks in rules_swift 4.0+ due to response file usage and was really just a proxy for `xcrun --find swift` anyway.
