### PR TITLE
fix: stop deleting modulemaps in library based xcframeworks

### DIFF
--- a/swiftpkg/internal/repo_rules.bzl
+++ b/swiftpkg/internal/repo_rules.bzl
@@ -258,6 +258,8 @@ def _remove_modulemaps(repository_ctx, directory, targets):
         directory,
         "module.modulemap",
         exclude_paths = [
+            # xcframeworks that vendor libraries can also contain modulemaps
+            "**/*.xcframework/*",
             # Framework modulemaps don't cause issues, and are needed
             "**/*.framework/*",
         ] + [


### PR DESCRIPTION
xcframework directories can vendor direct static libraries with headers.
In this case they don't match the `*.framework` glob, but we still need
to keep the modulemaps. Example valid layout:

```
IDKitFFI.xcframework/macos-arm64_x86_64/Headers/IDKit/idkit_coreFFI.h
IDKitFFI.xcframework/macos-arm64_x86_64/Headers/IDKit/module.modulemap
IDKitFFI.xcframework/macos-arm64_x86_64/libidkitFFI.a
```

rules_apple then handles this modulemap correctly.
