### PR TITLE
fix: read module name from modulemap when relevant

### DIFF
--- a/swiftpkg/internal/clang_files.bzl
+++ b/swiftpkg/internal/clang_files.bzl
@@ -120,8 +120,8 @@ def _is_public_modulemap(path, public_includes = []):
 
     return False
 
-def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path, module_name):
-    """Retrieves the list of headers declared in the specified modulemap file \
+def _get_info_from_modulemap(repository_ctx, modulemap_path, module_name):
+    """Retrieves module info declared in the specified modulemap file \
     for the specified module.
 
     If the specified module is not found, all of the headers from the top-level
@@ -133,7 +133,8 @@ def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path, module_name):
         module_name: The name of the module.
 
     Returns:
-        A `list` of path `string` values.
+        A `struct` containing the module name and a list of header path `string`
+        values.
     """
     modulemap_str = repository_ctx.read(modulemap_path)
     decls, err = modulemap_parser.parse(modulemap_str)
@@ -148,8 +149,12 @@ def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path, module_name):
     # headers from that module if it is found. Otherwise, we collect all of the
     # headers in all of the module declarations at the top-level.
     module_decl = lists.find(module_decls, lambda m: m.module_id == module_name)
+    resolved_module_name = module_name
     if module_decl != None:
         module_decls = [module_decl]
+        resolved_module_name = module_decl.module_id
+    elif len(module_decls) == 1:
+        resolved_module_name = module_decls[0].module_id
 
     modulemap_dirname = paths.dirname(modulemap_path)
     hdrs = []
@@ -161,7 +166,10 @@ def _get_hdr_paths_from_modulemap(repository_ctx, modulemap_path, module_name):
                 normalized_hdr_path = paths.normalize(hdr_path)
                 hdrs.append(normalized_hdr_path)
 
-    return hdrs
+    return struct(
+        hdrs = hdrs,
+        module_name = resolved_module_name,
+    )
 
 def _is_under_path(path, parent):
     """Determines whether a path is under a another path.
@@ -253,6 +261,7 @@ def _collect_files(
 
     modulemap = None
     modulemap_orig_path = None
+    modulemap_module_name = None
     for orig_path in all_srcs:
         path = _relativize(orig_path, relative_to)
         _root, ext = paths.split_extension(path)
@@ -285,11 +294,13 @@ def _collect_files(
     # the referenced headers are included. For now, we will just add the
     # modulemap hdrs to the ones that we have already found.
     if modulemap_orig_path != None:
-        mm_hdrs = _get_hdr_paths_from_modulemap(
+        modulemap_info = _get_info_from_modulemap(
             repository_ctx,
             modulemap_orig_path,
             module_name,
         )
+        modulemap_module_name = modulemap_info.module_name
+        mm_hdrs = modulemap_info.hdrs
         mm_hdrs = _relativize_paths(mm_hdrs, relative_to)
 
         # There are modulemaps in the wild (e.g.,
@@ -358,6 +369,7 @@ def _collect_files(
         public_includes = sorted(public_includes),
         private_includes = sorted(private_includes),
         modulemap = modulemap,
+        module_name = modulemap_module_name,
         others = sorted(others),
         textual_hdrs = sorted(textual_hdrs),
     )
@@ -395,7 +407,6 @@ def _organize_srcs(srcs):
 clang_files = struct(
     collect_files = _collect_files,
     find_magical_public_hdr_dir = _find_magical_public_hdr_dir,
-    get_hdr_paths_from_modulemap = _get_hdr_paths_from_modulemap,
     is_hdr = _is_hdr,
     is_include_hdr = _is_include_hdr,
     is_public_modulemap = _is_public_modulemap,

--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -1602,6 +1602,7 @@ def _new_clang_src_info_from_sources(
         textual_hdrs = textual_hdrs,
         public_includes = public_includes,
         private_includes = private_includes,
+        module_name = organized_files.module_name,
         modulemap_path = organized_files.modulemap,
         frameworks = frameworks,
     )
@@ -1613,6 +1614,7 @@ def _new_clang_src_info(
         textual_hdrs = [],
         public_includes = [],
         private_includes = [],
+        module_name = None,
         modulemap_path = None,
         frameworks = []):
     return struct(
@@ -1622,6 +1624,7 @@ def _new_clang_src_info(
         textual_hdrs = textual_hdrs,
         public_includes = public_includes,
         private_includes = private_includes,
+        module_name = module_name,
         modulemap_path = modulemap_path,
         frameworks = frameworks,
     )

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -514,6 +514,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
     decls = []
     child_dep_names = []
     load_stmts = []
+    module_name = clang_src_info.module_name or target.c99name
 
     def _attrs_for_child(name):
         child_attrs = dict(attrs)
@@ -559,7 +560,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
                     # modulemaps entierly.
                     "deps": [],
                     "hdrs": clang_src_info.hdrs,
-                    "module_name": target.c99name,
+                    "module_name": module_name,
                     "visibility": _implementation_target_visibility(),
                 },
             ),
@@ -587,7 +588,7 @@ def _clang_target_build_file(repository_ctx, pkg_ctx, target):
             name = aspect_hint_target_name,
             attrs = {
                 "module_map": hint_module_map,
-                "module_name": target.c99name,
+                "module_name": module_name,
             },
         ),
     )


### PR DESCRIPTION
Previously if a user defined a target named 'foo' and in their custom
modulemap they had 'module bar', the module would be compiled with the
wrong module name and fail. The modulemap module name now takes
priority.
