### PR TITLE
fix: don't include everything under public includes

### DIFF
--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -32,6 +32,8 @@ _OTHER_SRC_EXTS = [".so", ".o", ".inc"]
 
 _TEXTUAL_HDR_EXTS = [".def", ".macros"]
 
+_PUBLIC_INCLUDE_FILE_EXTS = _TEXTUAL_HDR_EXTS + [".modulemap"]
+
 # Acceptable sources clang and objc:
 # https://bazel.build/reference/be/c-cpp#cc_library.srcs
 # https://bazel.build/reference/be/objective-c#objc_library.srcs
@@ -43,6 +45,10 @@ _SRC_EXTS = _C_SRC_EXTS + _CXX_SRC_EXTS + _OBJC_SRC_EXTS + _OBJCXX_SRC_EXTS + \
 def _is_hdr(path):
     _root, ext = paths.split_extension(path)
     return lists.contains(_HEADER_EXTS, ext)
+
+def _is_public_include_file(path):
+    _root, ext = paths.split_extension(path)
+    return _is_hdr(path) or lists.contains(_PUBLIC_INCLUDE_FILE_EXTS, ext)
 
 def _is_include_hdr(path, public_includes = []):
     """Determines whether the path is a public header.
@@ -189,6 +195,23 @@ def _is_under_path(path, parent):
     if path.startswith(parent_prefix):
         return True
     return False
+
+def _public_include_file_scan_paths(public_include, src_paths):
+    """Returns paths to scan for public include files.
+
+    If a source path sits under the public include root, scanning the whole
+    include root would pull files from sibling directories outside the explicit
+    source paths. If no source path sits under the public include root, treat
+    the public include as a separate header directory and scan it directly.
+    """
+    source_paths_under_public_include = [
+        sp
+        for sp in src_paths
+        if _is_under_path(sp, public_include)
+    ]
+    if source_paths_under_public_include:
+        return source_paths_under_public_include
+    return [public_include]
 
 def _relativize(path, relative_to):
     """Returns a path relative to another path.
@@ -409,9 +432,11 @@ clang_files = struct(
     find_magical_public_hdr_dir = _find_magical_public_hdr_dir,
     is_hdr = _is_hdr,
     is_include_hdr = _is_include_hdr,
+    is_public_include_file = _is_public_include_file,
     is_public_modulemap = _is_public_modulemap,
     is_under_path = _is_under_path,
     organize_srcs = _organize_srcs,
+    public_include_file_scan_paths = _public_include_file_scan_paths,
     reduce_paths = _reduce_paths,
     relativize = _relativize,
 )

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -30,29 +30,6 @@ _DEFAULT_LOCALIZATION = "en"
 # are enabled by default when no explicit trait selection is provided.
 _DEFAULT_TRAIT_NAME = "default"
 
-_PUBLIC_INCLUDE_FILE_EXTS = [".def", ".macros", ".modulemap"]
-
-def _is_public_include_file(path):
-    _root, ext = paths.split_extension(path)
-    return clang_files.is_hdr(path) or lists.contains(_PUBLIC_INCLUDE_FILE_EXTS, ext)
-
-def _public_include_file_scan_paths(public_include, src_paths):
-    """Returns paths to scan for public include files.
-
-    If a source path sits under the public include root, scanning the whole
-    include root would pull files from sibling directories outside the explicit
-    source paths. If no source path sits under the public include root, treat
-    the public include as a separate header directory and scan it directly.
-    """
-    source_paths_under_public_include = [
-        sp
-        for sp in src_paths
-        if clang_files.is_under_path(sp, public_include)
-    ]
-    if source_paths_under_public_include:
-        return source_paths_under_public_include
-    return [public_include]
-
 def _package_command_args(
         subcommand_args,
         registries_directory = None,
@@ -1526,7 +1503,7 @@ def _new_clang_src_info_from_sources(
     # files under directories such as `javascript`.
     if source_paths != None:
         for pi in public_includes:
-            for scan_path in _public_include_file_scan_paths(pi, src_paths):
+            for scan_path in clang_files.public_include_file_scan_paths(pi, src_paths):
                 all_srcs.extend([
                     f
                     for f in repository_files.list_files_under(
@@ -1534,7 +1511,7 @@ def _new_clang_src_info_from_sources(
                         scan_path,
                         exclude_paths = abs_exclude_paths,
                     )
-                    if _is_public_include_file(f)
+                    if clang_files.is_public_include_file(f)
                 ])
 
     # SPM's exclude list only excludes files from being compiled as sources,

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -30,6 +30,29 @@ _DEFAULT_LOCALIZATION = "en"
 # are enabled by default when no explicit trait selection is provided.
 _DEFAULT_TRAIT_NAME = "default"
 
+_PUBLIC_INCLUDE_FILE_EXTS = [".def", ".macros", ".modulemap"]
+
+def _is_public_include_file(path):
+    _root, ext = paths.split_extension(path)
+    return clang_files.is_hdr(path) or lists.contains(_PUBLIC_INCLUDE_FILE_EXTS, ext)
+
+def _public_include_file_scan_paths(public_include, src_paths):
+    """Returns paths to scan for public include files.
+
+    If a source path sits under the public include root, scanning the whole
+    include root would pull files from sibling directories outside the explicit
+    source paths. If no source path sits under the public include root, treat
+    the public include as a separate header directory and scan it directly.
+    """
+    source_paths_under_public_include = [
+        sp
+        for sp in src_paths
+        if clang_files.is_under_path(sp, public_include)
+    ]
+    if source_paths_under_public_include:
+        return source_paths_under_public_include
+    return [public_include]
+
 def _package_command_args(
         subcommand_args,
         registries_directory = None,
@@ -1464,19 +1487,12 @@ def _new_clang_src_info_from_sources(
         )
 
     # If the Swift package manifest has explicit source paths, respect them.
-    # (Be sure to include any explicitly specified include directories.)
     # Otherwise, use all of the source files under the target path.
     if source_paths != None:
         src_paths = [
             paths.normalize(paths.join(abs_target_path, sp))
             for sp in source_paths
         ]
-
-        # The public includes are already relative to the abs_target_path.
-        src_paths.extend([
-            paths.normalize(paths.join(pkg_path, pi))
-            for pi in public_includes
-        ])
         src_paths = sets.to_list(sets.make(src_paths))
     else:
         src_paths = [abs_target_path]
@@ -1502,6 +1518,24 @@ def _new_clang_src_info_from_sources(
             sp,
             exclude_paths = abs_exclude_paths,
         ))
+
+    # Explicit public include directories may be broader than the target's
+    # source paths. For example, Yoga uses `path = "."`, `sources = ["yoga"]`,
+    # and `publicHeadersPath = "."`. In that case, the package root must be
+    # searched for public headers and module maps without compiling unrelated C
+    # files under directories such as `javascript`.
+    if source_paths != None:
+        for pi in public_includes:
+            for scan_path in _public_include_file_scan_paths(pi, src_paths):
+                all_srcs.extend([
+                    f
+                    for f in repository_files.list_files_under(
+                        repository_ctx,
+                        scan_path,
+                        exclude_paths = abs_exclude_paths,
+                    )
+                    if _is_public_include_file(f)
+                ])
 
     # SPM's exclude list only excludes files from being compiled as sources,
     # but headers in excluded directories are still available for inclusion.
@@ -2142,4 +2176,5 @@ pkginfos = struct(
 pkginfos_testing = struct(
     describe_package_args = _describe_package_args,
     dump_package_args = _dump_package_args,
+    new_clang_src_info_from_sources = _new_clang_src_info_from_sources,
 )

--- a/swiftpkg/tests/BUILD.bazel
+++ b/swiftpkg/tests/BUILD.bazel
@@ -16,6 +16,7 @@ load(":pkginfo_ext_deps_tests.bzl", "pkginfo_ext_deps_test_suite")
 load(":pkginfo_target_deps_tests.bzl", "pkginfo_target_deps_test_suite")
 load(":pkginfo_targets_tests.bzl", "pkginfo_targets_test_suite")
 load(":pkginfo_traits_tests.bzl", "pkginfo_traits_test_suite")
+load(":pkginfos_clang_src_info_tests.bzl", "pkginfos_clang_src_info_test_suite")
 load(":pkginfos_command_args_tests.bzl", "pkginfos_command_args_test_suite")
 load(":repo_rules_tests.bzl", "repo_rules_test_suite")
 load(":repository_files_tests.bzl", "repository_files_test_suite")
@@ -60,6 +61,8 @@ pkginfo_target_deps_test_suite()
 pkginfo_targets_test_suite()
 
 pkginfo_traits_test_suite()
+
+pkginfos_clang_src_info_test_suite()
 
 pkginfos_command_args_test_suite()
 

--- a/swiftpkg/tests/clang_files_tests.bzl
+++ b/swiftpkg/tests/clang_files_tests.bzl
@@ -26,6 +26,25 @@ def _is_hdr_test(ctx):
 
 is_hdr_test = unittest.make(_is_hdr_test)
 
+def _is_public_include_file_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(path = "foo.h", exp = True, msg = "header"),
+        struct(path = "foo.def", exp = True, msg = "textual def header"),
+        struct(path = "foo.macros", exp = True, msg = "textual macros header"),
+        struct(path = "module.modulemap", exp = True, msg = "modulemap"),
+        struct(path = "foo.c", exp = False, msg = "source file"),
+        struct(path = "README.md", exp = False, msg = "unknown extension"),
+    ]
+    for t in tests:
+        actual = clang_files.is_public_include_file(t.path)
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+is_public_include_file_test = unittest.make(_is_public_include_file_test)
+
 def _is_include_hdr_test(ctx):
     env = unittest.begin(ctx)
 
@@ -141,6 +160,52 @@ def _is_under_path_test(ctx):
     return unittest.end(env)
 
 is_under_path_test = unittest.make(_is_under_path_test)
+
+def _public_include_file_scan_paths_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            msg = "source paths under public include",
+            public_include = "/pkg",
+            src_paths = [
+                "/pkg/yoga",
+                "/pkg/yoga/algorithm",
+                "/another/source",
+            ],
+            exp = [
+                "/pkg/yoga",
+                "/pkg/yoga/algorithm",
+            ],
+        ),
+        struct(
+            msg = "public include separate from source paths",
+            public_include = "/pkg/include",
+            src_paths = [
+                "/pkg/src",
+            ],
+            exp = ["/pkg/include"],
+        ),
+        struct(
+            msg = "source path equals public include",
+            public_include = "/pkg/include",
+            src_paths = [
+                "/pkg/include",
+                "/pkg/include_extra",
+            ],
+            exp = ["/pkg/include"],
+        ),
+    ]
+    for t in tests:
+        actual = clang_files.public_include_file_scan_paths(
+            t.public_include,
+            t.src_paths,
+        )
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+public_include_file_scan_paths_test = unittest.make(_public_include_file_scan_paths_test)
 
 def _find_magical_public_hdr_dir_test(ctx):
     env = unittest.begin(ctx)
@@ -312,10 +377,12 @@ def clang_files_test_suite():
         collect_files_uses_custom_modulemap_name_test,
         organize_srcs_test,
         is_hdr_test,
+        is_public_include_file_test,
         is_include_hdr_test,
         is_public_modulemap_test,
         relativize_test,
         is_under_path_test,
+        public_include_file_scan_paths_test,
         find_magical_public_hdr_dir_test,
         reduce_paths_test,
     )

--- a/swiftpkg/tests/pkginfos_clang_src_info_tests.bzl
+++ b/swiftpkg/tests/pkginfos_clang_src_info_tests.bzl
@@ -1,0 +1,137 @@
+"""Tests for `pkginfos` clang source info collection."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//swiftpkg/internal:pkginfos.bzl", "pkginfos_testing")
+load(":testutils.bzl", "testutils")
+
+def _explicit_source_paths_do_not_compile_public_include_sources_test(ctx):
+    env = unittest.begin(ctx)
+
+    repository_ctx = testutils.new_stub_repository_ctx(
+        "yoga",
+        file_contents = {
+            "/pkg/yoga/module.modulemap": """
+module core {
+  header "YGConfig.h"
+  export *
+}
+""",
+        },
+        find_results = {
+            "/pkg": [
+                "/pkg/benchmark/Benchmark.h",
+                "/pkg/javascript/src/wasm_bridge.c",
+                "/pkg/yoga/YGConfig.cpp",
+                "/pkg/yoga/YGConfig.h",
+                "/pkg/yoga/module.modulemap",
+            ],
+            "/pkg/yoga": [
+                "/pkg/yoga/YGConfig.cpp",
+                "/pkg/yoga/YGConfig.h",
+                "/pkg/yoga/module.modulemap",
+            ],
+        },
+    )
+
+    actual = pkginfos_testing.new_clang_src_info_from_sources(
+        repository_ctx = repository_ctx,
+        pkg_path = "/pkg",
+        c99name = "core",
+        target_path = ".",
+        source_paths = ["yoga"],
+        public_hdrs_path = ".",
+        exclude_paths = [],
+    )
+
+    asserts.equals(
+        env,
+        ["yoga/YGConfig.cpp"],
+        sorted(actual.explicit_srcs),
+    )
+    asserts.equals(env, [], actual.organized_srcs.c_srcs)
+    asserts.equals(
+        env,
+        ["yoga/YGConfig.cpp"],
+        sorted(actual.organized_srcs.cxx_srcs),
+    )
+    asserts.false(
+        env,
+        "javascript/src/wasm_bridge.c" in actual.explicit_srcs,
+    )
+    asserts.equals(
+        env,
+        ["yoga/YGConfig.h"],
+        sorted(actual.hdrs),
+    )
+    asserts.false(
+        env,
+        "benchmark/Benchmark.h" in actual.hdrs,
+    )
+    asserts.equals(env, "yoga/module.modulemap", actual.modulemap_path)
+    asserts.equals(env, "core", actual.module_name)
+
+    return unittest.end(env)
+
+explicit_source_paths_do_not_compile_public_include_sources_test = unittest.make(
+    _explicit_source_paths_do_not_compile_public_include_sources_test,
+)
+
+def _explicit_source_paths_keep_separate_public_include_test(ctx):
+    env = unittest.begin(ctx)
+
+    repository_ctx = testutils.new_stub_repository_ctx(
+        "cpackage",
+        file_contents = {
+            "/pkg/include/module.modulemap": """
+module core {
+  header "Core.h"
+  export *
+}
+""",
+        },
+        find_results = {
+            "/pkg/include": [
+                "/pkg/include/Core.h",
+                "/pkg/include/module.modulemap",
+            ],
+            "/pkg/src": [
+                "/pkg/src/Core.c",
+            ],
+        },
+    )
+
+    actual = pkginfos_testing.new_clang_src_info_from_sources(
+        repository_ctx = repository_ctx,
+        pkg_path = "/pkg",
+        c99name = "core",
+        target_path = ".",
+        source_paths = ["src"],
+        public_hdrs_path = "include",
+        exclude_paths = [],
+    )
+
+    asserts.equals(
+        env,
+        ["src/Core.c"],
+        sorted(actual.explicit_srcs),
+    )
+    asserts.equals(
+        env,
+        ["include/Core.h"],
+        sorted(actual.hdrs),
+    )
+    asserts.equals(env, "include/module.modulemap", actual.modulemap_path)
+    asserts.equals(env, "core", actual.module_name)
+
+    return unittest.end(env)
+
+explicit_source_paths_keep_separate_public_include_test = unittest.make(
+    _explicit_source_paths_keep_separate_public_include_test,
+)
+
+def pkginfos_clang_src_info_test_suite():
+    unittest.suite(
+        "pkginfos_clang_src_info_tests",
+        explicit_source_paths_do_not_compile_public_include_sources_test,
+        explicit_source_paths_keep_separate_public_include_test,
+    )


### PR DESCRIPTION
Previously all source files under the public headers path would be
included. This is different from SwiftPM which only includes source
files from public headers if they are under the sources directory.
