### PR TITLE
fix(ci): export INTERESTING_DEPS_INHERIT_ENV in Renovate post-upgrade

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -43,6 +43,17 @@ else
   install-tool clang-12 12.0.0
 fi
 
+# The `interesting_deps` example gates its real dependency list behind two
+# environment variables, falling back to an intentionally-invalid
+# `not-a-real-package` when either is missing. It is a fixture for the
+# `env`/`env_inherit` attrs on the `swift_deps` module extension. That example's
+# MODULE.bazel supplies `INTERESTING_DEPS_ENV` via `env`, but it lists
+# `INTERESTING_DEPS_INHERIT_ENV` in `env_inherit`, so that one must be present in
+# the ambient environment. Its `do_test` exports it for the integration tests;
+# export it here so that tidy resolves the real dependencies when Renovate
+# modifies that example.
+export INTERESTING_DEPS_INHERIT_ENV=1
+
 # Execute tidy for workspaces with modifications The export of CC and the
 # --action_env=PATH are specific to running this repository on Linux.
 export CC=clang


### PR DESCRIPTION
## Summary

Renovate's `artifacts` check has been failing on every PR that touches `examples/interesting_deps/Package.resolved` (most recently #2443, and identically on #2400 before it). All GitHub Actions checks pass on those PRs — the failure is only in Renovate's `postUpgradeTasks`, reported via a PR comment rather than an Actions log, which is why it went unnoticed for a while.

## Root cause

`examples/interesting_deps/Package.swift` deliberately gates its real dependency list behind two environment variables, falling back to an intentionally-invalid `not-a-real-package` when either is missing. It is a fixture for the `env`/`env_inherit` attrs on the `swift_deps` module extension (#1636).

- `INTERESTING_DEPS_ENV` is injected by that example's `MODULE.bazel` via `env`, so it is always present.
- `INTERESTING_DEPS_INHERIT_ENV` is declared in `env_inherit`, so it must exist in the ambient environment. `examples/interesting_deps/do_test` exports it, which is why the integration tests pass.

`do_renovate_post_upgrade` never exported it. When Renovate runs `//:tidy_modified` and that example is among the modified workspaces, SwiftPM resolves the fake package and analysis of `//:update_build_files` fails on a dangling `@swiftpkg_not_a_real_package//:pkg_info.json` label.

This is the counterpart to #2398, which fixed the same class of bug for the standalone `//:update_swift_packages` target but left the `tidy` / module-extension path uncovered.

## Notes

- Verification only comes from a real Renovate run, since the failure reproduces in Renovate's sandbox rather than in CI. Once this lands, ticking the rebase/retry box on #2443 should turn `renovate/artifacts` green.
- There is a related latent bug this does **not** fix: `_declare_unresolved_pkg_from_dependency` in `swiftpkg/bzlmod/swift_deps.bzl` writes a placeholder repo with an empty `BUILD.bazel`, but `direct_dep_pkg_infos` is built from all dependencies earlier in `_declare_pkgs_from_package` — before the unresolved check — so with `declare_swift_deps_info = True` an unresolved dep always leaves a dangling label. That breaks the intended graceful degradation for anyone who adds a dependency and runs tidy before resolving. Worth a separate PR.
- The debug output in `do_renovate_post_upgrade` is intentionally left in place.