### PR TITLE
Support localhost HTTP registries without checksum

### DIFF
--- a/swiftpkg/internal/registry_swift_package.bzl
+++ b/swiftpkg/internal/registry_swift_package.bzl
@@ -60,6 +60,10 @@ def _get_registry_url(*, id, registries):
     """
     return registries.scoped.get(id.scope, registries.default)
 
+def _is_localhost_url(url):
+    """Returns True if the URL points to a localhost address."""
+    return url.startswith("http://localhost") or url.startswith("http://127.0.0.1")
+
 def _download_and_parse_package_json(*, id, output, repository_ctx, registry_url, version):
     """Downloads and parses the package JSON metadata from the registry.
 
@@ -71,11 +75,33 @@ def _download_and_parse_package_json(*, id, output, repository_ctx, registry_url
         id.name,
         version,
     )
-    repository_ctx.download(
-        headers = _REGISTRY_JSON_ACCEPT_HEADER,
-        url = package_json_url,
-        output = output,
-    )
+
+    if _is_localhost_url(package_json_url):
+        # Bazel rejects plain http:// URLs without a checksum, but the
+        # metadata checksum is not known ahead of time (it is inside the
+        # response). For localhost registries (e.g. a local registry proxy),
+        # fall back to curl since the traffic never leaves the machine.
+        result = repository_ctx.execute(
+            [
+                "curl", "-sL",
+                "-H", "Accept: application/vnd.swift.registry.v1+json",
+                "-o", output,
+                "-w", "%{http_code}",
+                package_json_url,
+            ],
+            timeout = 30,
+        )
+        if result.return_code != 0 or not result.stdout.startswith("2"):
+            fail("Failed to download package metadata from {url}: {err}".format(
+                url = package_json_url,
+                err = result.stderr if result.return_code != 0 else "HTTP " + result.stdout,
+            ))
+    else:
+        repository_ctx.download(
+            headers = _REGISTRY_JSON_ACCEPT_HEADER,
+            url = package_json_url,
+            output = output,
+        )
 
     return json.decode(repository_ctx.read(output))
 


### PR DESCRIPTION
## Problem

When using a localhost HTTP registry (e.g. a local proxy that mirrors a remote Swift package registry), `registry_swift_package` fails at the metadata download step:

```
Error in download: java.io.IOException: No URLs left after removing plain http URLs due to missing checksum.
Please provide either a checksum or an https download location.
```

This happens because `_download_and_parse_package_json` calls `repository_ctx.download()` without a checksum — which is correct, since the checksum is contained *inside* the metadata response and cannot be known ahead of time. However, Bazel rejects plain `http://` URLs without checksums as a security measure (bazelbuild/bazel#8607).

This makes it impossible to use `registry_swift_package` with a localhost registry proxy (e.g. `http://localhost:8080/registry/...`).

## Fix

Detect `http://localhost` and `http://127.0.0.1` URLs and fall back to `repository_ctx.execute()` with `curl` for the metadata fetch. This is safe because:

- Traffic never leaves the machine
- The subsequent source archive download already has a checksum (extracted from the metadata response) and continues to use `repository_ctx.download_and_extract()` normally
- `curl` is universally available on macOS and Linux build environments

The existing behavior for all non-localhost URLs is completely unchanged.

## Use Case

Local registry proxies that cache/mirror remote Swift package registries for offline builds, network-restricted environments, or corporate build infrastructure.

Fixes #2006