### PR TITLE
fix(examples): set env vars on interesting_deps update tool

### DIFF
--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -18,6 +18,15 @@ tidy(
 swift_package_tool(
     name = "update_swift_packages",
     cmd = "update",
+    # Package.swift gates its real dependency list behind these env vars
+    # (see the INTERESTING_DEPS_* checks). The module extension injects
+    # them via `env`/`env_inherit` in MODULE.bazel, but this tool runs
+    # SwiftPM directly, so set them here to avoid passing them on the
+    # command line.
+    env = {
+        "INTERESTING_DEPS_ENV": "1",
+        "INTERESTING_DEPS_INHERIT_ENV": "1",
+    },
     package = "Package.swift",
 )
 


### PR DESCRIPTION
## Summary

- The `interesting_deps` example's `Package.swift` gates its real dependency list behind `INTERESTING_DEPS_ENV` and `INTERESTING_DEPS_INHERIT_ENV`, falling back to an intentionally-invalid `not-a-real-package` when they are unset (a fixture for the extension's `env`/`env_inherit` attrs from #1636).
- The module extension supplies those vars via `env`/`env_inherit` in `MODULE.bazel`, but the standalone `//:update_swift_packages` target runs SwiftPM directly, so it resolved `not-a-real-package` and failed unless the vars were passed on the command line.
- Set the vars directly on the `swift_package_tool` target so the maintenance tool runs standalone (`bazel run //:update_swift_packages`) without extra env plumbing.

## Notes

- This does not touch the intended `env`/`env_inherit` test path: `do_test` exercises those through `//:tidy` and `@swift_package//:resolve` (the module extension), not this standalone target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)