### PR TITLE
fix: add binary targets to generated public swift_library_group

### DIFF
--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -1319,12 +1319,36 @@ def _library_product_build_file(pkg_ctx, product):
             pkginfo_target_deps.labels_for_target(pkg_ctx.repo_name, target),
         )
 
+    binary_target_deps = []
+    for target in pkg_ctx.pkg_info.targets:
+        if product.name not in target.product_memberships:
+            continue
+        for target_dep in target.dependencies:
+            dep_target_name = None
+            if target_dep.target:
+                dep_target_name = target_dep.target.target_name
+            elif target_dep.by_name:
+                dep_target_name = target_dep.by_name.name
+            if not dep_target_name:
+                continue
+            dep_target = pkginfo_targets.get(
+                targets = pkg_ctx.pkg_info.targets,
+                name = dep_target_name,
+                fail_if_not_found = False,
+            )
+            if not dep_target or dep_target.type != target_types.binary:
+                continue
+            binary_target_deps.extend(
+                pkginfo_target_deps.bzl_select_list(pkg_ctx, target_dep),
+            )
+
     if len(target_labels) == 0:
         fail("No targets specified for a library product. name:", product.name)
     deps = [
         bazel_labels.normalize(label)
         for label in target_labels
     ]
+    deps.extend(binary_target_deps)
     return build_files.new(
         load_stmts = [swift_library_group_load_stmt],
         decls = [
@@ -1332,7 +1356,7 @@ def _library_product_build_file(pkg_ctx, product):
                 swift_kinds.library_group,
                 product.name,
                 attrs = {
-                    "deps": deps,
+                    "deps": bzl_selects.to_starlark(deps),
                     "visibility": ["//visibility:public"],
                 },
             ),

--- a/swiftpkg/internal/swiftpkg_build_files.bzl
+++ b/swiftpkg/internal/swiftpkg_build_files.bzl
@@ -1,6 +1,7 @@
 """Module for creating Bazel declarations to build a Swift package."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@cgrindel_bazel_starlib//bzllib:defs.bzl", "bazel_labels", "lists")
 load(
     "//config_settings/bazel/compilation_mode:compilation_modes.bzl",
@@ -1319,7 +1320,15 @@ def _library_product_build_file(pkg_ctx, product):
             pkginfo_target_deps.labels_for_target(pkg_ctx.repo_name, target),
         )
 
-    binary_target_deps = []
+    if len(target_labels) == 0:
+        fail("No targets specified for a library product. name:", product.name)
+
+    deps = [
+        bazel_labels.normalize(label)
+        for label in target_labels
+    ]
+    target_label_set = sets.make(deps)
+    binary_target_dep_pairs = sets.make()
     for target in pkg_ctx.pkg_info.targets:
         if product.name not in target.product_memberships:
             continue
@@ -1338,15 +1347,34 @@ def _library_product_build_file(pkg_ctx, product):
             )
             if not dep_target or dep_target.type != target_types.binary:
                 continue
-            binary_target_deps.extend(
-                pkginfo_target_deps.bzl_select_list(pkg_ctx, target_dep),
-            )
+            for binary_target_dep in pkginfo_target_deps.bzl_select_list(
+                pkg_ctx,
+                target_dep,
+            ):
+                for label in binary_target_dep.value:
+                    if not sets.contains(target_label_set, label):
+                        sets.insert(
+                            binary_target_dep_pairs,
+                            (binary_target_dep.condition, label),
+                        )
 
-    if len(target_labels) == 0:
-        fail("No targets specified for a library product. name:", product.name)
-    deps = [
-        bazel_labels.normalize(label)
-        for label in target_labels
+    binary_target_dep_pairs_list = sets.to_list(binary_target_dep_pairs)
+    unconditional_binary_target_labels = sets.make([
+        label
+        for (condition, label) in binary_target_dep_pairs_list
+        if condition == None
+    ])
+    binary_target_deps = [
+        bzl_selects.new(
+            value = label,
+            kind = pkginfo_target_deps.target_dep_kind,
+            condition = condition,
+        )
+        for (condition, label) in binary_target_dep_pairs_list
+        if condition == None or not sets.contains(
+            unconditional_binary_target_labels,
+            label,
+        )
     ]
     deps.extend(binary_target_deps)
     return build_files.new(

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -84,6 +84,33 @@ def _pkg_info(
                 targets = ["LibraryWithBinaryTargets"],
             ),
             pkginfos.new_product(
+                name = "SharedBinaryProduct",
+                type = pkginfos.new_product_type(
+                    library = pkginfos.new_library_type(
+                        library_type_kinds.automatic,
+                    ),
+                ),
+                targets = ["SharedBinaryLibA", "SharedBinaryLibB"],
+            ),
+            pkginfos.new_product(
+                name = "LibraryWithBinaryInTargets",
+                type = pkginfos.new_product_type(
+                    library = pkginfos.new_library_type(
+                        library_type_kinds.automatic,
+                    ),
+                ),
+                targets = ["LibraryWithBinaryInTargets", "BinaryFrameworkTarget"],
+            ),
+            pkginfos.new_product(
+                name = "ConditionalBinaryDedupProduct",
+                type = pkginfos.new_product_type(
+                    library = pkginfos.new_library_type(
+                        library_type_kinds.automatic,
+                    ),
+                ),
+                targets = ["ConditionalBinaryDepsA", "ConditionalBinaryDepsB"],
+            ),
+            pkginfos.new_product(
                 name = "ObjcLibraryWithModulemap",
                 type = pkginfos.new_product_type(
                     library = pkginfos.new_library_type(
@@ -424,6 +451,115 @@ def _pkg_info(
                 swift_src_info = pkginfos.new_swift_src_info(),
             ),
             pkginfos.new_target(
+                name = "SharedBinaryLibA",
+                type = "regular",
+                c99name = "SharedBinaryLibA",
+                module_type = "SwiftTarget",
+                path = "Source/SharedBinaryLibA",
+                sources = ["SharedBinaryLibA.swift"],
+                dependencies = [
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "BinaryFrameworkTarget",
+                        ),
+                    ),
+                ],
+                product_memberships = ["SharedBinaryProduct"],
+                repo_name = _repo_name,
+                swift_src_info = pkginfos.new_swift_src_info(),
+            ),
+            pkginfos.new_target(
+                name = "SharedBinaryLibB",
+                type = "regular",
+                c99name = "SharedBinaryLibB",
+                module_type = "SwiftTarget",
+                path = "Source/SharedBinaryLibB",
+                sources = ["SharedBinaryLibB.swift"],
+                dependencies = [
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "BinaryFrameworkTarget",
+                        ),
+                    ),
+                ],
+                product_memberships = ["SharedBinaryProduct"],
+                repo_name = _repo_name,
+                swift_src_info = pkginfos.new_swift_src_info(),
+            ),
+            pkginfos.new_target(
+                name = "LibraryWithBinaryInTargets",
+                type = "regular",
+                c99name = "LibraryWithBinaryInTargets",
+                module_type = "SwiftTarget",
+                path = "Source/LibraryWithBinaryInTargets",
+                sources = ["LibraryWithBinaryInTargets.swift"],
+                dependencies = [
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "BinaryFrameworkTarget",
+                        ),
+                    ),
+                ],
+                product_memberships = ["LibraryWithBinaryInTargets"],
+                repo_name = _repo_name,
+                swift_src_info = pkginfos.new_swift_src_info(),
+            ),
+            pkginfos.new_target(
+                name = "ConditionalBinaryDepsA",
+                type = "regular",
+                c99name = "ConditionalBinaryDepsA",
+                module_type = "SwiftTarget",
+                path = "Source/ConditionalBinaryDepsA",
+                sources = ["ConditionalBinaryDepsA.swift"],
+                dependencies = [
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "BinaryFrameworkTarget",
+                            condition = pkginfos.new_target_dependency_condition(
+                                platforms = [spm_platforms.ios],
+                            ),
+                        ),
+                    ),
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "ConditionalBinaryFrameworkTarget",
+                            condition = pkginfos.new_target_dependency_condition(
+                                platforms = [spm_platforms.ios],
+                            ),
+                        ),
+                    ),
+                ],
+                product_memberships = ["ConditionalBinaryDedupProduct"],
+                repo_name = _repo_name,
+                swift_src_info = pkginfos.new_swift_src_info(),
+            ),
+            pkginfos.new_target(
+                name = "ConditionalBinaryDepsB",
+                type = "regular",
+                c99name = "ConditionalBinaryDepsB",
+                module_type = "SwiftTarget",
+                path = "Source/ConditionalBinaryDepsB",
+                sources = ["ConditionalBinaryDepsB.swift"],
+                dependencies = [
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "BinaryFrameworkTarget",
+                            condition = pkginfos.new_target_dependency_condition(
+                                platforms = [spm_platforms.ios],
+                            ),
+                        ),
+                    ),
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "ConditionalBinaryFrameworkTarget",
+                        ),
+                    ),
+                ],
+                product_memberships = ["ConditionalBinaryDedupProduct"],
+                repo_name = _repo_name,
+                swift_src_info = pkginfos.new_swift_src_info(),
+            ),
+            pkginfos.new_target(
                 name = "ClangLibraryWithConditionalDep",
                 type = "regular",
                 c99name = "ClangLibraryWithConditionalDep",
@@ -592,6 +728,11 @@ def _pkg_info(
                 path = "BinaryFrameworkTarget.xcframework",
                 sources = [],
                 dependencies = [],
+                product_memberships = [
+                    "BinaryFrameworkTarget",
+                    "ConditionalBinaryDedupProduct",
+                    "LibraryWithBinaryTargets",
+                ],
                 repo_name = _repo_name,
             ),
             pkginfos.new_target(
@@ -602,6 +743,10 @@ def _pkg_info(
                 path = "ConditionalBinaryFrameworkTarget.xcframework",
                 sources = [],
                 dependencies = [],
+                product_memberships = [
+                    "ConditionalBinaryDedupProduct",
+                    "LibraryWithBinaryTargets",
+                ],
                 repo_name = _repo_name,
             ),
         ] + extra_targets,
@@ -2162,6 +2307,62 @@ swift_library_group(
         "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm"],
         "@rules_swift_package_manager//config_settings/spm/platform:macos": ["@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm"],
         "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+""",
+        ),
+        struct(
+            msg = "library product where two targets share a binary target dep",
+            name = "SharedBinaryProduct",
+            pkg_info = _pkg_info(),
+            exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+
+swift_library_group(
+    name = "SharedBinaryProduct",
+    deps = [
+        "@swiftpkg_mypackage//:SharedBinaryLibA.rspm",
+        "@swiftpkg_mypackage//:SharedBinaryLibB.rspm",
+        "@swiftpkg_mypackage//:BinaryFrameworkTarget.rspm",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+        ),
+        struct(
+            msg = "library product listing a binary target in its targets",
+            name = "LibraryWithBinaryInTargets",
+            pkg_info = _pkg_info(),
+            exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+
+swift_library_group(
+    name = "LibraryWithBinaryInTargets",
+    deps = [
+        "@swiftpkg_mypackage//:LibraryWithBinaryInTargets.rspm",
+        "@swiftpkg_mypackage//:BinaryFrameworkTarget.rspm",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+        ),
+        struct(
+            msg = "conditional binary target dependencies are deduplicated",
+            name = "ConditionalBinaryDedupProduct",
+            pkg_info = _pkg_info(),
+            exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+
+swift_library_group(
+    name = "ConditionalBinaryDedupProduct",
+    deps = [
+        "@swiftpkg_mypackage//:ConditionalBinaryDepsA.rspm",
+        "@swiftpkg_mypackage//:ConditionalBinaryDepsB.rspm",
+        "@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm",
+    ] + select({
+        "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:BinaryFrameworkTarget.rspm"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/swiftpkg/tests/swiftpkg_build_files_tests.bzl
+++ b/swiftpkg/tests/swiftpkg_build_files_tests.bzl
@@ -75,6 +75,15 @@ def _pkg_info(
                 targets = ["RegularSwiftTargetAsLibrary"],
             ),
             pkginfos.new_product(
+                name = "LibraryWithBinaryTargets",
+                type = pkginfos.new_product_type(
+                    library = pkginfos.new_library_type(
+                        library_type_kinds.automatic,
+                    ),
+                ),
+                targets = ["LibraryWithBinaryTargets"],
+            ),
+            pkginfos.new_product(
                 name = "ObjcLibraryWithModulemap",
                 type = pkginfos.new_product_type(
                     library = pkginfos.new_library_type(
@@ -384,6 +393,37 @@ def _pkg_info(
                 swift_src_info = pkginfos.new_swift_src_info(),
             ),
             pkginfos.new_target(
+                name = "LibraryWithBinaryTargets",
+                type = "regular",
+                c99name = "LibraryWithBinaryTargets",
+                module_type = "SwiftTarget",
+                path = "Source/LibraryWithBinaryTargets",
+                sources = ["LibraryWithBinaryTargets.swift"],
+                dependencies = [
+                    pkginfos.new_target_dependency(
+                        by_name = pkginfos.new_by_name_reference(
+                            "BinaryFrameworkTarget",
+                        ),
+                    ),
+                    pkginfos.new_target_dependency(
+                        target = pkginfos.new_target_reference(
+                            "ConditionalBinaryFrameworkTarget",
+                            condition = pkginfos.new_target_dependency_condition(
+                                platforms = [
+                                    spm_platforms.ios,
+                                    spm_platforms.maccatalyst,
+                                    spm_platforms.macos,
+                                    spm_platforms.tvos,
+                                ],
+                            ),
+                        ),
+                    ),
+                ],
+                product_memberships = ["LibraryWithBinaryTargets"],
+                repo_name = _repo_name,
+                swift_src_info = pkginfos.new_swift_src_info(),
+            ),
+            pkginfos.new_target(
                 name = "ClangLibraryWithConditionalDep",
                 type = "regular",
                 c99name = "ClangLibraryWithConditionalDep",
@@ -550,6 +590,16 @@ def _pkg_info(
                 c99name = "BinaryFrameworkTarget",
                 module_type = "BinaryTarget",
                 path = "BinaryFrameworkTarget.xcframework",
+                sources = [],
+                dependencies = [],
+                repo_name = _repo_name,
+            ),
+            pkginfos.new_target(
+                name = "ConditionalBinaryFrameworkTarget",
+                type = "binary",
+                c99name = "ConditionalBinaryFrameworkTarget",
+                module_type = "BinaryTarget",
+                path = "ConditionalBinaryFrameworkTarget.xcframework",
                 sources = [],
                 dependencies = [],
                 repo_name = _repo_name,
@@ -824,7 +874,11 @@ def _minimum_os_wrapper_behavior_test(ctx):
         "RegularSwiftTargetAsLibrary",
         "swift_library_group",
     )
-    asserts.equals(env, ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"], library_product.attrs["deps"])
+    asserts.equals(
+        env,
+        "[\"@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm\"]",
+        scg.to_starlark(library_product.attrs["deps"]),
+    )
 
     executable_product_bf = _product_build_file(pkg_info, "swiftexec")
     executable_product = _assert_decl(env, executable_product_bf, "swiftexec", "alias")
@@ -2088,6 +2142,28 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
 swift_library_group(
     name = "RegularSwiftTargetAsLibrary",
     deps = ["@swiftpkg_mypackage//:RegularSwiftTargetAsLibrary.rspm"],
+    visibility = ["//visibility:public"],
+)
+""",
+        ),
+        struct(
+            msg = "library product with binary target dependencies",
+            name = "LibraryWithBinaryTargets",
+            pkg_info = _pkg_info(),
+            exp = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+
+swift_library_group(
+    name = "LibraryWithBinaryTargets",
+    deps = [
+        "@swiftpkg_mypackage//:LibraryWithBinaryTargets.rspm",
+        "@swiftpkg_mypackage//:BinaryFrameworkTarget.rspm",
+    ] + select({
+        "@rules_swift_package_manager//config_settings/spm/platform:ios": ["@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm"],
+        "@rules_swift_package_manager//config_settings/spm/platform:macos": ["@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm"],
+        "@rules_swift_package_manager//config_settings/spm/platform:tvos": ["@swiftpkg_mypackage//:ConditionalBinaryFrameworkTarget.rspm"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 """,


### PR DESCRIPTION
rules_swift has a feature to detect transitive module imports. This is referred to as layering check.
We make sure that binary targets are added to publically generated `swift_library_group` so that it satisfies the layering check.