### PR TITLE
fix: Replace the bare repo working directory in stored JSON files

### DIFF
--- a/swiftpkg/internal/pkginfos.bzl
+++ b/swiftpkg/internal/pkginfos.bzl
@@ -243,6 +243,7 @@ def _get(
 
     # Dump the merged pkg_info for debug purposes
     json_str = json.encode_indent(pkg_info, indent = "  ")
+    json_str = repository_utils.replace_working_directory(json_str, directory)
     repository_ctx.file("pkg_info.json", content = json_str, executable = False)
 
     return pkg_info

--- a/swiftpkg/internal/repository_utils.bzl
+++ b/swiftpkg/internal/repository_utils.bzl
@@ -185,9 +185,9 @@ def _copy(repository_ctx, src, dest):
 def _replace_working_directory(json_str, working_directory):
     """Replace the working directory prefix in a JSON string.
 
-    Uses a path-prefix-safe replacement by appending a trailing
-    slash to ensure only full path-prefix matches are replaced.
-    Without the trailing slash, a working directory like
+    Uses a path-prefix-safe replacement by appending a trailing slash or
+    a trailing quotation mark to ensure only full path-prefix matches are
+    replaced. Without the trailing indicator, a working directory like
     "/path/to/MyApp" would incorrectly match
     "/path/to/MyAppFrameworks".
 
@@ -203,7 +203,7 @@ def _replace_working_directory(json_str, working_directory):
     """
     if not working_directory:
         return json_str
-    return json_str.replace(working_directory + "/", "./")
+    return json_str.replace(working_directory + "/", "./").replace(working_directory + "\"", "./\"")
 
 repository_utils = struct(
     copy = _copy,

--- a/swiftpkg/tests/repository_utils_tests.bzl
+++ b/swiftpkg/tests/repository_utils_tests.bzl
@@ -108,11 +108,11 @@ empty working directory leaves string unchanged\
 working directory without trailing content is replaced\
 """,
             json_str = """\
-{"name": "/path/to/MyApp"}\
+{"path": "/path/to/MyApp"}\
 """,
             working_directory = "/path/to/MyApp",
             expected = """\
-{"name": "./"}\
+{"path": "./"}\
 """,
         ),
     ]

--- a/swiftpkg/tests/repository_utils_tests.bzl
+++ b/swiftpkg/tests/repository_utils_tests.bzl
@@ -105,14 +105,14 @@ empty working directory leaves string unchanged\
         ),
         struct(
             msg = """\
-working directory without trailing content is not replaced\
+working directory without trailing content is replaced\
 """,
             json_str = """\
 {"name": "/path/to/MyApp"}\
 """,
             working_directory = "/path/to/MyApp",
             expected = """\
-{"name": "/path/to/MyApp"}\
+{"name": "./"}\
 """,
         ),
     ]


### PR DESCRIPTION
The stored `desc.json`, `dump.json`, and `pkg_info.json` all contain the bare repository working directory inside of a JSON string literal. Before this PR those paths were left in the stored JSON files which causes the repo content to not be reproducible between workspaces or across machines.

This change ensures that the the repo content cache is reproducible and that the cached JSON files don't contain absolute paths when using the `cached_json_directory` feature.