### PR TITLE
fix: Ignore duplicate modulemaps at the same path

### DIFF
--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -269,7 +269,7 @@ def _collect_files(
             orig_path,
             public_includes = public_includes,
         ):
-            if modulemap != None:
+            if modulemap != None and modulemap != path:
                 fail("Found multiple modulemap files. {first} {second}".format(
                     first = modulemap,
                     second = path,

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -3,6 +3,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//swiftpkg/internal:clang_files.bzl", "clang_files")
+load(":testutils.bzl", "testutils")
 
 def _is_hdr_test(ctx):
     env = unittest.begin(ctx)
@@ -269,9 +270,47 @@ def _organize_srcs_test(ctx):
 
 organize_srcs_test = unittest.make(_organize_srcs_test)
 
+def _collect_files_uses_custom_modulemap_name_test(ctx):
+    env = unittest.begin(ctx)
+
+    repository_ctx = testutils.new_stub_repository_ctx(
+        "mypackage",
+        file_contents = {
+            "/pkg/yoga/module.modulemap": """\
+module yoga {
+  header "Yoga.h"
+  export *
+}
+""",
+        },
+    )
+
+    actual = clang_files.collect_files(
+        repository_ctx,
+        [
+            "/pkg/yoga/module.modulemap",
+            "/pkg/yoga/module.modulemap",
+            "/pkg/yoga/Yoga.h",
+        ],
+        "core",
+        public_includes = ["/pkg"],
+        relative_to = "/pkg",
+    )
+
+    asserts.equals(env, "yoga/module.modulemap", actual.modulemap)
+    asserts.equals(env, "yoga", actual.module_name)
+    asserts.equals(env, ["yoga/Yoga.h"], actual.hdrs)
+
+    return unittest.end(env)
+
+collect_files_uses_custom_modulemap_name_test = unittest.make(
+    _collect_files_uses_custom_modulemap_name_test,
+)
+
 def clang_files_test_suite():
     return unittest.suite(
         "clang_files_tests",
+        collect_files_uses_custom_modulemap_name_test,
         organize_srcs_test,
         is_hdr_test,
         is_include_hdr_test,

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -298,7 +298,6 @@ module yoga {
     )
 
     asserts.equals(env, "yoga/module.modulemap", actual.modulemap)
-    asserts.equals(env, "yoga", actual.module_name)
     asserts.equals(env, ["yoga/Yoga.h"], actual.hdrs)
 
     return unittest.end(env)


### PR DESCRIPTION
Unlike all the other branches in this loop modulemaps are not allowed to
be duplicated. The callers of this function can pass a list with
duplicate entries. For modulemaps we don't need to error unless there
are different files.

Fixes https://github.com/cgrindel/rules_swift_package_manager/pull/1452
