### PR TITLE
fix: support versioned macOS frameworks

### DIFF
--- a/swiftpkg/internal/artifact_infos.bzl
+++ b/swiftpkg/internal/artifact_infos.bzl
@@ -75,7 +75,7 @@ def _new_framework_info_from_framework_dir(repository_ctx, path):
     """
     framework_name = _framework_name_from_path(path)
 
-    # Frameworks have a structure like the following:
+    # Unversioned frameworks have a structure like the following:
     # XXX.framework
     #   └─ Headers (dir)
     #   └─ Modules (dir)
@@ -87,6 +87,12 @@ def _new_framework_info_from_framework_dir(repository_ctx, path):
         by_name = framework_name,
         depth = 1,
     )
+
+    # Versioned macOS frameworks expose the root binary through Versions/Current.
+    if len(binary_files) == 0:
+        versioned_binary_path = paths.join(path, "Versions", "Current", framework_name)
+        if repository_files.path_exists(repository_ctx, versioned_binary_path):
+            binary_files = [versioned_binary_path]
     if len(binary_files) == 0:
         fail("No binary files were found for framework at {}".format(path))
     link_type = _link_type(repository_ctx, binary_files[0])

--- a/swiftpkg/tests/artifact_infos_tests.bzl
+++ b/swiftpkg/tests/artifact_infos_tests.bzl
@@ -110,8 +110,33 @@ Load command 3
 
 link_type_test = unittest.make(_link_type_test)
 
+def _versioned_macos_framework_test(ctx):
+    env = unittest.begin(ctx)
+    xcframework_path = "Breez.xcframework"
+    framework_path = xcframework_path + "/macos-arm64_x86_64/Breez.framework"
+    binary_path = framework_path + "/Versions/Current/Breez"
+    repository_ctx = testutils.new_stub_repository_ctx(
+        repo_name = "breez",
+        find_results = {
+            xcframework_path: [framework_path],
+            framework_path: [],
+        },
+        path_exists_results = {binary_path: True},
+        file_type_results = {
+            binary_path: "Mach-O 64-bit dynamically linked shared library arm64",
+        },
+    )
+
+    actual = artifact_infos.new_xcframework_info_from_files(repository_ctx, xcframework_path)
+
+    asserts.equals(env, link_types.dynamic, actual.link_type)
+    return unittest.end(env)
+
+versioned_macos_framework_test = unittest.make(_versioned_macos_framework_test)
+
 def artifact_infos_test_suite(name = "artifact_infos_tests"):
     return unittest.suite(
         name,
         link_type_test,
+        versioned_macos_framework_test,
     )

--- a/swiftpkg/tests/testutils.bzl
+++ b/swiftpkg/tests/testutils.bzl
@@ -12,6 +12,7 @@ def _new_stub_repository_ctx(
         file_contents = {},
         find_results = {},
         is_directory_results = {},
+        path_exists_results = {},
         file_type_results = {},
         load_commands_results = {}):
     def read(path):
@@ -27,6 +28,11 @@ def _new_stub_repository_ctx(
             stdout = "TRUE" if result else "FALSE"
             stdout += "\n"
             exec_result = _new_exec_result(stdout = stdout)
+
+        elif args_len == 3 and args[0] == "test" and args[1] == "-e":
+            path = args[2]
+            return_code = 0 if path_exists_results.get(path, False) else 1
+            exec_result = _new_exec_result(return_code = return_code)
 
         elif args_len >= 4 and args[0] == "find":
             # The find command that we expect is `find -H -L path`.


### PR DESCRIPTION
## Why
The importer only checks `<Name>.framework/<Name>` when determining link type, so it can fail before `rules_apple` processes a documented versioned macOS framework layout.

## What
- Fall back to `Versions/Current/<Name>` when the root framework executable is not discoverable
- Add regression coverage for dynamic versioned macOS frameworks

## References
- Apple bundle guidance: https://developer.apple.com/documentation/bundleresources/placing-content-in-a-bundle
- Framework anatomy: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html
- `rules_apple` versioned import support: https://github.com/bazelbuild/rules_apple/pull/2133
- `bazel test //swiftpkg/...` (270 tests passed)

Generated with Codex
