### PR TITLE
fix(ci): use the BuildBuddy remote cache in the Renovate post-upgrade

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -65,11 +65,40 @@ export INTERESTING_DEPS_INHERIT_ENV=1
 # a public branch and `git ls-files -m` would report the root workspace as
 # modified.
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bb_bazelrc="${repo_root}/local.bazelrc"
+bb_marker="# Written by do_renovate_post_upgrade. Do not commit."
+
+# Remove a local.bazelrc that an earlier run of this script left behind.
+# Renovate reuses clones across runs, so without this a revoked or absent key
+# leaves stale credentials in place and every Bazel call fails on auth instead
+# of falling back to an uncached build.
+#
+# Only our own file is removed. A developer's hand-written local.bazelrc is left
+# alone, which is why the generated file carries a marker line.
+remove_generated_bazelrc() {
+  if [[ -f ${bb_bazelrc} ]] \
+    && [[ "$(head -n 1 "${bb_bazelrc}")" == "${bb_marker}" ]]; then
+    rm -f "${bb_bazelrc}"
+  fi
+}
+
 # Disable tracing for the whole block so that the API key is not written to the
-# log. The `[[ -n ... ]]` test alone is enough to leak it.
+# log. The `[[ -n ... ]]` test alone is enough to leak it. Restore rather than
+# unconditionally re-enable, so that removing the DEBUG block above does not
+# silently start tracing a script that handles a credential.
+xtrace_was_on=0
+case $- in *x*) xtrace_was_on=1 ;; esac
 set +x
-if [[ -n ${BUILDBUDDY_API_KEY:-} ]]; then
-  cat >"${repo_root}/local.bazelrc" <<EOF
+remove_generated_bazelrc
+if [[ -f ${bb_bazelrc} ]]; then
+  # Someone else's local.bazelrc, since ours was just removed. Assume it is
+  # already configured and leave it alone.
+  echo "Using the existing local.bazelrc."
+elif [[ -n ${BUILDBUDDY_API_KEY:-} ]]; then
+  # Do not leave the credentials in the clone once tidy has finished.
+  trap remove_generated_bazelrc EXIT
+  cat >"${bb_bazelrc}" <<EOF
+${bb_marker}
 build:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
 build --config=cache
 EOF
@@ -77,7 +106,9 @@ EOF
 else
   echo "BUILDBUDDY_API_KEY is not set. Building without the remote cache."
 fi
-set -x
+if [[ ${xtrace_was_on} -eq 1 ]]; then
+  set -x
+fi
 
 # Execute tidy for workspaces with modifications The export of CC and the
 # --action_env=PATH are specific to running this repository on Linux.

--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -54,6 +54,31 @@ fi
 # modifies that example.
 export INTERESTING_DEPS_INHERIT_ENV=1
 
+# A wide upgrade can modify MODULE.bazel in dozens of workspaces. Each one is a
+# separate Bazel workspace with its own output base, so without a shared cache
+# every one of them rebuilds the toolchains from scratch. Write the BuildBuddy
+# credentials to local.bazelrc, which every workspace's .bazelrc try-imports
+# from the repository root.
+#
+# This must be local.bazelrc and not shared.bazelrc. local.bazelrc is
+# gitignored; shared.bazelrc is tracked, so Renovate would commit the API key to
+# a public branch and `git ls-files -m` would report the root workspace as
+# modified.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Disable tracing for the whole block so that the API key is not written to the
+# log. The `[[ -n ... ]]` test alone is enough to leak it.
+set +x
+if [[ -n ${BUILDBUDDY_API_KEY:-} ]]; then
+  cat >"${repo_root}/local.bazelrc" <<EOF
+build:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+build --config=cache
+EOF
+  echo "Configured the BuildBuddy remote cache."
+else
+  echo "BUILDBUDDY_API_KEY is not set. Building without the remote cache."
+fi
+set -x
+
 # Execute tidy for workspaces with modifications The export of CC and the
 # --action_env=PATH are specific to running this repository on Linux.
 export CC=clang


### PR DESCRIPTION
Pairs with cgrindel/renovate-bot#649, which supplies the key. Inert alone.

- Wrote the BuildBuddy credentials to `local.bazelrc` when `BUILDBUDDY_API_KEY` is set, so Bazel invocations across modified workspaces share cached actions instead of each rebuilding the toolchains
- Fell back to an uncached build when the variable is unset or empty
- Removed a `local.bazelrc` left by an earlier run, and removed the generated file again on exit
- Left a hand-written `local.bazelrc` alone, matching on a marker line the generated file carries

`local.bazelrc` rather than `shared.bazelrc` because `shared.bazelrc` is tracked, and Renovate commits every modified file after a post-upgrade task, so the key would land on a public branch.

Worth weighing before merge: this cuts CPU, not disk. External repositories are extracted per output base and no cache flag dedupes that, so if the runner is dying of disk exhaustion this gets further and still dies. Nobody has measured which resource runs out, because the failure takes its own diagnostics with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)