### PR TITLE
chore: bump tca_example minimum_os_version to 17.0

### DIFF
--- a/examples/tca_example/Sources/BUILD.bazel
+++ b/examples/tca_example/Sources/BUILD.bazel
@@ -18,7 +18,7 @@ ios_application(
         "ipad",
     ],
     infoplists = [":Info.plist"],
-    minimum_os_version = "16.0",
+    minimum_os_version = "17.0",
     visibility = ["//visibility:public"],
     deps = [":TCAExample"],
 )

--- a/examples/tca_example/Tests/BUILD.bazel
+++ b/examples/tca_example/Tests/BUILD.bazel
@@ -15,7 +15,7 @@ swift_library(
 
 ios_unit_test(
     name = "TCAExampleTests",
-    minimum_os_version = "16.0",
+    minimum_os_version = "17.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     visibility = ["//visibility:private"],
     deps = [":TCAExampleTestsLib"],


### PR DESCRIPTION
Raise the TCA example app and unit test targets from iOS 16.0 to 17.0.

## Motivation

Issue #892 reported that apps depending on `swift-composable-architecture` (via `swift-perception`) failed to build at `minimum_os_version >= 17.0`, with errors like `'Bindable' is unavailable in iOS`. The root cause was that `swift_library` compiled transitive SPM deps against the consumer app's minimum OS instead of each package's own declared deployment target.

That was fixed by wrapping generated targets in per-package minimum OS transitions (#2259), with a follow-up dedup fix (#2300). The original reporter has since re-verified on `main` that `//Sources:iosapp` builds cleanly at 17.0.

## Change

The `tca_example` targets, however, were still pinned at `16.0`, so nothing in CI guards the fix at the version that used to break. This bumps:

- `examples/tca_example/Sources/BUILD.bazel` — `ios_application` `minimum_os_version`: `16.0` → `17.0`
- `examples/tca_example/Tests/BUILD.bazel` — `ios_unit_test` `minimum_os_version`: `16.0` → `17.0`

Bumping the test target as well exercises the transition dedup path from #2300 (which used a 17.0 `TCAExampleTests` as its validation scenario).

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119icaFycF8doDsRceGWjUu)_