### PR TITLE
fix(ci): shut down idle Bazel servers during the Renovate post-upgrade

### DIFF
--- a/do_renovate_post_upgrade
+++ b/do_renovate_post_upgrade
@@ -55,10 +55,11 @@ fi
 export INTERESTING_DEPS_INHERIT_ENV=1
 
 # A wide upgrade can modify MODULE.bazel in dozens of workspaces. Each one is a
-# separate Bazel workspace with its own output base, so without a shared cache
-# every one of them rebuilds the toolchains from scratch. Write the BuildBuddy
-# credentials to local.bazelrc, which every workspace's .bazelrc try-imports
-# from the repository root.
+# separate Bazel workspace with its own output base and its own server, so
+# without a shared cache every one of them rebuilds the toolchains from scratch,
+# and without an idle limit every server stays resident until the end of the
+# run. Write Bazel settings for the whole run to local.bazelrc, which every
+# workspace's .bazelrc try-imports from the repository root.
 #
 # This must be local.bazelrc and not shared.bazelrc. local.bazelrc is
 # gitignored; shared.bazelrc is tracked, so Renovate would commit the API key to
@@ -94,17 +95,29 @@ if [[ -f ${bb_bazelrc} ]]; then
   # Someone else's local.bazelrc, since ours was just removed. Assume it is
   # already configured and leave it alone.
   echo "Using the existing local.bazelrc."
-elif [[ -n ${BUILDBUDDY_API_KEY:-} ]]; then
-  # Do not leave the credentials in the clone once tidy has finished.
-  trap remove_generated_bazelrc EXIT
-  cat >"${bb_bazelrc}" <<EOF
-${bb_marker}
-build:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
-build --config=cache
-EOF
-  echo "Configured the BuildBuddy remote cache."
 else
-  echo "BUILDBUDDY_API_KEY is not set. Building without the remote cache."
+  # Do not leave the file, which may hold credentials, in the clone once tidy
+  # has finished.
+  trap remove_generated_bazelrc EXIT
+  {
+    echo "${bb_marker}"
+    # tidy_all.sh starts a Bazel server in every workspace it visits and never
+    # shuts any of them down. By default a server idles for three hours, so a
+    # wide upgrade leaves dozens of JVMs resident at once, which starves the
+    # GitHub runner. Have each server exit shortly after its workspace is done.
+    # The root server also idles while `bazel run` executes tidy_all.sh; its
+    # exit does not affect the running script.
+    echo "startup --max_idle_secs=15"
+    if [[ -n ${BUILDBUDDY_API_KEY:-} ]]; then
+      echo "build:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+      echo "build --config=cache"
+    fi
+  } >"${bb_bazelrc}"
+  if [[ -n ${BUILDBUDDY_API_KEY:-} ]]; then
+    echo "Configured the BuildBuddy remote cache."
+  else
+    echo "BUILDBUDDY_API_KEY is not set. Building without the remote cache."
+  fi
 fi
 if [[ ${xtrace_was_on} -eq 1 ]]; then
   set -x


### PR DESCRIPTION
- Wrote `startup --max_idle_secs=15` to the generated `local.bazelrc`, so each workspace's Bazel server exits shortly after tidy finishes there instead of idling for three hours
- Wrote the file whether or not `BUILDBUDDY_API_KEY` is set; the cache lines are still added only when it is

`tidy_all.sh` visits every modified workspace and never shuts down the server it started there. A wide upgrade leaves dozens of JVMs resident at once, which is the most likely reason the runner stops responding partway through the post-upgrade.

Claude verified with Bazel 9.2 that the startup option is honored through `try-import` from the root and from a nested workspace, and that a `bazel run` whose server idles out mid-script still completes. Not verified end to end; it only takes effect on a Renovate run.

If the runner is dying of disk rather than memory, this changes nothing. The next run tells us which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)